### PR TITLE
Use UTC for the default date

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -938,7 +938,7 @@ class CSSSpec(object):
     # optional metadata
     TR = None
     title = "???"
-    date = date.today()
+    date = datetime.utcnow().date()
     deadline = None
     group = "csswg"
     editors = []


### PR DESCRIPTION
It seems to make a little more sense, though I’m not sure.
