### PR TITLE
Unfix typography for autolinking.

### DIFF
--- a/bikeshed/ReferenceManager.py
+++ b/bikeshed/ReferenceManager.py
@@ -50,6 +50,7 @@ class ReferenceManager(object):
             if hasClass(el, "no-ref"):
                 continue
             for linkText in linkTextsFromElement(el):
+                linkText = unfixTypography(linkText)
                 type = treeAttr(el, 'data-dfn-type')
                 dfnFor = treeAttr(el, 'data-dfn-for')
                 if dfnFor is None:
@@ -103,6 +104,8 @@ class ReferenceManager(object):
         # 'maybe' links might not link up, so it's fine for them to have no references.
         # The relevent errors are gated by this variable.
         zeroRefsError = error and linkType!="maybe"
+
+        text = unfixTypography(text)
 
         status = status or self.specStatus
         if status not in ("ED", "TR", "local"):

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -180,21 +180,6 @@ def replaceTextMacros(text):
     return text
 
 
-def fixTypography(text):
-    # Replace straight aposes with curly quotes for possessives and contractions.
-    text = re.sub(r"([\w])'([\w])", r"\1’\2", text)
-    text = re.sub(r"(</[\w]+>)'([\w])", r"\1’\2", text)
-    # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
-    text = re.sub(r"([^<][^!])(—|--)\r?\n\s+(\S)", r"\1—<wbr>\3", text)
-    return text
-
-def unfixTypography(text):
-    # Replace curly quotes with straight quotes, and emdashes with double dashes.
-    text = re.sub(r"’", r"'", text)
-    # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
-    text = re.sub(r"—<wbr>", r"--", text)
-    return text
-
 def transformMarkdownParagraphs(doc):
     doc.lines = markdown.parse(doc.lines)
 
@@ -1032,7 +1017,7 @@ def processAutolinks(doc):
             el.set('href', '#'+simplifyText(linkText))
             continue
 
-        url = doc.refs.getRef(linkType, unfixTypography(linkText),
+        url = doc.refs.getRef(linkType, linkText,
                               spec=el.get('data-link-spec'),
                               status=el.get('data-link-status'),
                               linkFor=el.get('data-link-for'),
@@ -1144,7 +1129,7 @@ def processIDL(doc):
         for el in findAll("idl", pre):
             idlType = el.get('data-idl-type')
             idlText = el.get('title')
-            url = doc.refs.getRef(idlType, unfixTypography(idlText.lower()),
+            url = doc.refs.getRef(idlType, idlText.lower(),
                                   linkFor=el.get('data-idl-for'),
                                   el=el,
                                   error=False)

--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -6,6 +6,7 @@ from html5lib.serializer import htmlserializer
 from lxml import html
 from lxml import etree
 from lxml.cssselect import CSSSelector
+import re
 
 from . import config
 from .messages import *
@@ -215,3 +216,18 @@ def isElement(node):
 
 def isOpaqueElement(el):
     return el.tag in ('pre', 'code', 'style', 'script')
+
+def fixTypography(text):
+    # Replace straight aposes with curly quotes for possessives and contractions.
+    text = re.sub(r"([\w])'([\w])", r"\1’\2", text)
+    text = re.sub(r"(</[\w]+>)'([\w])", r"\1’\2", text)
+    # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
+    text = re.sub(r"([^<][^!])(—|--)\r?\n\s+(\S)", r"\1—<wbr>\3", text)
+    return text
+
+def unfixTypography(text):
+    # Replace curly quotes with straight quotes, and emdashes with double dashes.
+    text = re.sub(r"’", r"'", text)
+    # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
+    text = re.sub(r"—<wbr>", r"--", text)
+    return text


### PR DESCRIPTION
"the script block's source" can't be autolinked, as the single quote is
typographized into a curly quote before autolinking. This patch unfixes
the typography before passing the string into 'getRef'.

Closes #150.
