### PR TITLE
Update MetadataManager.py

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -486,8 +486,8 @@ def getSpecRepository(doc):
     '''
     if doc and doc.inputSource and doc.inputSource != "-":
         source_dir = os.path.dirname(os.path.abspath(doc.inputSource))
+        old_dir = os.getcwd()
         try:
-            old_dir = os.getcwd()
             os.chdir(source_dir)
             with open(os.devnull, "wb") as fnull:
                 remotes = check_output(["git", "remote", "-v"], stderr=fnull)
@@ -499,6 +499,7 @@ def getSpecRepository(doc):
                 return ""
         except:
             # check_output will throw CalledProcessError when not in a git repo
+            os.chdir(old_dir)
             return ""
 
 def parseDoc(doc):


### PR DESCRIPTION
When looking for repository, restore cwd _before_ returning from method.
This bug currently results in the output path being relative to the directory of the input file, rather than the cwd of the invocation.
