### PR TITLE
Add a setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+
+setup(
+    name='css-preprocessor',
+    author='Tab Atkins Jr.',
+    py_modules=['preprocess'],
+    install_requires=['lxml', 'html5lib', 'cssselect'],
+    entry_points={'console_scripts': ['css-preprocess = preprocess:main']},
+)


### PR DESCRIPTION
This setuptools/pip will automatically install the dependencies and an executable script.

With this file in the repository, `pip install git+https://github.com/tabatkins/css-preprocessor.git` should be enough to install the preprocessor on a system with pip, python-dev, libxml2-dev, and libxslt1-dev.
