### PR TITLE
Let each <dd><dt> in References section to be one line in generated HTML...

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1837,18 +1837,18 @@ def addSpecMetadataSection(doc):
 
 
 def addReferencesSection(doc):
-    text = "<dl>"
+    text = "<dl>\n"
     for ref in sorted(doc.normativeRefs, key=lambda r: r.linkText):
         text += "<dt id='{1}' title='{0}'>[{0}]</dt>".format(ref.linkText, simplifyText(ref.linkText))
-        text += "<dd>{0}</dd>".format(ref)
+        text += "<dd>{0}</dd>\n".format(ref)
     text += "</dl>"
     fillWith("normative-references", parseHTML(text))
 
-    text = "<dl>"
+    text = "<dl>\n"
     # If the same doc is referenced as both normative and informative, normative wins.
     for ref in sorted(doc.informativeRefs - doc.normativeRefs, key=lambda r: r.linkText):
         text += "<dt id='{1}' title='{0}'>[{0}]</dt>".format(ref.linkText, simplifyText(ref.linkText))
-        text += "<dd>{0}</dd>".format(ref)
+        text += "<dd>{0}</dd>\n".format(ref)
     text += "</dl>"
     fillWith("informative-references", parseHTML(text))
 


### PR DESCRIPTION
I would like each reference in References section to be in separate lines so that diff can clarify which references were updated. This helps me when I'm bug'ed about incorrect/old references.
Not sure whether you or others like or not, please consider if you like.
