### PR TITLE
Store readonly/nullable in attribute idl markup, and insert this information in <span attribute-info> spans.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -786,7 +786,7 @@ def fillAttributeInfoSpans(doc):
             if datatype[-1] == "?":
                 decorations += ", nullable"
                 datatype = datatype[:-1]
-            replaceContents(el, parseHTML("of type <span data-type>{0}</span>{1}".format(datatype, decorations)))
+            replaceContents(el, parseHTML("of type <a interface>{0}</a>{1}".format(datatype, decorations)))
             # FIXME: Is there a nicer way to force a leading space here?
             el.text = ' ' + el.text
 


### PR DESCRIPTION
The attribute currentTime of AnimationTimeline:
<code>
interface AnimationTimeline {
    readonly attribute double? currentTime;
}
</code>

was marked up as:
<code>
&lt;a title="currentTime" data-idl-for=" data-idl-type="attribute"&gt;currentTime&lt;/a&gt;
</code>

I've added data-type and an optional data-readonly:
<code>
&lt;a title="currentTime" data-idl-for=" data-idl-type="attribute" data-readonly data-type="double?" &gt;currentTime&lt;/a&gt;
</code>

I've also added processing of
<code>
&lt;span attribute-info for=currentTime&gt;&lt;/span&gt;
</code>

To produce
<code>
&lt;span data-attribute-info for="currentTime"&gt; of type &lt;span data-type&gt;double&lt;/span&gt;, readonly, nullable&lt;/span&gt;
</code>
