### PR TITLE
Ensure that inlined anchor definitions take priority.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -571,7 +571,10 @@ def transformAnchors(lines, doc, **kwargs):
                     continue
                 anchor[field][i] = re.sub(r'\s+', ' ', anchor[field][i].strip()) + "\n"
         for text in anchor['linkingText']:
-            doc.refs.refs[text.lower()].append(anchor)
+            # Overwrite existing references whose shortname matches the inline-defined anchor.
+            if doc.refs.refs[text.lower()]:
+                doc.refs.refs[text.lower()] = [ref for ref in doc.refs.refs[text.lower()] if ref['shortname'] != anchor['shortname']]
+            doc.refs.refs[text.lower()].insert(0, anchor)
     return []
 
 


### PR DESCRIPTION
If an author defines a link inline, it's a safe bet that she wishes to
use that link in the document. This patch drops any existing references
which have the same shortname/text combination as the newly defined
anchor, and ensures that the inlined anchor is inserted at the beginning
of the list of references for a term (so that it will be the default
choice in the absence of `Link Defaults` metadata.
