### PR TITLE
Add support for commit and branch snapshots with warnings

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -210,7 +210,7 @@ class MetadataManager:
             'abstract': 'Abstract'
         }
 
-        if self.status != 'LS':
+        if self.status not in config.noEDStatuses:
             requiredSingularKeys['ED'] = 'ED'
         if self.status in config.deadlineStatuses:
             requiredSingularKeys['deadline'] = 'Deadline'
@@ -277,6 +277,10 @@ class MetadataManager:
             macros["testsuite"] = doc.testSuites[self.vshortname]['vshortname']
         if self.warning and self.warning[1] is not None:
             macros["replacedby"] = self.warning[1]
+        if self.warning and self.warning[2] is not None:
+            macros["snapshotid"] = self.warning[2]
+        if self.warning and self.warning[3] is not None:
+            macros["snapshoturl"] = self.warning[3]
         macros["logo"] = self.logo
         # get GH repo from remote
         macros["repository"] = getSpecRepository(doc)
@@ -309,6 +313,12 @@ def convertWarning(key, val):
         return "warning-obsolete",
     if val.lower() == "not ready":
         return "warning-not-ready",
+    match = re.match(r"Commit +([^ ]+) +(.+) +replaced by +(.+)", val, re.I)
+    if match:
+        return "warning-commit", match.group(3), match.group(1), match.group(2)
+    match = re.match(r"Branch +([^ ]+) +(.+) +replaced by +(.+)", val, re.I)
+    if match:
+        return "warning-branch", match.group(3), match.group(1), match.group(2)
     match = re.match(r"Replaced By +(.+)", val, re.I)
     if match:
         return "warning-replaced-by", match.group(1)

--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -15,8 +15,9 @@ doc = None
 textMacros = {}
 
 TRStatuses = ["WD", "FPWD", "LCWD", "CR", "PR", "REC", "PER", "NOTE", "MO"]
-unlevelledStatuses = ["LS", "DREAM", "UD"]
+unlevelledStatuses = ["LS", "DREAM", "UD", "Commit", "Branch"]
 deadlineStatuses = ["LCWD", "PR"]
+noEDStatuses = ["LS", "LS-COMMIT", "LS-BRANCH"]
 shortToLongStatus = {
     "ED": "Editor's Draft",
     "WD": "W3C Working Draft",
@@ -30,7 +31,9 @@ shortToLongStatus = {
     "MO": "W3C Member-only Draft",
     "UD": "Unofficial Proposal Draft",
     "DREAM": "A Collection of Interesting Ideas",
-    "LS": "Living Standard"
+    "LS": "Living Standard",
+    "LS-COMMIT": "Commit Snapshot",
+    "LS-BRANCH": "Branch Snapshot"
 }
 
 dfnClassToType = {

--- a/bikeshed/include/header-whatwg.include
+++ b/bikeshed/include/header-whatwg.include
@@ -5,7 +5,7 @@
   <link href="https://www.whatwg.org/style/specification" rel="stylesheet">
   <link href="https://resources.whatwg.org/bikeshed.css" rel="stylesheet">
   <link href="[LOGO]" rel="icon">
-<body class="h-entry">
+<body class="h-entry status-[STATUS]">
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[SPECTITLE]</h1>

--- a/bikeshed/include/warning-branch.include
+++ b/bikeshed/include/warning-branch.include
@@ -1,0 +1,10 @@
+<details open class='annoying-warning'>
+  <summary>This Is a Branch Snapshot of the Standard</summary>
+  <p>
+    This document contains the contents of the standard as they were last seen in the <a href="[SNAPSHOTURL]">[SNAPSHOTID] branch</a>,
+    and do not reflect the state of the master branch and the living standard it embodies.
+  <p>
+    Do not attempt to implement this version of the specification.
+    Do not reference this version as authoritative in any way.
+    Instead, see <a href="[REPLACEDBY]">[REPLACEDBY]</a> for the living standard.
+</details>

--- a/bikeshed/include/warning-commit.include
+++ b/bikeshed/include/warning-commit.include
@@ -1,0 +1,11 @@
+<details open class='annoying-warning'>
+  <summary>This Is a Commit Snapshot of the Standard</summary>
+  <p>
+    This document contains the contents of the standard as of the <a href="[SNAPSHOTURL]">[SNAPSHOTID] commit</a>,
+    and should only be used as a historical reference.
+    This commit may not even have been merged into master.
+  <p>
+    Do not attempt to implement this version of the specification.
+    Do not reference this version as authoritative in any way.
+    Instead, see <a href="[REPLACEDBY]">[REPLACEDBY]</a> for the living standard.
+</details>

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -48,7 +48,7 @@ There are several additional optional keys:
 
 * **TR** must contain a link that points to the latest version on /TR.
 * **Former Editor** must contain a former editor's information, in the same format as "Editor".
-* **Warning** must contain either "Obsolete", "Not Ready", "New Version XXX", or "Replaced by XXX", which triggers the appropriate warning message in the boilerplate.
+* **Warning** must contain either "Obsolete", "Not Ready", "New Version XXX", "Replaced by XXX", "Commit deadb33f http://example.com/url/to/deadb33f replaced by XXX", or "Branch XXX http://example.com/url/to/XXX replaced by YYY" which triggers the appropriate warning message in the boilerplate.
 * **Previous Version** must contain a link that points to a previous (dated) version on /TR.  You can specify this key more than once for multiple entries.
 * **At Risk** must contain an at-risk feature.  You can specify this key more than once for multiple entries.
 * **Group** must contain the name of the group the spec is being generated for.  This is used by the boilerplate generation to select the correct file.  It defaults to "csswg".


### PR DESCRIPTION
<del>Needs docs, but </del>wanted to get the code up for review. Successfully able to produce my desired commit and branch snapshots using the commands:

```
bikeshed spec index.bs --md-status=Commit --md-warning="Commit deadb33f http://example.com/url/to/deadb33f replaced by https://streams.spec.whatwg.org/" --md-title="Streams Standard (Commit Snapshot deadbeef)"

bikeshed spec index.bs --md-status=Branch --md-warning="Branch ready-fulfill-only http://example.com/url/to/ready-fulfill-only replaced by https://streams.spec.whatwg.org/" --md-title="Streams Standard (Branch Snapshot ready-fulfill-only)"
```

which will be pretty easy to script to run automatically in CI.
