### PR TITLE
Tweaks to WHATWG header

### DIFF
--- a/bikeshed/include/header-whatwg.include
+++ b/bikeshed/include/header-whatwg.include
@@ -8,13 +8,11 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[SPECTITLE]</h1>
-  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS] — Last Updated
     <span class="dt-updated"><span class="value-title" title="[CDATE]">[DATE]</span></h2>
   <script async="" src="//resources.whatwg.org/file-bug.js"></script>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
-  <p class='copyright' data-fill-with='copyright'></p>
-  <hr title="Separator for header">
 </div>
 
 <h2 class='no-num no-toc no-ref' id='abstract'>Abstract</h2>


### PR DESCRIPTION
- Update date to be prefixed by "last updated" instead of a comma.
- Remove copyright; we're moving it to the bottom since it's not important enough to be the first thing you read.
- Remove a redundant `<hr>` that was being visually hidden anyway.
