### PR TITLE
Add a heuristic to detect ends of paragraphs inside block elements.

### DIFF
--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -142,6 +142,7 @@ def parseMultiLineHeading(stream):
 	return lines
 
 def parseParagraph(stream):
+	initialIndent = len(stream.currraw()) - len(stream.currraw().lstrip())
 	line = stream.currtext()
 	if line.startswith("Note: ") or line.startswith("Note, "):
 		p = "<p class='note'>"
@@ -153,9 +154,20 @@ def parseParagraph(stream):
 	lines = ["{0}{1}\n".format(p, line)]
 	while True:
 		stream.advance()
+
+		# Check the indentation of the current line; if it's smaller than the
+		# initial indentation, close the paragraph, and append the raw line.
+		currentIndent = len(stream.currraw()) - len(stream.currraw().lstrip())
+		if currentIndent < initialIndent:
+			lines[-1] = lines[-1][0:-1] + "</p>" + "\n"
+			lines.append(stream.currraw())
+			return lines
+		# Otherwise, if we've hit a blank line or the end of the file, close
+		# the paragraph and return.
 		if stream.currtype() in ("eof", "blank"):
 			lines[-1] = lines[-1][0:-1] + "</p>" + "\n"
 			return lines
+		# Otherwise, just keep appending.
 		lines.append(stream.currraw())
 
 def parseBulleted(stream):

--- a/bikeshed/test/test.bs
+++ b/bikeshed/test/test.bs
@@ -46,3 +46,10 @@ More Foo
   3</a>
   <a>new term
   4</a>
+
+<section>
+  <h2 id="whatever">Whatever</h2>
+
+  This is a section that contains a
+  very short paragraph indeed.
+</section>

--- a/bikeshed/test/test.html
+++ b/bikeshed/test/test.html
@@ -543,14 +543,14 @@ span.issue, span.note {
   <p data-fill-with=logo></p>
   <h1 class="p-name no-ref" id=title>Foo</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
-    <span class=dt-updated><span class=value-title title=20140520>20 May 2014</span></span></span></h2>
+    <span class=dt-updated><span class=value-title title=20140521>21 May 2014</span></span></span></h2>
   <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=http://example.com/foo>http://example.com/foo</a><dt>Editor’s Draft:<dd><a href=http://example.com/foo>http://example.com/foo</a><dt>Test Suite:<dd>None Yet<dt>Editors:
 <dd class="p-author h-card vcard"><span class="p-name fn">Tab Atkins</span></dl></div>
   <div data-fill-with=warning></div>
-  <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=http://i.creativecommons.org/p/zero/1.0/80x15.png></a>
+  <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=https://i.creativecommons.org/p/zero/1.0/80x15.png></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 20 May 2014,
+In addition, as of 21 May 2014,
 the editors have made this specification available under the
 <a href=http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0 rel=license>Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
@@ -570,6 +570,7 @@ Parts of this work may be from another specification document.  If so, those par
 		<ul class=toc>
 		<li><a href=#bar><span class=secno>1.1</span>Bar Subsection</a></ul>
 	<li><a href=#more-foo><span class=secno>2</span>More Foo</a>
+	<li><a href=#whatever><span class=secno>3</span>Whatever</a>
 	<li><a href=#conformance><span class=secno></span> Conformance</a>
 	<li><a href=#references><span class=secno></span> References</a>
 		<ul class=toc>
@@ -602,6 +603,7 @@ Parts of this work may be from another specification document.  If so, those par
   <dfn data-dfn-type=dfn data-noexport="" id=new-term-4>new term
   4<a class=self-link href=#new-term-4></a></dfn></p>
 
+
 <p>foo foo</p>
 
 <p><em>foo foo</em></p>
@@ -617,6 +619,15 @@ Parts of this work may be from another specification document.  If so, those par
   <a data-link-type=dfn href=#new-term-4 title="new term 4">new term
   4</a></p>
 
+
+<section>
+  <h2 class="heading settled heading" data-level=3 id=whatever><span class=secno>3 </span><span class=content>Whatever</span><a class=self-link href=#whatever></a></h2>
+
+<p>This is a section that contains a
+  very short paragraph indeed.</p>
+</section>
+
+
 <h2 class="no-ref no-num heading settled heading" id=conformance><span class=content>
 Conformance</span><a class=self-link href=#conformance></a></h2>
 
@@ -630,7 +641,7 @@ Conformance</span><a class=self-link href=#conformance></a></h2>
 
     <p>
         All of the text of this specification is normative
-        except sections explicitly marked as non-normative, examples, and notes. <a data-biblio-type=normative data-link-type=biblio href=#rfc2119 title=rfc2119>[RFC2119]</a>
+        except sections explicitly marked as non-normative, examples, and notes. <a data-biblio-type=normative data-link-type=biblio href=#biblio-rfc2119 title=biblio-rfc2119>[RFC2119]</a>
 
     <p>
         Examples in this specification are introduced with the words “for example”
@@ -652,11 +663,14 @@ References</span><a class=self-link href=#references></a></h2>
 
 <h3 class="no-num no-ref heading settled heading" id=normative><span class=content>
 Normative References</span><a class=self-link href=#normative></a></h3>
-<div data-fill-with=normative-references><dl><dt id=rfc2119 title=RFC2119><a class=self-link href=#rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a></dl></div>
+<div data-fill-with=normative-references><dl>
+<dt id=biblio-rfc2119 title=RFC2119><a class=self-link href=#biblio-rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a></dd>
+</dl></div>
 
 <h3 class="no-num no-ref heading settled heading" id=informative><span class=content>
 Informative References</span><a class=self-link href=#informative></a></h3>
-<div data-fill-with=informative-references><dl></dl></div>
+<div data-fill-with=informative-references><dl>
+</dl></div>
 
 <h2 class="no-num no-ref heading settled heading" id=index><span class=content>
 Index</span><a class=self-link href=#index></a></h2>


### PR DESCRIPTION
Currently, the Markdown paragraph parser eats the closing tag of a block
element that encloses a paragraph. This patch adds a heuristic which
measures the amount of indentation for the paragraph's first line, and
ends the paragraph when a line is encountered that is outdented from
that initial point.

Fixes #165.
