### PR TITLE
Add external issue tracker links to issues.

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -56,6 +56,7 @@ class MetadataManager:
         self.markupShorthands = set(["css", "biblio", "markup", "idl"])
         self.customTextMacros = []
         self.issues = []
+        self.issueTrackerTemplate = None
 
         self.otherMetadata = defaultdict(list)
 
@@ -86,7 +87,8 @@ class MetadataManager:
             "Indent": "indent",
             "Use <I> Autolinks": "useIAutolinks",
             "No Editor": "noEditor",
-            "Default Biblio Status": "defaultBiblioStatus"
+            "Default Biblio Status": "defaultBiblioStatus",
+            "Issue Tracker Template": "issueTrackerTemplate"
         }
 
         # Some keys are multi-value:

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -803,8 +803,13 @@ def processIssues(doc):
         remoteIssueID = el.get('data-remote-issue-id')
         if remoteIssueID:
             del el.attrib['data-remote-issue-id']
-            if doc.md.issueTrackerTemplate:
+            githubMatch = re.match(r"([^/]+)/([^#]+)#(\d+)", remoteIssueID)
+            remoteIssueURL = None
+            if githubMatch:
+                remoteIssueURL = "https://github.com/{0}/{1}/issues/{2}".format(githubMatch.group(1), githubMatch.group(2), githubMatch.group(3))
+            elif doc.md.issueTrackerTemplate:
                 remoteIssueURL = doc.md.issueTrackerTemplate.format(remoteIssueID)
+            if remoteIssueURL:
                 appendChild(el, " ", E.a({"href": remoteIssueURL }, "<" + remoteIssueURL + ">"))
     dedupIds(doc, findAll(".issue", doc))
 

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -803,7 +803,7 @@ def processIssues(doc):
         remoteIssueID = el.get('data-remote-issue-id')
         if remoteIssueID:
             del el.attrib['data-remote-issue-id']
-            githubMatch = re.match(r"([^/]+)/([^#]+)#(\d+)", remoteIssueID)
+            githubMatch = re.match(r"\s*([\w\-_]+)/([^\w\-_]+)#(\d+)\s*$", remoteIssueID)
             remoteIssueURL = None
             if githubMatch:
                 remoteIssueURL = "https://github.com/{0}/{1}/issues/{2}".format(githubMatch.group(1), githubMatch.group(2), githubMatch.group(3))

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -803,7 +803,7 @@ def processIssues(doc):
         remoteIssueID = el.get('data-remote-issue-id')
         if remoteIssueID:
             del el.attrib['data-remote-issue-id']
-            githubMatch = re.match(r"\s*([\w\-_]+)/([^\w\-_]+)#(\d+)\s*$", remoteIssueID)
+            githubMatch = re.match(r"\s*([\w-]+)/([\w-]+)#(\d+)\s*$", remoteIssueID)
             remoteIssueURL = None
             if githubMatch:
                 remoteIssueURL = "https://github.com/{0}/{1}/issues/{2}".format(githubMatch.group(1), githubMatch.group(2), githubMatch.group(3))

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -796,9 +796,16 @@ decorateAutolink.cache = {}
 
 def processIssues(doc):
     import hashlib
-    # Add an auto-genned and stable-against-changes-elsewhere id to all issues.
+    # Add an auto-genned and stable-against-changes-elsewhere id to all issues, and
+    # link to remote issues if possible:
     for el in findAll(".issue:not([id])", doc):
         el.set('id', "issue-"+hashContents(el))
+        remoteIssueID = el.get('data-remote-issue-id')
+        if remoteIssueID:
+            del el.attrib['data-remote-issue-id']
+            if doc.md.issueTrackerTemplate:
+                remoteIssueURL = doc.md.issueTrackerTemplate % remoteIssueID
+                appendChild(el, " ", E.a({"href": remoteIssueURL }, "<" + remoteIssueURL + ">"))
     dedupIds(doc, findAll(".issue", doc))
 
 

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -804,7 +804,7 @@ def processIssues(doc):
         if remoteIssueID:
             del el.attrib['data-remote-issue-id']
             if doc.md.issueTrackerTemplate:
-                remoteIssueURL = doc.md.issueTrackerTemplate % remoteIssueID
+                remoteIssueURL = doc.md.issueTrackerTemplate.format(remoteIssueID)
                 appendChild(el, " ", E.a({"href": remoteIssueURL }, "<" + remoteIssueURL + ">"))
     dedupIds(doc, findAll(".issue", doc))
 

--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -222,7 +222,12 @@ def parseParagraph(stream):
 		p = "<strong class='advisement'>"
 		endTag = "</strong>"
 	else:
-		p = "<p>"
+		match = re.match(r"issue\(([^)]+)\): (.+)", line, re.I)
+		if match:
+			line = match.group(2)
+                        p = "<p data-remote-issue-id='%s' class='issue'>" % match.group(1)
+                else:
+			p = "<p>"
 	lines = ["{0}{1}\n".format(p, line)]
 	while True:
 		stream.advance()

--- a/tests/notes-issues001.bs
+++ b/tests/notes-issues001.bs
@@ -10,6 +10,7 @@ Abstract: Index entries should be the original casing, even though dfns are matc
 Abstract: Notes and issues should be generated correctly.
 Editor: Example Editor
 Date: 1970-01-01
+Issue Tracker Template: https://issue-tracker.test/issue-%s
 </pre>
 
 Note: This is a note.
@@ -23,3 +24,5 @@ NOTE, notes! Though I don't like this syntax, it's easy.
 Issue: This is an issue.
 
 ISSUE: THIS IS AN ISSUE OMG!!!!11!!!1!
+
+ISSUE(123): This is an issue, linked via the template in the metadata.

--- a/tests/notes-issues001.bs
+++ b/tests/notes-issues001.bs
@@ -26,3 +26,5 @@ Issue: This is an issue.
 ISSUE: THIS IS AN ISSUE OMG!!!!11!!!1!
 
 ISSUE(123): This is an issue, linked via the template in the metadata.
+
+ISSUE(tabatkins/bikeshed#1): This is an issue, linked to GitHub via the magic of regular expressions.

--- a/tests/notes-issues001.bs
+++ b/tests/notes-issues001.bs
@@ -10,7 +10,7 @@ Abstract: Index entries should be the original casing, even though dfns are matc
 Abstract: Notes and issues should be generated correctly.
 Editor: Example Editor
 Date: 1970-01-01
-Issue Tracker Template: https://issue-tracker.test/issue-%s
+Issue Tracker Template: https://issue-tracker.test/issue-{0}
 </pre>
 
 Note: This is a note.

--- a/tests/notes-issues001.bs
+++ b/tests/notes-issues001.bs
@@ -28,3 +28,9 @@ ISSUE: THIS IS AN ISSUE OMG!!!!11!!!1!
 ISSUE(123): This is an issue, linked via the template in the metadata.
 
 ISSUE(tabatkins/bikeshed#1): This is an issue, linked to GitHub via the magic of regular expressions.
+
+ISSUE(  tabatkins/bikeshed#2  ): This is an issue, linked to GitHub via the magic of regular expressions as well!
+
+ISSUE(  ta-bat_kins/bikesh123ed#1 ): This is an issue, linked to GitHub via the magic of regular expressions and this one too!
+
+ISSUE(Hahaha, this/looks like a github url#123456789 but it's not surprise sucka!): This is not a GitHub issue.

--- a/tests/notes-issues001.html
+++ b/tests/notes-issues001.html
@@ -89,6 +89,9 @@ Notes and issues should be generated correctly.</p>
 
    <p class="issue" id="issue-290cde08"><a class="self-link" href="#issue-290cde08"></a>This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a></p>
 
+
+   <p class="issue" id="issue-cfb7f5c7"><a class="self-link" href="#issue-cfb7f5c7"></a>This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a></p>
+
 </main>
 
 
@@ -98,5 +101,6 @@ Notes and issues should be generated correctly.</p>
   <div style="counter-reset:issue">
    <div class="issue">This is an issue.<a href="#issue-05237a4c"> ↵ </a></div>
    <div class="issue">THIS IS AN ISSUE OMG!!!!11!!!1!<a href="#issue-7004b3b3"> ↵ </a></div>
-   <div class="issue">This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a><a href="#issue-290cde08"> ↵ </a></div></div></body>
+   <div class="issue">This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a><a href="#issue-290cde08"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a><a href="#issue-cfb7f5c7"> ↵ </a></div></div></body>
 </html>

--- a/tests/notes-issues001.html
+++ b/tests/notes-issues001.html
@@ -90,7 +90,16 @@ Notes and issues should be generated correctly.</p>
    <p class="issue" id="issue-290cde08"><a class="self-link" href="#issue-290cde08"></a>This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a></p>
 
 
-   <p class="issue" id="issue-cfb7f5c7"><a class="self-link" href="#issue-cfb7f5c7"></a>This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a></p>
+   <p class="issue" id="issue-cfb7f5c7"><a class="self-link" href="#issue-cfb7f5c7"></a>This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://issue-tracker.test/issue-tabatkins/bikeshed#1">&lt;https://issue-tracker.test/issue-tabatkins/bikeshed#1></a></p>
+
+
+   <p class="issue" id="issue-302c2cef"><a class="self-link" href="#issue-302c2cef"></a>This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ">&lt;https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ></a></p>
+
+
+   <p class="issue" id="issue-361a85f0"><a class="self-link" href="#issue-361a85f0"></a>This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ">&lt;https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ></a></p>
+
+
+   <p class="issue" id="issue-6aec6caa"><a class="self-link" href="#issue-6aec6caa"></a>This is not a GitHub issue. <a href="https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!">&lt;https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!></a></p>
 
 </main>
 
@@ -102,5 +111,8 @@ Notes and issues should be generated correctly.</p>
    <div class="issue">This is an issue.<a href="#issue-05237a4c"> ↵ </a></div>
    <div class="issue">THIS IS AN ISSUE OMG!!!!11!!!1!<a href="#issue-7004b3b3"> ↵ </a></div>
    <div class="issue">This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a><a href="#issue-290cde08"> ↵ </a></div>
-   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a><a href="#issue-cfb7f5c7"> ↵ </a></div></div></body>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://issue-tracker.test/issue-tabatkins/bikeshed#1">&lt;https://issue-tracker.test/issue-tabatkins/bikeshed#1></a><a href="#issue-cfb7f5c7"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ">&lt;https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ></a><a href="#issue-302c2cef"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ">&lt;https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ></a><a href="#issue-361a85f0"> ↵ </a></div>
+   <div class="issue">This is not a GitHub issue. <a href="https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!">&lt;https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!></a><a href="#issue-6aec6caa"> ↵ </a></div></div></body>
 </html>

--- a/tests/notes-issues001.html
+++ b/tests/notes-issues001.html
@@ -90,13 +90,13 @@ Notes and issues should be generated correctly.</p>
    <p class="issue" id="issue-290cde08"><a class="self-link" href="#issue-290cde08"></a>This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a></p>
 
 
-   <p class="issue" id="issue-cfb7f5c7"><a class="self-link" href="#issue-cfb7f5c7"></a>This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://issue-tracker.test/issue-tabatkins/bikeshed#1">&lt;https://issue-tracker.test/issue-tabatkins/bikeshed#1></a></p>
+   <p class="issue" id="issue-cfb7f5c7"><a class="self-link" href="#issue-cfb7f5c7"></a>This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a></p>
 
 
-   <p class="issue" id="issue-302c2cef"><a class="self-link" href="#issue-302c2cef"></a>This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ">&lt;https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ></a></p>
+   <p class="issue" id="issue-302c2cef"><a class="self-link" href="#issue-302c2cef"></a>This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://github.com/tabatkins/bikeshed/issues/2">&lt;https://github.com/tabatkins/bikeshed/issues/2></a></p>
 
 
-   <p class="issue" id="issue-361a85f0"><a class="self-link" href="#issue-361a85f0"></a>This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ">&lt;https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ></a></p>
+   <p class="issue" id="issue-361a85f0"><a class="self-link" href="#issue-361a85f0"></a>This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://github.com/ta-bat_kins/bikesh123ed/issues/1">&lt;https://github.com/ta-bat_kins/bikesh123ed/issues/1></a></p>
 
 
    <p class="issue" id="issue-6aec6caa"><a class="self-link" href="#issue-6aec6caa"></a>This is not a GitHub issue. <a href="https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!">&lt;https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!></a></p>
@@ -111,8 +111,8 @@ Notes and issues should be generated correctly.</p>
    <div class="issue">This is an issue.<a href="#issue-05237a4c"> ↵ </a></div>
    <div class="issue">THIS IS AN ISSUE OMG!!!!11!!!1!<a href="#issue-7004b3b3"> ↵ </a></div>
    <div class="issue">This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a><a href="#issue-290cde08"> ↵ </a></div>
-   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://issue-tracker.test/issue-tabatkins/bikeshed#1">&lt;https://issue-tracker.test/issue-tabatkins/bikeshed#1></a><a href="#issue-cfb7f5c7"> ↵ </a></div>
-   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ">&lt;https://issue-tracker.test/issue-  tabatkins/bikeshed#2  ></a><a href="#issue-302c2cef"> ↵ </a></div>
-   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ">&lt;https://issue-tracker.test/issue-  ta-bat_kins/bikesh123ed#1 ></a><a href="#issue-361a85f0"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions. <a href="https://github.com/tabatkins/bikeshed/issues/1">&lt;https://github.com/tabatkins/bikeshed/issues/1></a><a href="#issue-cfb7f5c7"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions as well! <a href="https://github.com/tabatkins/bikeshed/issues/2">&lt;https://github.com/tabatkins/bikeshed/issues/2></a><a href="#issue-302c2cef"> ↵ </a></div>
+   <div class="issue">This is an issue, linked to GitHub via the magic of regular expressions and this one too! <a href="https://github.com/ta-bat_kins/bikesh123ed/issues/1">&lt;https://github.com/ta-bat_kins/bikesh123ed/issues/1></a><a href="#issue-361a85f0"> ↵ </a></div>
    <div class="issue">This is not a GitHub issue. <a href="https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!">&lt;https://issue-tracker.test/issue-Hahaha, this/looks like a github url#123456789 but it’s not surprise sucka!></a><a href="#issue-6aec6caa"> ↵ </a></div></div></body>
 </html>

--- a/tests/notes-issues001.html
+++ b/tests/notes-issues001.html
@@ -86,6 +86,9 @@ Notes and issues should be generated correctly.</p>
 
    <p class="issue" id="issue-7004b3b3"><a class="self-link" href="#issue-7004b3b3"></a>THIS IS AN ISSUE OMG!!!!11!!!1!</p>
 
+
+   <p class="issue" id="issue-290cde08"><a class="self-link" href="#issue-290cde08"></a>This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a></p>
+
 </main>
 
 
@@ -94,5 +97,6 @@ Notes and issues should be generated correctly.</p>
   <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span></h2>
   <div style="counter-reset:issue">
    <div class="issue">This is an issue.<a href="#issue-05237a4c"> ↵ </a></div>
-   <div class="issue">THIS IS AN ISSUE OMG!!!!11!!!1!<a href="#issue-7004b3b3"> ↵ </a></div></div></body>
+   <div class="issue">THIS IS AN ISSUE OMG!!!!11!!!1!<a href="#issue-7004b3b3"> ↵ </a></div>
+   <div class="issue">This is an issue, linked via the template in the metadata. <a href="https://issue-tracker.test/issue-123">&lt;https://issue-tracker.test/issue-123></a><a href="#issue-290cde08"> ↵ </a></div></div></body>
 </html>


### PR DESCRIPTION
This patch adds a "ISSUE(...): " syntax to auto-generated, inlined
issues which simplifies the process of linking out to topics that are
being discussed on a remote issue tracker.

I considered a GitHub-specific syntax, but putting a template URL in the
document's metadata seemed simpler and more inclusive.