### PR TITLE
Add external references to the Index.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1842,7 +1842,7 @@ def addIndexOfExternallyDefinedTerms(doc, container):
             ref = doc.externalRefsUsed[spec][title]
             attrs = {"data-link-type": ref.type}
             if len(ref.for_):
-                attrs['for'] = ref.for_[0]
+                attrs['data-link-for'] = ref.for_[0]
             appendChild(termsUl, E.li(E.a(attrs, title)))
         appendChild(specLi, termsUl)
         appendChild(ul, specLi)

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -758,15 +758,13 @@ def processAutolinks(doc):
         # those defined in `<pre class="anchor">` datablocks, which we do
         # want to capture here.
         if ref and ref.spec is not None and ref.spec is not "" and ref.spec != doc.refs.specVName:
-            if ref.spec not in doc.externalRefsUsed:
-                doc.externalRefsUsed[ref.spec] = {}
             if ref.text not in doc.externalRefsUsed[ref.spec]:
                 doc.externalRefsUsed[ref.spec][ref.text] = ref
             biblioRef = doc.refs.getBiblioRef(ref.spec, status="normative")
             if biblioRef:
                 doc.normativeRefs[biblioRef.linkText] = biblioRef
 
-        if ref.url is not None:
+        if ref:
             el.set('href', ref.url)
             el.tag = "a"
         else:
@@ -945,7 +943,7 @@ def processIDL(doc):
                                       linkFor=el.get('data-idl-for'),
                                       el=el,
                                       error=False)
-                if ref.url:
+                if ref:
                     url = ref.url
                     break;
             globalNames = GlobalNames.fromEl(el)
@@ -1153,7 +1151,7 @@ class CSSSpec(object):
         self.normativeRefs = {}
         self.informativeRefs = {}
         self.refs = ReferenceManager()
-        self.externalRefsUsed = {}
+        self.externalRefsUsed = defaultdict(dict)
         self.md = metadata.MetadataManager(doc=self)
         self.biblios = {}
         self.paragraphMode = "markdown"

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1833,21 +1833,23 @@ def addIndexOfExternallyDefinedTerms(doc, container):
         return
 
     specs = sorted(doc.externalRefsUsed.keys())
-    dl = E.dl()
+    ul = E.ul({"class": "indexlist"})
     for spec in specs:
         attrs = {"data-lt":spec, "data-link-type":"biblio", "data-biblio-type":"normative"}
-        dt = E.dt(E.a(attrs, "[", spec, "]"), " defines the following terms:");
-        appendChild(dl, dt)
+        specLi = E.li(E.a(attrs, "[", spec, "]"), " defines the following terms:")
+        termsUl = E.ul()
         for title in sorted(doc.externalRefsUsed[spec].keys()):
             ref = doc.externalRefsUsed[spec][title]
             attrs = {"data-link-type": ref.type}
             if len(ref.for_):
                 attrs['for'] = ref.for_[0]
-            appendChild(dl, E.dd(E.a(attrs, title)))
+            appendChild(termsUl, E.li(E.a(attrs, title)))
+        appendChild(specLi, termsUl)
+        appendChild(ul, specLi)
 
     appendChild(container,
         E.h3({"class":"no-num", "id":"index-defined-elsewhere"}, "Terms defined by reference"))
-    appendChild(container, dl)
+    appendChild(container, ul)
 
 
 def addPropertyIndex(doc):

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -729,10 +729,11 @@ def processBiblioLinks(doc):
 def processAutolinks(doc):
     # An <a> without an href is an autolink.
     # <i> is a legacy syntax for term autolinks. If it links up, we change it into an <a>.
+    # We exclude bibliographical links, as those are processed in `processBiblioLinks`.
+    query = "a:not([href]):not([data-link-type='biblio'])"
     if doc.md.useIAutolinks:
-        autolinks = findAll("a:not([href]), i", doc)
-    else:
-        autolinks = findAll("a:not([href])", doc)
+        query += ", i"
+    autolinks = findAll(query, doc)
     for el in autolinks:
         # Explicitly empty linking text indicates this shouldn't be an autolink.
         if el.get('data-lt') == '':
@@ -1250,11 +1251,11 @@ class CSSSpec(object):
         processIDL(self)
         fillAttributeInfoSpans(self)
         formatElementdefTables(self)
-        processBiblioLinks(self)
         processAutolinks(self)
-
-        addReferencesSection(self)
         addIndexSection(self)
+
+        processBiblioLinks(self)
+        addReferencesSection(self)
         addPropertyIndex(self)
         addIDLSection(self)
         addIssuesSection(self)
@@ -1262,7 +1263,6 @@ class CSSSpec(object):
         processHeadings(self, "all") # again
         addTOCSection(self)
         addSelfLinks(self)
-        processBiblioLinks(self) # again, as biblio links could be added by addIndexSection().
         processAutolinks(self)
         addAnnotations(self)
         addSyntaxHighlighting(self)

--- a/bikeshed/datablocks.py
+++ b/bikeshed/datablocks.py
@@ -356,7 +356,8 @@ def processAnchors(anchors, doc):
             "url": url,
             "for": anchor.get('for', []),
             "export": True,
-            "status": "local"
+            "status": "local",
+            "spec": anchor.get('spec', [''])[0]
             })
     return []
 

--- a/docs/definitions-autolinks.md
+++ b/docs/definitions-autolinks.md
@@ -166,6 +166,7 @@ with the following keys:
 * **type** - the definition's type (dfn, interface, etc)  (Exactly 1 required.)
 * **urlPrefix** and/or **url** - define the anchor's url, as described below.  (At least one of `urlPrefix` or `url` must be specified. 0+ `urlPrefix` entries allowed, 0 or 1 `url` entries allowed.)
 * **for** - what the definition is for.  (Any number allowed, including 0.)
+* **spec** - Which spec the definition comes from. (optional)
 
 To generate the url for the anchor,
 first all of the `urlPrefix` entries are concatenated.
@@ -176,11 +177,13 @@ otherwise, the `text` is url-ified and appended.
 If neither `urlPrefix` nor `url` had a "#" character in them,
 one is inserted between them.
 
+The `spec` attribute is used only for index generation, and has no effect on URL generation.
+
 Example:
 
 ```html
 <pre class="anchors">
-urlPrefix: https://encoding.spec.whatwg.org/; type: dfn
+urlPrefix: https://encoding.spec.whatwg.org/; type: dfn; spec: ENCODING
   text: ascii whitespace
   text: decoder
 url: http://www.unicode.org/reports/tr46/#ToASCII; type: dfn; text: toascii

--- a/tests/index001.html
+++ b/tests/index001.html
@@ -57,6 +57,9 @@
    <ul class="toc" role="directory">
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ul>
    </ul></div>
 
   <main>
@@ -101,6 +104,7 @@
 
   <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="indexlist">
    <li>ArgumenT, <a href="#dom-method-argument">Unnumbered section</a>
    <li>At-rulE, <a href="#at-ruledef-at-rule">Unnumbered section</a>

--- a/tests/index001.html
+++ b/tests/index001.html
@@ -55,11 +55,11 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
      </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul></div>
 
   <main>
@@ -102,7 +102,6 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="indexlist">
@@ -134,5 +133,6 @@
    <li>StringifieR, <a href="#stringifier">Unnumbered section</a>
    <li>TypE, <a href="#typedef-type">Unnumbered section</a>
    <li>TypedeF, <a href="#typedefdef-typedef">Unnumbered section</a>
-   <li>ValuE, <a href="#valdef-property-value">Unnumbered section</a></ul></body>
+   <li>ValuE, <a href="#valdef-property-value">Unnumbered section</a></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2></body>
 </html>

--- a/tests/index002.bs
+++ b/tests/index002.bs
@@ -1,0 +1,16 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: Indexing external references
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+<a>flex container</a>
+<{iframe}>
+

--- a/tests/index002.bs
+++ b/tests/index002.bs
@@ -12,5 +12,5 @@ Date: 1970-01-01
 </pre>
 
 <a>flex container</a>
-<{iframe}>
+'will-change'
 

--- a/tests/index002.html
+++ b/tests/index002.html
@@ -88,9 +88,13 @@
    <dd>Robin Berjon; et al. <a href="http://www.w3.org/html/wg/drafts/html/master/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/html/wg/drafts/html/master/">http://www.w3.org/html/wg/drafts/html/master/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
-  <dl>
-   <dt><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
-   <dd><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
-   <dt><a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
-   <dd><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></dl></body>
+  <ul class="indexlist">
+   <li><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
+    <ul>
+     <li><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
+    </ul>
+   <li><a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
+    <ul>
+     <li><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a>
+    </ul></ul></body>
 </html>

--- a/tests/index002.html
+++ b/tests/index002.html
@@ -55,13 +55,13 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
-      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
-     </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
      </ul>
    </ul></div>
 
@@ -79,13 +79,6 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
-  <dl>
-   <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
-   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://dev.w3.org/csswg/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://dev.w3.org/csswg/css-flexbox/">http://dev.w3.org/csswg/css-flexbox/</a>
-   <dt id="biblio-css-will-change-1"><a class="self-link" href="#biblio-css-will-change-1"></a>[css-will-change-1]
-   <dd>Tab Atkins Jr.. <a href="http://dev.w3.org/csswg/css-will-change/">CSS Will Change Module Level 1</a>. 29 April 2014. WD. URL: <a href="http://dev.w3.org/csswg/css-will-change/">http://dev.w3.org/csswg/css-will-change/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
   <ul class="indexlist">
@@ -96,5 +89,12 @@
    <li><a data-link-type="biblio" href="#biblio-css-will-change-1">[css-will-change-1]</a> defines the following terms:
     <ul>
      <li><a class="css" data-link-type="property" href="http://dev.w3.org/csswg/css-will-change-1/#propdef-will-change">will-change</a>
-    </ul></ul></body>
+    </ul></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
+  <dl>
+   <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
+   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://www.w3.org/TR/css-flexbox-1/">http://www.w3.org/TR/css-flexbox-1/</a>
+   <dt id="biblio-css-will-change-1"><a class="self-link" href="#biblio-css-will-change-1"></a>[css-will-change-1]
+   <dd>Tab Atkins Jr.. <a href="http://www.w3.org/TR/css-will-change-1/">CSS Will Change Module Level 1</a>. 29 April 2014. WD. URL: <a href="http://www.w3.org/TR/css-will-change-1/">http://www.w3.org/TR/css-will-change-1/</a></dl></body>
 </html>

--- a/tests/index002.html
+++ b/tests/index002.html
@@ -72,7 +72,7 @@
 
 
    <p><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
-<code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></code></p>
+<a class="property" data-link-type="propdesc" href="http://dev.w3.org/csswg/css-will-change-1/#propdef-will-change">will-change</a></p>
 
 
 </main>
@@ -84,8 +84,8 @@
   <dl>
    <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
    <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://dev.w3.org/csswg/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://dev.w3.org/csswg/css-flexbox/">http://dev.w3.org/csswg/css-flexbox/</a>
-   <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[html5]
-   <dd>Robin Berjon; et al. <a href="http://www.w3.org/html/wg/drafts/html/master/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/html/wg/drafts/html/master/">http://www.w3.org/html/wg/drafts/html/master/</a></dl>
+   <dt id="biblio-css-will-change-1"><a class="self-link" href="#biblio-css-will-change-1"></a>[css-will-change-1]
+   <dd>Tab Atkins Jr.. <a href="http://dev.w3.org/csswg/css-will-change/">CSS Will Change Module Level 1</a>. 29 April 2014. WD. URL: <a href="http://dev.w3.org/csswg/css-will-change/">http://dev.w3.org/csswg/css-will-change/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
   <ul class="indexlist">
@@ -93,8 +93,8 @@
     <ul>
      <li><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
     </ul>
-   <li><a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
+   <li><a data-link-type="biblio" href="#biblio-css-will-change-1">[css-will-change-1]</a> defines the following terms:
     <ul>
-     <li><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a>
+     <li><a class="css" data-link-type="property" href="http://dev.w3.org/csswg/css-will-change-1/#propdef-will-change">will-change</a>
     </ul></ul></body>
 </html>

--- a/tests/index002.html
+++ b/tests/index002.html
@@ -44,7 +44,7 @@
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
 
   <div class="p-summary" data-fill-with="abstract">
-   <p>Testing interaction of local and foreign links.</p>
+   <p>Indexing external references</p>
 
 </div>
 
@@ -61,7 +61,6 @@
      </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
-      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ul>
    </ul></div>
@@ -72,10 +71,9 @@
 
 
 
-   <p><dfn class="css" data-dfn-type="property" data-export="" id="propdef-flex-container">flex container<a class="self-link" href="#propdef-flex-container"></a></dfn></p>
+   <p><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
+<code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></code></p>
 
-
-   <p><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a></p>
 
 </main>
 
@@ -85,13 +83,14 @@
   <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
   <dl>
    <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
-   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://dev.w3.org/csswg/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://dev.w3.org/csswg/css-flexbox/">http://dev.w3.org/csswg/css-flexbox/</a></dl>
+   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://dev.w3.org/csswg/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://dev.w3.org/csswg/css-flexbox/">http://dev.w3.org/csswg/css-flexbox/</a>
+   <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[html5]
+   <dd>Robin Berjon; et al. <a href="http://www.w3.org/html/wg/drafts/html/master/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/html/wg/drafts/html/master/">http://www.w3.org/html/wg/drafts/html/master/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
-  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
-  <ul class="indexlist">
-   <li>flex container, <a href="#propdef-flex-container">Unnumbered section</a></ul>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
   <dl>
    <dt><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
-   <dd><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a></dl></body>
+   <dd><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
+   <dt><a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
+   <dd><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></dl></body>
 </html>

--- a/tests/index003.bs
+++ b/tests/index003.bs
@@ -1,0 +1,32 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: Indexing external references defined in local datablocks.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+<pre class="biblio">
+{
+    "EXAMPLE-SPEC": {
+        "authors": [ "bar", "baz" ],
+        "href": "https://example.test/foo/",
+        "title": "Foo Level 1",
+        "status": "REC",
+        "publisher": "W3C"
+    }
+}
+</pre>
+
+<pre class="anchors">
+urlPrefix: https://example.test/foo/; spec: EXAMPLE-SPEC
+    type: dfn
+        text: term
+</pre>
+
+<a>term</a>

--- a/tests/index003.html
+++ b/tests/index003.html
@@ -5,7 +5,7 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   
   
-  <title>Section Links With Weird HTML</title>
+  <title>Foo</title>
   
 
   <meta content="Bikeshed 1.0.0" name="generator">
@@ -18,7 +18,7 @@
   
    <p data-fill-with="logo"></p>
   
-   <h1 class="p-name no-ref" id="title">Section Links With Weird HTML</h1>
+   <h1 class="p-name no-ref" id="title">Foo</h1>
   
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
     <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
@@ -44,7 +44,7 @@
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
 
   <div class="p-summary" data-fill-with="abstract">
-   <p>Section links are awesome.</p>
+   <p>Indexing external references defined in local datablocks.</p>
 
 </div>
 
@@ -55,12 +55,13 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#a"><span class="secno">1</span> <span class="content">Section <span>dfn</span></span></a>
-    <li><a href="#b"><span class="secno">2</span> <span class="content">Section B</span></a>
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+     </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
-      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ul>
    </ul></div>
 
@@ -70,30 +71,24 @@
 
 
 
-   <h2 class="heading settled" data-level="1" id="a"><span class="secno">1. </span><span class="content">Section <dfn data-dfn-type="dfn" data-noexport="" id="dfn">dfn<a class="self-link" href="#dfn"></a></dfn></span><a class="self-link" href="#a"></a></h2>
 
 
-   <p><a href="#b">§2 Section B</a></p>
 
 
-   <p><a href="#b">§2 Section B</a></p>
-
-
-   <h2 class="heading settled" data-level="2" id="b"><span class="secno">2. </span><span class="content">Section B</span><a class="self-link" href="#b"></a></h2>
-
-
-   <p><a href="#a">§1 Section dfn</a></p>
-
-
-   <p><a href="#a">§1 Section dfn</a></p>
+   <p><a data-link-type="dfn" href="https://example.test/foo/#term">term</a></p>
 
 </main>
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
-  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
-  <ul class="indexlist">
-   <li>dfn, <a href="#dfn">1</a></ul></body>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
+  <dl>
+   <dt id="biblio-example-spec"><a class="self-link" href="#biblio-example-spec"></a>[EXAMPLE-SPEC]
+   <dd>bar; baz. <a href="https://example.test/foo/">Foo Level 1</a>. REC. URL: <a href="https://example.test/foo/">https://example.test/foo/</a></dl>
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
+  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
+  <dl>
+   <dt><a data-link-type="biblio" href="#biblio-example-spec">[EXAMPLE-SPEC]</a> defines the following terms:
+   <dd><a data-link-type="dfn" href="https://example.test/foo/#term">term</a></dl></body>
 </html>

--- a/tests/index003.html
+++ b/tests/index003.html
@@ -55,13 +55,13 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
-      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
-     </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
      </ul>
    </ul></div>
 
@@ -81,16 +81,16 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
-  <dl>
-   <dt id="biblio-example-spec"><a class="self-link" href="#biblio-example-spec"></a>[EXAMPLE-SPEC]
-   <dd>bar; baz. <a href="https://example.test/foo/">Foo Level 1</a>. REC. URL: <a href="https://example.test/foo/">https://example.test/foo/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
   <ul class="indexlist">
    <li><a data-link-type="biblio" href="#biblio-example-spec">[EXAMPLE-SPEC]</a> defines the following terms:
     <ul>
      <li><a data-link-type="dfn" href="https://example.test/foo/#term">term</a>
-    </ul></ul></body>
+    </ul></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
+  <dl>
+   <dt id="biblio-example-spec"><a class="self-link" href="#biblio-example-spec"></a>[EXAMPLE-SPEC]
+   <dd>bar; baz. <a href="https://example.test/foo/">Foo Level 1</a>. REC. URL: <a href="https://example.test/foo/">https://example.test/foo/</a></dl></body>
 </html>

--- a/tests/index003.html
+++ b/tests/index003.html
@@ -88,7 +88,9 @@
    <dd>bar; baz. <a href="https://example.test/foo/">Foo Level 1</a>. REC. URL: <a href="https://example.test/foo/">https://example.test/foo/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
-  <dl>
-   <dt><a data-link-type="biblio" href="#biblio-example-spec">[EXAMPLE-SPEC]</a> defines the following terms:
-   <dd><a data-link-type="dfn" href="https://example.test/foo/#term">term</a></dl></body>
+  <ul class="indexlist">
+   <li><a data-link-type="biblio" href="#biblio-example-spec">[EXAMPLE-SPEC]</a> defines the following terms:
+    <ul>
+     <li><a data-link-type="dfn" href="https://example.test/foo/#term">term</a>
+    </ul></ul></body>
 </html>

--- a/tests/link-shorthands001.html
+++ b/tests/link-shorthands001.html
@@ -64,11 +64,11 @@
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
     <li><a href="#test"><span class="secno">1</span> <span class="content">Test</span></a>
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
      </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul></div>
 
   <main>
@@ -156,7 +156,6 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="indexlist">
@@ -194,5 +193,6 @@
      <li>value for @at-rule/descriptor, <a href="#descriptor-value">1</a>
      <li>value for @at-rule, <a href="#at-rule-value">1</a>
      <li>value for &lt;type>, <a href="#type-value">1</a>
-    </ul></ul></body>
+    </ul></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2></body>
 </html>

--- a/tests/link-shorthands001.html
+++ b/tests/link-shorthands001.html
@@ -66,6 +66,9 @@
     <li><a href="#test"><span class="secno">1</span> <span class="content">Test</span></a>
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ul>
    </ul></div>
 
   <main>
@@ -155,6 +158,7 @@
 
   <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="indexlist">
    <li>ambiguous-attr
     <ul>

--- a/tests/links001.html
+++ b/tests/links001.html
@@ -55,14 +55,14 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
-     <ul class="toc">
-      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
-     </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
       <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
      </ul>
    </ul></div>
 
@@ -81,11 +81,6 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
-  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
-  <dl>
-   <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
-   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://dev.w3.org/csswg/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://dev.w3.org/csswg/css-flexbox/">http://dev.w3.org/csswg/css-flexbox/</a></dl>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="indexlist">
@@ -95,5 +90,10 @@
    <li><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
     <ul>
      <li><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
-    </ul></ul></body>
+    </ul></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span></h3>
+  <dl>
+   <dt id="biblio-css-flexbox-1"><a class="self-link" href="#biblio-css-flexbox-1"></a>[css-flexbox-1]
+   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="http://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1</a>. 25 September 2014. LCWD. URL: <a href="http://www.w3.org/TR/css-flexbox-1/">http://www.w3.org/TR/css-flexbox-1/</a></dl></body>
 </html>

--- a/tests/links001.html
+++ b/tests/links001.html
@@ -91,7 +91,9 @@
   <ul class="indexlist">
    <li>flex container, <a href="#propdef-flex-container">Unnumbered section</a></ul>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span></h3>
-  <dl>
-   <dt><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
-   <dd><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a></dl></body>
+  <ul class="indexlist">
+   <li><a data-link-type="biblio" href="#biblio-css-flexbox-1">[css-flexbox-1]</a> defines the following terms:
+    <ul>
+     <li><a data-link-type="dfn" href="http://dev.w3.org/csswg/css-flexbox-1/#flex-container">flex container</a>
+    </ul></ul></body>
 </html>

--- a/tests/links003.html
+++ b/tests/links003.html
@@ -55,11 +55,11 @@
 
   <div data-fill-with="table-of-contents" role="navigation">
    <ul class="toc" role="directory">
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
      </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul></div>
 
   <main>
@@ -88,11 +88,11 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="indexlist">
    <li>link with dashes, <a href="#link-with-dashes">Unnumbered section</a>
    <li>link-with-dashes, <a href="#link_with_dashes">Unnumbered section</a>
-   <li>property-with-dashes, <a href="#propdef-property-with-dashes">Unnumbered section</a></ul></body>
+   <li>property-with-dashes, <a href="#propdef-property-with-dashes">Unnumbered section</a></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2></body>
 </html>

--- a/tests/links003.html
+++ b/tests/links003.html
@@ -57,6 +57,9 @@
    <ul class="toc" role="directory">
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ul>
    </ul></div>
 
   <main>
@@ -87,6 +90,7 @@
 
   <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="indexlist">
    <li>link with dashes, <a href="#link-with-dashes">Unnumbered section</a>
    <li>link-with-dashes, <a href="#link_with_dashes">Unnumbered section</a>

--- a/tests/section-links002.html
+++ b/tests/section-links002.html
@@ -57,11 +57,11 @@
    <ul class="toc" role="directory">
     <li><a href="#a"><span class="secno">1</span> <span class="content">Section <span>dfn</span></span></a>
     <li><a href="#b"><span class="secno">2</span> <span class="content">Section B</span></a>
-    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
      </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul></div>
 
   <main>
@@ -91,9 +91,9 @@
 
 
 
-  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="indexlist">
-   <li>dfn, <a href="#dfn">1</a></ul></body>
+   <li>dfn, <a href="#dfn">1</a></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2></body>
 </html>


### PR DESCRIPTION
This patch splits a document's index into two sections, the first
listing terms defined directly in the document, the second listing terms
defined elsewhere. The latter are grouped by specification, in the hopes
of making references clear for readers.

To do so, this patch changes `ReferenceManager::getRef` to return a
reference rather than a URL. When we process autolinks, we grab the
relevant references, and store them in a new `externalRefsUsed` property
on the `CSSSpec` object itself. In `addIndexSection`, we then walk
through the external references in order to build up a list of
definitions.

This is a first pass at tabatkins/bikeshed#361. There will be followups.