### PR TITLE
Remove FXTF abstract

### DIFF
--- a/bikeshed/include/abstract-fxtf.include
+++ b/bikeshed/include/abstract-fxtf.include
@@ -1,4 +1,0 @@
-[ABSTRACT]
-<a href='http://www.w3.org/TR/CSS/'>CSS</a> is a language for describing the rendering of structured documents 
-(such as HTML and XML) 
-on screen, on paper, in speech, etc.


### PR DESCRIPTION
This reference to CSS is irrelevant to many FXTF specs.
