### PR TITLE
Add "heading" to the acceptible autolink types.

### DIFF
--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -38,7 +38,8 @@ dfnClassToType = {
     "typedefdef"      : "typedef",
     "stringdef"       : "stringifier",
     "serialdef"       : "serializer",
-    "iterdef"         : "iterator" }
+    "iterdef"         : "iterator",
+    "headingdef"      : "heading" }
 
 dfnTypes = frozenset(dfnClassToType.values())
 maybeTypes = frozenset(["value", "type", "at-rule", "function", "selector"])


### PR DESCRIPTION
There might be a wonderful reason that you haven't done this already; I'd like to be able to link to [HTML5's "pragma directives"](http://www.w3.org/TR/html5/document-metadata.html#pragma-directives), however, which, for whatever reason, isn't currently a `<dfn>`.
