### PR TITLE
Fix dashes inside links defined in datablocks.

### DIFF
--- a/bikeshed/datablocks.py
+++ b/bikeshed/datablocks.py
@@ -345,7 +345,7 @@ def transformAnchors(lines, doc, **kwargs):
         if "url" in anchor:
             urlSuffix = anchor['url'][0]
         else:
-            urlSuffix = config.simplifyText(anchor['text'][0])
+            urlSuffix = config.simplifyText(anchor['text'][0], convertDashes=anchor['type'][0] == "dfn")
         url = urlPrefix + ("" if "#" in urlPrefix or "#" in urlSuffix else "#") + urlSuffix
         if anchor['type'][0] in config.lowercaseTypes:
             anchor['text'][0] = anchor['text'][0].lower()

--- a/tests/links003.bs
+++ b/tests/links003.bs
@@ -1,0 +1,33 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: Testing that "link-with-dashes" is not the same as "link with dashes".
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+<dfn>link with dashes</dfn>
+<dfn>link-with-dashes</dfn>
+<dfn property>property-with-dashes</dfn>
+
+<a>link with dashes</a>
+<a>link-with-dashes</a>
+<a property>property-with-dashes</a>
+
+<pre class="anchors">
+urlPrefix: https://example.com/spec/
+    type: dfn
+        text: anchor with dashes
+        text: anchor-with-dashes
+    type: property
+        text: anchor-property-with-dashes
+</pre>
+
+<a>anchor with dashes</a>
+<a>anchor-with-dashes</a>
+<a property>anchor-property-with-dashes</a>

--- a/tests/links003.html
+++ b/tests/links003.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+ <head>
+  
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  
+  
+  <title>Foo</title>
+  
+
+  <meta content="1.0.0" name="bikeshed-semver">
+ </head>
+ 
+
+ <body class="h-entry">
+
+  <div class="head">
+  
+   <p data-fill-with="logo"></p>
+  
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+  
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
+    <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+  
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor">
+      <div class="p-author h-card vcard"><span class="p-name fn">Example Editor</span></div>
+    </dl>
+   </div>
+  
+   <div data-fill-with="warning"></div>
+  
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE
+</p>
+  
+   <hr title="Separator for header">
+</div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Testing that "link-with-dashes" is not the same as "link with dashes".</p>
+
+</div>
+
+  <div data-fill-with="at-risk"></div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+    <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+   </ul></div>
+
+  <main>
+
+
+
+
+
+   <p><dfn data-dfn-type="dfn" data-noexport="" id="link-with-dashes">link with dashes<a class="self-link" href="#link-with-dashes"></a></dfn>
+<dfn data-dfn-type="dfn" data-noexport="" id="link_with_dashes">link-with-dashes<a class="self-link" href="#link_with_dashes"></a></dfn>
+<dfn class="css" data-dfn-type="property" data-export="" id="propdef-property-with-dashes">property-with-dashes<a class="self-link" href="#propdef-property-with-dashes"></a></dfn></p>
+
+
+   <p><a data-link-type="dfn" href="#link-with-dashes">link with dashes</a>
+<a data-link-type="dfn" href="#link_with_dashes">link-with-dashes</a>
+<a class="css" data-link-type="property" href="#propdef-property-with-dashes">property-with-dashes</a></p>
+
+
+
+
+   <p><a data-link-type="dfn" href="https://example.com/spec/#anchor-with-dashes">anchor with dashes</a>
+<a data-link-type="dfn" href="https://example.com/spec/#anchor_with_dashes">anchor-with-dashes</a>
+<a class="css" data-link-type="property" href="https://example.com/spec/#anchor-property-with-dashes">anchor-property-with-dashes</a></p>
+
+</main>
+
+
+
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
+  <ul class="indexlist">
+   <li>link with dashes, <a href="#link-with-dashes">Unnumbered section</a>
+   <li>link-with-dashes, <a href="#link_with_dashes">Unnumbered section</a>
+   <li>property-with-dashes, <a href="#propdef-property-with-dashes">Unnumbered section</a></ul></body>
+</html>


### PR DESCRIPTION
Applies the fix from tabatkins/bikeshed@d8997b51d62569b862231888125e18f5bb12a5b8
to links generated from datablocks.

Closes #343.