### PR TITLE
Correctly collapse indented-<pre> whitespace.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -275,7 +275,7 @@ def transformDataBlocks(doc):
 
 
 def transformPre(lines, tagName, firstLine, **kwargs):
-    prefix = re.match(r"\s*", firstLine).group(0)
+    prefix = re.match(r"\s*", lines[0]).group(0)
     for (i, line) in enumerate(lines):
         # Remove the whitespace prefix from each line.
         match = re.match(prefix+"(.*)", line, re.DOTALL)


### PR DESCRIPTION
`<pre>`'s whitespace collapsing behavior should be based on the first line
of the block, rather than on the indentation of the opening `<pre>` tag.
That is:

``` html
  Text text text.

    <pre>
        Pre pre pre
    </pre>
```

Should generate:

``` html
  <p>Text text text.</p>
  <pre>
  Pre pre pre
  </pre>
```

This patch modifies `transformPre()` to grab the prefix from the first
inner line of the block, rather than |startLine|.
