### PR TITLE
Add FXTF specification template.

### DIFF
--- a/include/abstract-fxtf.include
+++ b/include/abstract-fxtf.include
@@ -1,0 +1,4 @@
+[ABSTRACT]
+<a href='http://www.w3.org/TR/CSS/'>CSS</a> is a language for describing the rendering of structured documents 
+(such as HTML and XML) 
+on screen, on paper, in speech, etc.

--- a/include/footer-fxtf.include
+++ b/include/footer-fxtf.include
@@ -1,0 +1,141 @@
+<h2 id="conformance" class="no-ref no-num">
+Conformance</h2>
+
+<h3 id="conventions" class="no-ref">
+Document conventions</h3>
+
+    <p>Conformance requirements are expressed with a combination of
+    descriptive assertions and RFC 2119 terminology. The key words "MUST",
+    "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+    "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this
+    document are to be interpreted as described in RFC 2119.
+    However, for readability, these words do not appear in all uppercase
+    letters in this specification.
+
+    <p>All of the text of this specification is normative except sections
+    explicitly marked as non-normative, examples, and notes. [[!RFC2119]]</p>
+
+    <p>Examples in this specification are introduced with the words "for example"
+    or are set apart from the normative text with <code>class="example"</code>,
+    like this:
+
+    <div class="example">
+        <p>This is an example of an informative example.</p>
+    </div>
+
+    <p>Informative notes begin with the word "Note" and are set apart from the
+    normative text with <code>class="note"</code>, like this:
+
+    <p class="note">Note, this is an informative note.</p>
+
+<h3 id="conformance-classes" class="no-ref">
+Conformance classes</h3>
+
+    <p>Conformance to this specification
+    is defined for three conformance classes:
+    <dl>
+        <dt>style sheet
+            <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#style-sheet">CSS
+            style sheet</a>.
+        <dt>renderer
+            <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a>
+            that interprets the semantics of a style sheet and renders
+            documents that use them.
+        <dt>authoring tool
+            <dd>A <a href="http://www.w3.org/TR/CSS21/conform.html#user-agent">UA</a>
+            that writes a style sheet.
+    </dl>
+
+    <p>A style sheet is conformant to this specification
+    if all of its statements that use syntax defined in this module are valid
+    according to the generic CSS grammar and the individual grammars of each
+    feature defined in this module.
+
+    <p>A renderer is conformant to this specification
+    if, in addition to interpreting the style sheet as defined by the
+    appropriate specifications, it supports all the features defined
+    by this specification by parsing them correctly
+    and rendering the document accordingly. However, the inability of a
+    UA to correctly render a document due to limitations of the device
+    does not make the UA non-conformant. (For example, a UA is not
+    required to render color on a monochrome monitor.)
+
+    <p>An authoring tool is conformant to this specification
+    if it writes style sheets that are syntactically correct according to the
+    generic CSS grammar and the individual grammars of each feature in
+    this module, and meet all other conformance requirements of style sheets
+    as described in this module.
+
+<h3 id="partial" class="no-ref">
+Partial implementations</h3>
+
+    <p>So that authors can exploit the forward-compatible parsing rules to
+    assign fallback values, CSS renderers <strong>must</strong>
+    treat as invalid (and <a href="http://www.w3.org/TR/CSS21/conform.html#ignore">ignore
+    as appropriate</a>) any at-rules, properties, property values, keywords,
+    and other syntactic constructs for which they have no usable level of
+    support. In particular, user agents <strong>must not</strong> selectively
+    ignore unsupported component values and honor supported values in a single
+    multi-value property declaration: if any value is considered invalid
+    (as unsupported values must be), CSS requires that the entire declaration
+    be ignored.</p>
+
+<h3 id="experimental" class="no-ref">
+Experimental implementations</h3>
+
+    <p>To avoid clashes with future CSS features, the CSS2.1 specification
+    reserves a <a href="http://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">prefixed
+    syntax</a> for proprietary and experimental extensions to CSS.
+
+    <p>Prior to a specification reaching the Candidate Recommendation stage
+    in the W3C process, all implementations of a CSS feature are considered
+    experimental. The CSS Working Group recommends that implementations
+    use a vendor-prefixed syntax for such features, including those in
+    W3C Working Drafts. This avoids incompatibilities with future changes
+    in the draft.
+    </p>
+
+<h3 id="testing" class="no-ref">
+Non-experimental implementations</h3>
+
+    <p>Once a specification reaches the Candidate Recommendation stage,
+    non-experimental implementations are possible, and implementors should
+    release an unprefixed implementation of any CR-level feature they
+    can demonstrate to be correctly implemented according to spec.
+
+    <p>To establish and maintain the interoperability of CSS across
+    implementations, the CSS Working Group requests that non-experimental
+    CSS renderers submit an implementation report (and, if necessary, the
+    testcases used for that implementation report) to the W3C before
+    releasing an unprefixed implementation of any CSS features. Testcases
+    submitted to W3C are subject to review and correction by the CSS
+    Working Group.
+
+    <p>Further information on submitting testcases and implementation reports
+    can be found from on the CSS Working Group's website at
+    <a href="http://www.w3.org/Style/CSS/Test/">http://www.w3.org/Style/CSS/Test/</a>.
+    Questions should be directed to the
+    <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a>
+    mailing list.
+
+<h2 class="no-num no-ref" id="references">
+References</h2>
+
+<h3 class="no-num no-ref" id="normative">
+Normative References</h3>
+<div data-fill-with="normative-references"></div>
+
+<h3 class="no-num no-ref" id="informative">
+Informative References</h3>
+<div data-fill-with="informative-references"></div>
+
+<h2 class="no-num no-ref" id="index">
+Index</h2>
+<div data-fill-with="index"></div>
+
+<h2 class="no-num no-ref" id="property-index">
+Property index</h2>
+<div data-fill-with="property-index"></div>
+
+</body>
+</html>

--- a/include/header-fxtf.include
+++ b/include/header-fxtf.include
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>[TITLE]</title>
+  <link href="../default.css" rel=stylesheet type="text/css">
+  <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
+  <link href="https://www.w3.org/StyleSheets/TR/W3C-[STATUS]" rel=stylesheet type="text/css">
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+    <span class="dt-updated"><span class="value-title" title="[CDATE]">[DATE]</span></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<h2 class='no-num no-toc no-ref' id='abstract'>Abstract</h2>
+<p class="p-summary" data-fill-with="abstract"></p>
+
+<h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<h2 class="no-num no-toc no-ref" id="contents">Table of contents</h2>
+<div data-fill-with="table-of-contents"></div>

--- a/include/status-fxtf-ED.include
+++ b/include/status-fxtf-ED.include
@@ -1,0 +1,30 @@
+<p>
+	This is a public copy of the editors' draft. 
+	It is provided for discussion only and may change at any moment. 
+	Its publication here does not imply endorsement of its contents by W3C. 
+	Don't cite this document other than as work in progress.
+
+<p>
+	The (<a href="http://lists.w3.org/Archives/Public/public-fx/">archived</a>) public mailing list
+	<a href="mailto:public-fx@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-fx@w3.org</a> 
+	(see <a href="http://www.w3.org/Mail/Request">instructions</a>) 
+	is preferred for discussion of this specification. 
+	When sending e-mail, 
+	please put the text “[SHORTNAME]” in the subject, 
+	preferably like this:
+	“[[SHORTNAME]] <em>…summary of comment…</em>”
+
+<p>
+	This document was produced by the <a href="/Style/CSS/members">CSS Working Group</a> 
+	(part of the <a href="/Style/">Style Activity</a>) and the <a
+	href="http://www.w3.org/Graphics/SVG/">SVG Working Group</a> (part of the
+	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+
+<p>
+	This document was produced by a group operating under 
+	the <a href="/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
+	W3C maintains a <a href="/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
+	made in connection with the deliverables of the group; 
+	that page also includes instructions for disclosing a patent. 
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
+	must disclose the information in accordance with <a href="/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.

--- a/include/status-fxtf-LCWD.include
+++ b/include/status-fxtf-LCWD.include
@@ -1,0 +1,44 @@
+<p>
+	<em>This section describes the status of this document at the time of
+	its publication. Other documents may supersede this document. A list of
+	current W3C publications and the latest revision of this technical report
+	can be found in the <a href="http://www.w3.org/TR/">W3C technical reports
+	index at http://www.w3.org/TR/.</a></em>
+
+<p>
+	Publication as a Last Call Working Draft does not imply endorsement by the W3C
+	Membership. This is a draft document and may be updated, replaced or
+	obsoleted by other documents at any time. It is inappropriate to cite this
+	document as other than work in progress.
+
+<p>
+	The (<a href="http://lists.w3.org/Archives/Public/public-fx/">archived</a>) public mailing list
+	<a href="mailto:public-fx@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-fx@w3.org</a> 
+	(see <a href="http://www.w3.org/Mail/Request">instructions</a>) 
+	is preferred for discussion of this specification. 
+	When sending e-mail, 
+	please put the text “[SHORTNAME]” in the subject, 
+	preferably like this:
+	“[[SHORTNAME]] <em>…summary of comment…</em>”
+
+<p>
+	This document was produced by the <a href="/Style/CSS/members">CSS Working Group</a> 
+	(part of the <a href="/Style/">Style Activity</a>) and the <a
+	href="http://www.w3.org/Graphics/SVG/">SVG Working Group</a> (part of the
+	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+
+<p>
+	This document was produced by a group operating under 
+	the <a href="/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
+	W3C maintains a <a href="/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
+	made in connection with the deliverables of the group; 
+	that page also includes instructions for disclosing a patent. 
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
+	must disclose the information in accordance with <a href="/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+ <p>
+ 	This specification is a <strong>Last Call Working Draft</strong>. All
+	persons are encouraged to review this document and <strong>send comments
+	to the <a href="http://lists.w3.org/Archives/Public/public-fx/">public-fx</a>
+	mailing list</strong> as described above. The <strong>deadline for
+	comments</strong> is <strong>[DEADLINE]</strong>.

--- a/include/status-fxtf-WD.include
+++ b/include/status-fxtf-WD.include
@@ -1,0 +1,37 @@
+<p>
+	<em>This section describes the status of this document at the time of
+	its publication. Other documents may supersede this document. A list of
+	current W3C publications and the latest revision of this technical report
+	can be found in the <a href="http://www.w3.org/TR/">W3C technical reports
+	index at http://www.w3.org/TR/.</a></em>
+
+<p>
+	Publication as a Working Draft does not imply endorsement by the W3C
+	Membership. This is a draft document and may be updated, replaced or
+	obsoleted by other documents at any time. It is inappropriate to cite this
+	document as other than work in progress.
+
+<p>
+	The (<a href="http://lists.w3.org/Archives/Public/public-fx/">archived</a>) public mailing list
+	<a href="mailto:public-fx@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-fx@w3.org</a> 
+	(see <a href="http://www.w3.org/Mail/Request">instructions</a>) 
+	is preferred for discussion of this specification. 
+	When sending e-mail, 
+	please put the text “[SHORTNAME]” in the subject, 
+	preferably like this:
+	“[[SHORTNAME]] <em>…summary of comment…</em>”
+
+<p>
+	This document was produced by the <a href="/Style/CSS/members">CSS Working Group</a> 
+	(part of the <a href="/Style/">Style Activity</a>) and the <a
+	href="http://www.w3.org/Graphics/SVG/">SVG Working Group</a> (part of the
+	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+
+<p>
+	This document was produced by a group operating under 
+	the <a href="/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
+	W3C maintains a <a href="/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
+	made in connection with the deliverables of the group; 
+	that page also includes instructions for disclosing a patent. 
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
+	must disclose the information in accordance with <a href="/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.


### PR DESCRIPTION
This adds all necessary specification templates for FXTF specs for ED, WD and LCWD. CR follows when needed.
