### PR TITLE
Autolinking: Ignore case when procesing the 'spec' attribute.

### DIFF
--- a/bikeshed/ReferenceManager.py
+++ b/bikeshed/ReferenceManager.py
@@ -152,7 +152,7 @@ class ReferenceManager(object):
 
         # If spec is specified, kill anything that doesn't match
         if spec is not None:
-            refs = [ref for ref in refs if ref['shortname']==spec or ref['spec']==spec]
+            refs = [ref for ref in refs if ref['shortname'].lower() == spec.lower() or ref['spec'].lower() ==spec.lower()]
         if len(refs) == 0:
             if zeroRefsError:
                 die("No '{0}' refs found for '{1}' with spec '{2}'.", linkType, text, spec)


### PR DESCRIPTION
`<a spec="CSSOM">...</a>` should link to the same spec as `[[!CSSOM]]`.
Now it does.

Closes issue #138.
