### PR TITLE
Add a trailing dot after header levels

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -502,7 +502,7 @@ def addHeadingBonuses(doc, headings):
     for header in headings:
         if header.get("data-level") is not None:
             secno = lxml.etree.Element('span', {"class":"secno"})
-            secno.text = header.get('data-level') + ' '
+            secno.text = header.get('data-level') + '. '
             header.insert(0, secno)
 
 


### PR DESCRIPTION
… so the output looks like

> ## 2. Terminology

… rather than:

> ## 2 Terminology

I think this looks nicer. What do you think?
