### PR TITLE
WHATWG header: add bikeshed.css; remove file-bug.js

### DIFF
--- a/bikeshed/include/header-whatwg.include
+++ b/bikeshed/include/header-whatwg.include
@@ -3,6 +3,7 @@
   <meta charset="utf-8">
   <title>[TITLE]</title>
   <link href="https://www.whatwg.org/style/specification" rel="stylesheet">
+  <link href="https://resources.whatwg.org/bikeshed.css" rel="stylesheet">
   <link href="[LOGO]" rel="icon">
 <body class="h-entry">
 <div class="head">
@@ -10,7 +11,6 @@
   <h1 id="title" class="p-name no-ref">[SPECTITLE]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS] — Last Updated
     <span class="dt-updated"><span class="value-title" title="[CDATE]">[DATE]</span></h2>
-  <script async="" src="//resources.whatwg.org/file-bug.js"></script>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
 </div>


### PR DESCRIPTION
file-bug.js is only used by those specs that use the W3C issue tracker, and errors otherwise. bikeshed.css contains mostly self-link stuff for now.
