### PR TITLE
Get default date from input file modified time

### DIFF
--- a/bikeshed.py
+++ b/bikeshed.py
@@ -927,6 +927,7 @@ class CSSSpec(object):
     def __init__(self, inputFile, paragraphMode="markdown"):
         try:
             self.lines = inputFile.readlines()
+            self.date = datetime.fromtimestamp(os.path.getmtime(inputFile.name))
         except OSError:
             die("Couldn't find the input file at the specified location '{0}'.", inputFilename)
 


### PR DESCRIPTION
Set the default spec date to the modified time of the input file. Necessary to prevent bad dates on server auto-generation of specs without date metadata.
