### PR TITLE
Add `((.../...))` autolink shortcuts for elements/attributes.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1459,6 +1459,12 @@ class CSSSpec(object):
             return E.code({"class":"idl"},
                 E.a({"data-link-type":linkType, "for": match.group(1)}, match.group(2)))
 
+        elementRe = re.compile(r"<{(?:(\w+)/)?(\w+)}>")
+        def elementReplacer(match):
+            linkType = "element" if match.group(1) is None else "element-attr"
+            return E.code({},
+                E.a({"data-link-type":linkType, "for": match.group(1)}, match.group(2)))
+
         def transformElement(parentEl):
             processContents = isElement(parentEl) and not isOpaqueElement(parentEl)
             if not processContents:
@@ -1477,6 +1483,7 @@ class CSSSpec(object):
             nodes = [text]
             config.processTextNodes(nodes, propdescRe, propdescReplacer)
             config.processTextNodes(nodes, idlRe, idlReplacer)
+            config.processTextNodes(nodes, elementRe, elementReplacer)
             config.processTextNodes(nodes, biblioRe, biblioReplacer)
             config.processTextNodes(nodes, sectionRe, sectionReplacer)
             return nodes

--- a/docs/definitions-autolinks.md
+++ b/docs/definitions-autolinks.md
@@ -222,6 +222,8 @@ There are several additional shortcuts for writing an autolink:
 * `[[foo]]` is an autolink to a bibliography entry named "foo", and auto-generates an informative reference in the biblio section.
     Add a leading exclamation point to the value, like `[[!foo]]` for a normative reference.
 * `[[#foo]]` is an autolink to a heading in the same document with the given ID.  (See [Section Links](#section-links) for more detail.)
+* `<{element}>` is an autolink to the element named "element".
+* `<{element/attribute}>` is an autolink to the attribute named "attribute" for the element "element".
 
 For any of the above shorthands that can have a "for" value, you can indicate this inline by preceding the linking text with the "for" value and separating it with a slash. For example, to disambiguate that you want the "foo" value from the "prop1" property (rather than "prop2", which also has a "foo" value), you can write:
 

--- a/tests/link-shorthands001.bs
+++ b/tests/link-shorthands001.bs
@@ -39,6 +39,8 @@ Setting up the definitions:
 <dfn dictionary>Dictionary</dfn>,
 <dfn attribute for="Interface" title="ambiguous-attr" id='interface-attr'>attribute for Interface</dfn>,
 <dfn dict-member for="Dictionary" title="ambiguous-attr" id='dict-attr'>attribute for Dictionary</dfn>
+<dfn element>element</dfn>
+<dfn element-attr for="element">attribute</dfn>
 
 Linking:
 'property'
@@ -80,3 +82,5 @@ Linking:
 {{Interface/attribute}} {{Interface/attribute}}
 '@at-rule/descriptor' '@at-rule/descriptor'
 ''property/value'' ''property/value''
+<{element}>
+<{element/attribute}>

--- a/tests/link-shorthands001.html
+++ b/tests/link-shorthands001.html
@@ -97,7 +97,9 @@
 <dfn class="idl-code" data-dfn-for="Interface" data-dfn-type="method" data-export="" id="dom-interface-method">method()<a class="self-link" href="#dom-interface-method"></a></dfn>,
 <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-dictionary">Dictionary<a class="self-link" href="#dictdef-dictionary"></a></dfn>,
 <dfn class="idl-code" data-dfn-for="Interface" data-dfn-type="attribute" data-export="" id="interface-attr" title="ambiguous-attr">attribute for Interface<a class="self-link" href="#interface-attr"></a></dfn>,
-<dfn class="idl-code" data-dfn-for="Dictionary" data-dfn-type="dict-member" data-export="" id="dict-attr" title="ambiguous-attr">attribute for Dictionary<a class="self-link" href="#dict-attr"></a></dfn></p>
+<dfn class="idl-code" data-dfn-for="Dictionary" data-dfn-type="dict-member" data-export="" id="dict-attr" title="ambiguous-attr">attribute for Dictionary<a class="self-link" href="#dict-attr"></a></dfn>
+<dfn data-dfn-type="element" data-export="" id="elementdef-element">element<a class="self-link" href="#elementdef-element"></a></dfn>
+<dfn data-dfn-for="element" data-dfn-type="element-attr" data-export="" id="element-attrdef-element-attribute">attribute<a class="self-link" href="#element-attrdef-element-attribute"></a></dfn></p>
 
 
       <p>Linking:
@@ -140,6 +142,8 @@
 <code class="idl"><a data-link-for="Interface" data-link-type="idl" href="#dom-interface-attribute">attribute</a></code> <code class="idl"><a data-link-for="Interface" data-link-type="idl" href="#dom-interface-attribute">attribute</a></code>
 <a class="property" data-link-for="@at-rule" data-link-type="propdesc" href="#descdef-at-rule-descriptor">descriptor</a> <a class="property" data-link-for="@at-rule" data-link-type="propdesc" href="#descdef-at-rule-descriptor">descriptor</a>
 <a class="css" data-link-for="property" data-link-type="maybe" href="#property-value">value</a> <a class="css" data-link-for="property" data-link-type="maybe" href="#property-value">value</a></p>
+<code><a data-link-type="element" href="#elementdef-element">element</a></code>
+<code><a data-link-for="element" data-link-type="element-attr" href="#element-attrdef-element-attribute">attribute</a></code>
 
 </main>
 
@@ -155,12 +159,18 @@
         </ul>
       </li>
       <li>@at-rule, <a href="#at-ruledef-at-rule" title="section 1">1</a></li>
-      <li>attribute, <a href="#dom-interface-attribute" title="section 1">1</a></li>
+      <li>attribute
+        <ul>
+          <li>attribute for Interface, <a href="#dom-interface-attribute" title="section 1">1</a></li>
+          <li>element-attr for element, <a href="#element-attrdef-element-attribute" title="section 1">1</a></li>
+        </ul>
+      </li>
       <li>!bang, <a href="#valdef-property-bang" title="section 1">1</a></li>
       <li>descriptor, <a href="#descdef-at-rule-descriptor" title="section 1">1</a></li>
       <li>Dictionary, <a href="#dictdef-dictionary" title="section 1">1</a></li>
       <li>different-value, <a href="#valdef-property-different-value" title="section 1">1</a></li>
       <li>!!double-bang, <a href="#valdef-property-double-bang" title="section 1">1</a></li>
+      <li>element, <a href="#elementdef-element" title="section 1">1</a></li>
       <li>function(), <a href="#funcdef-function" title="section 1">1</a></li>
       <li>Interface, <a href="#interface" title="section 1">1</a></li>
       <li>method(), <a href="#dom-interface-method" title="section 1">1</a></li>


### PR DESCRIPTION
This patch adds the fairly lame double-parens shortcut for elements and
element attributes. That is `((element))` will produce a link to the
element named 'element', and `((element/attribute))` will produce a link
to the attribute 'attribute' for the element 'element'.

Closes #323.