### PR TITLE
Accept '0' as a level which doesn't suffix the shortname.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -555,7 +555,10 @@ def transformAnchors(lines, doc, **kwargs):
             if not checkTypes(anchor, key, field, basestring, int):
                 continue
             anchor[field] = unicode(anchor[field]).strip() + "\n"
-        anchor['spec'] = "{0}-{1}\n".format(anchor['shortname'].strip(), anchor['level'].strip())
+        if anchor['level'].strip() != '0':
+            anchor['spec'] = "{0}-{1}\n".format(anchor['shortname'].strip(), anchor['level'].strip())
+        else:
+            anchor['spec'] = anchor['shortname'].strip()
         anchor['export'] = True
         # String or list-of-strings fields, convert to list
         for field in ["linkingText", "for"]:


### PR DESCRIPTION
Some specifications don't actually have levels. "Fetch", for instance. And "html5".

This patch accepts `"level": 0` as a hint that the shortname shouldn't be suffixed. An alternative approach would be to make the `level` attribute optional, but since you'd explicitly made it required, I'm not sure you'd accept that patch. :)

WDYT?