### PR TITLE
Fold whitespace when getting the textContent of an element.

### DIFF
--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -31,7 +31,10 @@ def find(sel, context=None):
 
 def textContent(el):
     str =  html.tostring(el, method='text', with_tail=False, encoding="unicode")
-    return re.sub(r"\s+", r" ", str)
+    if (el.tag.lower() == "pre"):
+        return str
+    else:
+        return re.sub(r"\s+", r" ", str)
 
 
 def innerHTML(el):


### PR DESCRIPTION
If definitions span lines, for example, the whitespace following
the newline is meaningful when generating definition IDs and etc.
We should fold multiple whitespace characters into a single space
when generating the text content of nodes to avoid this issue.

Closes #153.
