### PR TITLE
Added auto generation of test suite links and annotations from Shepherd API

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -13,6 +13,7 @@ class MetadataManager:
     abstracts = []
     shortname = None
     level = None
+    vshortname = None
 
     # optional metadata
     TR = None

--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -68,3 +68,6 @@ typeRe["method"] = typeRe["function"]
 typeRe["interface"] = re.compile("^\w+$")
 
 anchorDataContentTypes = ["application/json", "application/vnd.csswg.shepherd.v1+json"]
+testSuiteDataContentTypes = ["application/json", "application/vnd.csswg.shepherd.v1+json"]
+
+testAnnotationURL = "//test.csswg.org/harness/annotate.js#"

--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -47,7 +47,12 @@ def parseHTML(str):
     doc = html5lib.parse(u(str), treebuilder='lxml', namespaceHTMLElements=False)
     body = doc.getroot()[1]
     if body.text is None:
-        return list(body.iterchildren())
+        if len(body):
+            return list(body.iterchildren())
+        head = doc.getroot()[0]
+        if head.text is None:
+            return list(head.iterchildren())
+        return [head.text] + list(head.iterchildren())
     else:
         return [body.text] + list(body.iterchildren())
 
@@ -118,13 +123,17 @@ def removeNode(node):
     parent.remove(node)
 
 
-def replaceContents(el, newElements):
-    clearContents(el)
+def appendContents(el, newElements):
     if(etree.iselement(newElements) and newElements.text is not None):
         appendChild(el, newElements.text)
     for new in newElements:
         appendChild(el, new)
     return el
+
+
+def replaceContents(el, newElements):
+    clearContents(el)
+    return appendContents(el, newElements)
 
 
 def moveContents(targetEl, sourceEl):

--- a/bikeshed/include/annotations.include
+++ b/bikeshed/include/annotations.include
@@ -1,0 +1,5 @@
+<head>
+  <script defer
+    src="[ANNOTATIONS][TESTSUITE]"
+    type="text/javascript"></script>
+</head>

--- a/bikeshed/spec-data/test-suites.json
+++ b/bikeshed/spec-data/test-suites.json
@@ -1,0 +1,178 @@
+{
+  "css-fonts-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Fonts 3 CR Test Suite.", 
+    "title": "CSS Fonts Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-fonts/nightly-unstable/", 
+    "spec": "css-fonts-3", 
+    "vshortname": "css-fonts-3_dev"
+  }, 
+  "css-text-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Text 3 CR Test Suite.", 
+    "title": "CSS Text Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-text/nightly-unstable/", 
+    "spec": "css-text-3", 
+    "vshortname": "css-text-3_dev"
+  }, 
+  "css-writing-modes-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Writing Modes 3 CR Test Suite.", 
+    "title": "CSS Writing Modes Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-writing-modes/nightly-unstable/", 
+    "spec": "css-writing-modes-3", 
+    "vshortname": "css-writing-modes-3_dev"
+  }, 
+  "css-style-attr-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Style Attributes 1 Test Suite.", 
+    "title": "CSS Style Attributes Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css-style-attr/nightly-unstable/", 
+    "spec": "css-style-attr-1", 
+    "vshortname": "css-style-attr-1_dev"
+  }, 
+  "css-ui-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Basic User Interface 3 CR Test Suite.", 
+    "title": "CSS Basic User Interface Module Level 3 CR Test Suite", 
+    "url": null, 
+    "spec": "css-ui-3", 
+    "vshortname": "css-ui-3_dev"
+  }, 
+  "css-transforms-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Transforms 1 CR Test Suite.", 
+    "title": "CSS Transforms Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-transforms/nightly-unstable/", 
+    "spec": "css-transforms-1", 
+    "vshortname": "css-transforms-1_dev"
+  }, 
+  "css-transitions-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Transitions 3 CR Test Suite.", 
+    "title": "CSS Transitions Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css-transitions-1/nightly-unstable/", 
+    "spec": "css-transitions-1", 
+    "vshortname": "css-transitions-1_dev"
+  }, 
+  "filters-1": {
+    "status": "dev", 
+    "description": "Nightly build of the Filters 1 CR Test Suite.", 
+    "title": "Filter Effects Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/filter-effects/nightly-unstable/", 
+    "spec": "filters-1", 
+    "vshortname": "filters-1_dev"
+  }, 
+  "css-exclusions-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Exclusions 1 CR Test Suite.", 
+    "title": "CSS Exclusions Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-exclusions/nightly-unstable/", 
+    "spec": "css-exclusions-1", 
+    "vshortname": "css-exclusions-1_dev"
+  }, 
+  "css21": {
+    "status": "beta", 
+    "description": "Nightly build of the CSS 2.1 Test Suite. Ongoing development for general conformance testing.", 
+    "title": "CSS 2.1 Conformance Test Suite", 
+    "url": "http://test.csswg.org/suites/css2.1/nightly-unstable/", 
+    "spec": "css21", 
+    "vshortname": "css21_dev"
+  }, 
+  "css-animations-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Animations 1 CR Test Suite.", 
+    "title": "CSS Animations Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css-animations-1/nightly-unstable/", 
+    "spec": "css-animations-1", 
+    "vshortname": "css-animations-1_dev"
+  }, 
+  "css-multicol-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Multicol 1 Test Suite.", 
+    "title": "CSS Multi-column Layout Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-multicol/nightly-unstable/", 
+    "spec": "css-multicol-1", 
+    "vshortname": "css-multicol-1_dev"
+  }, 
+  "css-shapes-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Shapes 1 CR Test Suite.", 
+    "title": "CSS Shapes Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-shapes/nightly-unstable/", 
+    "spec": "css-shapes-1", 
+    "vshortname": "css-shapes-1_dev"
+  }, 
+  "css-color-3": {
+    "status": "beta", 
+    "description": "Nightly build of the CSS Color 3 Test Suite. Ongoing development for general conformance testing.", 
+    "title": "CSS Color Module Level 3 Conformance Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-color/nightly-unstable/", 
+    "spec": "css-color-3", 
+    "vshortname": "css-color-3_dev"
+  }, 
+  "css-flexbox-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Flexbox 1 CR Test Suite.", 
+    "title": "CSS Flexible Box Layout Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-flexbox/nightly-unstable/", 
+    "spec": "css-flexbox-1", 
+    "vshortname": "css-flexbox-1_dev"
+  }, 
+  "css-masking-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Masking 1 CR Test Suite.", 
+    "title": "CSS Masking Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css-masking/nightly-unstable/", 
+    "spec": "css-masking-1", 
+    "vshortname": "css-masking-1_dev"
+  }, 
+  "css-backgrounds-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Backgrounds 3 CR Test Suite.", 
+    "title": "CSS Backgrounds and Borders Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-background/nightly-unstable/", 
+    "spec": "css-backgrounds-3", 
+    "vshortname": "css-backgrounds-3_dev"
+  }, 
+  "css-variables-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Custom Properties for Cascading Variables CR Test Suite.", 
+    "title": "CSS Custom Properties Level 1 CR Test Suite", 
+    "url": null, 
+    "spec": "css-variables-1", 
+    "vshortname": "css-variables-1_dev"
+  }, 
+  "css-conditional-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Conditional 3 CR Test Suite.", 
+    "title": "CSS Conditional Rules Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-conditional/nightly-unstable/", 
+    "spec": "css-conditional-3", 
+    "vshortname": "css-conditional-3_dev"
+  }, 
+  "compositing-1": {
+    "status": "dev", 
+    "description": "Nightly build of the Compositing and Blending 1 CR Test Suite.", 
+    "title": "Compositing and Blending Level 1 CR Test Suite", 
+    "url": null, 
+    "spec": "compositing-1", 
+    "vshortname": "compositing-1_dev"
+  }, 
+  "css-text-decor-3": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Text Decoration 3 CR Test Suite.", 
+    "title": "CSS Text Decoration Module Level 3 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css-text-decor-3/nightly-unstable/", 
+    "spec": "css-text-decor-3", 
+    "vshortname": "css-text-decor-3_dev"
+  }, 
+  "css-regions-1": {
+    "status": "dev", 
+    "description": "Nightly build of the CSS Regions 1 CR Test Suite.", 
+    "title": "CSS Regions Module Level 1 CR Test Suite", 
+    "url": "http://test.csswg.org/suites/css3-regions/nightly-unstable/", 
+    "spec": "css-regions-1", 
+    "vshortname": "css-regions-1_dev"
+  }
+}


### PR DESCRIPTION
When you land this, one of us needs to remove all the annotation scripts from the bikesheded source files otherwise they'll double up. I'm happy to take care of it if you ping me.

The test suite metadata is still respected if present, but if not present, it's taken from the Shepherd API too, so ideally we should remove those too so the URLs will stay current when I move test suites around.
