### PR TITLE
Switch license images to licensebuttons.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ which isn't generally what you want.)
 License
 -------
 
-This document and all associated files in the github project are licensed under [CC0](http://creativecommons.org/publicdomain/zero/1.0/) ![](http://i.creativecommons.org/p/zero/1.0/80x15.png).
+This document and all associated files in the github project are licensed under [CC0](http://creativecommons.org/publicdomain/zero/1.0/) ![](http://licensebuttons.net/p/zero/1.0/80x15.png).
 This means you can reuse, remix, or otherwise appropriate this project for your own use **without restriction**.
 (The actual legal meaning can be found at the above link.)
 Don't ask me for permission to use any part of this project, **just use it**.

--- a/bikeshed/include/copyright-personal.include
+++ b/bikeshed/include/copyright-personal.include
@@ -1,4 +1,4 @@
-<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://i.creativecommons.org/p/zero/1.0/80x15.png"></a>
+<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a>
 To the extent possible under law, the editors have waived all copyright 
 and related or neighboring rights to this work. 
 In addition, as of [DATE], 

--- a/bikeshed/include/copyright.include
+++ b/bikeshed/include/copyright.include
@@ -1,4 +1,4 @@
-<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://i.creativecommons.org/p/zero/1.0/80x15.png"></a>
+<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
 In addition, as of [DATE],


### PR DESCRIPTION
Creative Commons now does a 301 redirect to licensebuttons.net. This
commit changes out the images in generated files to avoid the redirect.
