### PR TITLE
<{.../...}> syntax ought to support all valid attribute/element characters.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1502,7 +1502,7 @@ class CSSSpec(object):
             return E.code({"class":"idl"},
                 E.a({"data-link-type":linkType, "for": match.group(1)}, match.group(2)))
 
-        elementRe = re.compile(r"<{(?:([^ \"'>/=]+)/)?([^ \"'>/=]+)}>")
+        elementRe = re.compile(r"<{(?:([\w-]+)/)?([\w-]+)}>")
         def elementReplacer(match):
             linkType = "element" if match.group(1) is None else "element-attr"
             return E.code({},

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1502,7 +1502,7 @@ class CSSSpec(object):
             return E.code({"class":"idl"},
                 E.a({"data-link-type":linkType, "for": match.group(1)}, match.group(2)))
 
-        elementRe = re.compile(r"<{(?:(\w+)/)?(\w+)}>")
+        elementRe = re.compile(r"<{(?:([^ \"'>/=]+)/)?([^ \"'>/=]+)}>")
         def elementReplacer(match):
             linkType = "element" if match.group(1) is None else "element-attr"
             return E.code({},

--- a/tests/link-shorthands001.bs
+++ b/tests/link-shorthands001.bs
@@ -41,6 +41,8 @@ Setting up the definitions:
 <dfn dict-member for="Dictionary" title="ambiguous-attr" id='dict-attr'>attribute for Dictionary</dfn>
 <dfn element>element</dfn>
 <dfn element-attr for="element">attribute</dfn>
+<dfn element>elements-can-have-dashes-too</dfn>
+<dfn element-attr for="element">attribute-with-dashes-because-attributes-can-have-dashes</dfn>
 
 Linking:
 'property'
@@ -84,3 +86,6 @@ Linking:
 ''property/value'' ''property/value''
 <{element}>
 <{element/attribute}>
+<{element/attribute-with-dashes-because-attributes-can-have-dashes}>
+<{elements-can-have-dashes-too}>
+

--- a/tests/link-shorthands001.html
+++ b/tests/link-shorthands001.html
@@ -98,7 +98,9 @@
 <dfn class="idl-code" data-dfn-for="Interface" data-dfn-type="attribute" data-export="" id="interface-attr" title="ambiguous-attr">attribute for Interface<a class="self-link" href="#interface-attr"></a></dfn>,
 <dfn class="idl-code" data-dfn-for="Dictionary" data-dfn-type="dict-member" data-export="" id="dict-attr" title="ambiguous-attr">attribute for Dictionary<a class="self-link" href="#dict-attr"></a></dfn>
 <dfn data-dfn-type="element" data-export="" id="elementdef-element">element<a class="self-link" href="#elementdef-element"></a></dfn>
-<dfn data-dfn-for="element" data-dfn-type="element-attr" data-export="" id="element-attrdef-element-attribute">attribute<a class="self-link" href="#element-attrdef-element-attribute"></a></dfn></p>
+<dfn data-dfn-for="element" data-dfn-type="element-attr" data-export="" id="element-attrdef-element-attribute">attribute<a class="self-link" href="#element-attrdef-element-attribute"></a></dfn>
+<dfn data-dfn-type="element" data-export="" id="elementdef-elements-can-have-dashes-too">elements-can-have-dashes-too<a class="self-link" href="#elementdef-elements-can-have-dashes-too"></a></dfn>
+<dfn data-dfn-for="element" data-dfn-type="element-attr" data-export="" id="element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">attribute-with-dashes-because-attributes-can-have-dashes<a class="self-link" href="#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes"></a></dfn></p>
 
 
    <p>Linking:
@@ -142,7 +144,10 @@
 <a class="property" data-link-type="propdesc" href="#descdef-at-rule-descriptor">descriptor</a> <a class="property" data-link-type="propdesc" href="#descdef-at-rule-descriptor">descriptor</a>
 <a class="css" data-link-type="maybe" href="#property-value">value</a> <a class="css" data-link-type="maybe" href="#property-value">value</a>
 <code><a data-link-type="element" href="#elementdef-element">element</a></code>
-<code><a data-link-type="element-attr" href="#element-attrdef-element-attribute">attribute</a></code></p>
+<code><a data-link-type="element-attr" href="#element-attrdef-element-attribute">attribute</a></code>
+<code><a data-link-type="element-attr" href="#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">attribute-with-dashes-because-attributes-can-have-dashes</a></code>
+<code><a data-link-type="element" href="#elementdef-elements-can-have-dashes-too">elements-can-have-dashes-too</a></code></p>
+
 
 </main>
 
@@ -162,12 +167,14 @@
      <li>attribute for Interface, <a href="#dom-interface-attribute">1</a>
      <li>element-attr for element, <a href="#element-attrdef-element-attribute">1</a>
     </ul>
+   <li>attribute-with-dashes-because-attributes-can-have-dashes, <a href="#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">1</a>
    <li>!bang, <a href="#valdef-property-bang">1</a>
    <li>descriptor, <a href="#descdef-at-rule-descriptor">1</a>
    <li>Dictionary, <a href="#dictdef-dictionary">1</a>
    <li>different-value, <a href="#valdef-property-different-value">1</a>
    <li>!!double-bang, <a href="#valdef-property-double-bang">1</a>
    <li>element, <a href="#elementdef-element">1</a>
+   <li>elements-can-have-dashes-too, <a href="#elementdef-elements-can-have-dashes-too">1</a>
    <li>function(), <a href="#funcdef-function">1</a>
    <li>Interface, <a href="#interface">1</a>
    <li>method(), <a href="#dom-interface-method">1</a>


### PR DESCRIPTION
Attribute can contain '-', for example. Who knew?