### PR TITLE
update widlparser

### DIFF
--- a/bikeshed/widlparser/setup.py
+++ b/bikeshed/widlparser/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='widlparser',
-      version='0.994',
+      version='0.995',
       description='WebIDL Parser',
       author='Peter Linss',
       author_email='peter.linss@hp.com',

--- a/bikeshed/widlparser/test.py
+++ b/bikeshed/widlparser/test.py
@@ -211,12 +211,19 @@ typedef (short or sequence<(DOMString[]?[] or short)>? or DOMString[]?[]) sequen
 [foo] partial dictionary FooDict:BarDict {
     [one "]" ( tricky ] test)] short bar;
     [two] sequence<(double or Foo)> foo = "hello";
+    required Foo baz;
 }
 
 callback callFoo = short();
 callback callFoo2 = unsigned long long(unrestricted double one, DOMString two, Fubar ... three);
 callback interface callMe {
     inherit attribute short round setraises (for the heck of it);
+};
+
+dictionary MyDictionary {
+    any value = null;
+    any[] value = null;
+    any [] value = null;
 };
 
 """
@@ -226,6 +233,7 @@ callback interface callMe {
     print repr(parser)
 
     testDifference(idl, unicode(parser))
+    assert(unicode(parser) == idl)
 
     print "MARKED UP:"
     marker = NullMarker()

--- a/bikeshed/widlparser/widlparser/productions.py
+++ b/bikeshed/widlparser/widlparser/productions.py
@@ -491,7 +491,7 @@ class SingleType(Production):    # NonAnyType | "any" [TypeSuffixStartingWithArr
             self.type = NonAnyType(tokens)
             self.suffix = None
         else:
-            self.type = Symbol(tokens, 'any')
+            self.type = Symbol(tokens, 'any', False)
             self.suffix = TypeSuffixStartingWithArray(tokens) if (TypeSuffixStartingWithArray.peek(tokens)) else None
         self._didParse(tokens, False)
 


### PR DESCRIPTION
This fixes a bug with whitespace handling for "any" types in markup, and adds the "required" keyword to dictmembers. 