### PR TITLE
Fix links in status section for EDs

### DIFF
--- a/include/status-csswg-ED.include
+++ b/include/status-csswg-ED.include
@@ -16,13 +16,13 @@
 
 <p>
 	This document was produced by the <a href="/Style/CSS/members">CSS Working Group</a> 
-	(part of the <a href="/Style/">Style Activity</a>).
+	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>).
 
 <p>
 	This document was produced by a group operating under 
-	the <a href="/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
-	W3C maintains a <a href="/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
+	the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
+	W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
 	made in connection with the deliverables of the group; 
 	that page also includes instructions for disclosing a patent. 
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
-	must disclose the information in accordance with <a href="/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
+	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.

--- a/include/status-fxtf-ED.include
+++ b/include/status-fxtf-ED.include
@@ -16,15 +16,15 @@
 
 <p>
 	This document was produced by the <a href="/Style/CSS/members">CSS Working Group</a> 
-	(part of the <a href="/Style/">Style Activity</a>) and the <a
+	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
 	href="http://www.w3.org/Graphics/SVG/">SVG Working Group</a> (part of the
 	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
 
 <p>
 	This document was produced by a group operating under 
-	the <a href="/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
-	W3C maintains a <a href="/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
+	the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>. 
+	W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a> 
 	made in connection with the deliverables of the group; 
 	that page also includes instructions for disclosing a patent. 
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
-	must disclose the information in accordance with <a href="/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> 
+	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.


### PR DESCRIPTION
It is enough to fix EDs for now. FPWDs, WDs, LCWDs, CRs and RECs are in the right position.
