### PR TITLE
Make travis faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-dev python-pip libxslt1-dev libxml2-dev
 install:
- - pip install lxml
  - sudo pip install --editable .
  - bikeshed update
 script: bikeshed test


### PR DESCRIPTION
I'm fairly certain this isn't necessary, as `pip` will install `lxml` on it's own. 99 seconds of travis time could be yours! Or, theirs, I guess.