### PR TITLE
Use an OrderedDict to maintain order for custom metadata.

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -2,6 +2,7 @@
 from __future__ import division, unicode_literals
 import re
 import os
+from DefaultOrderedDict import DefaultOrderedDict
 from subprocess import check_output
 from collections import defaultdict
 from datetime import date, datetime
@@ -58,7 +59,7 @@ class MetadataManager:
         self.issues = []
         self.issueTrackerTemplate = None
 
-        self.otherMetadata = defaultdict(list)
+        self.otherMetadata = DefaultOrderedDict(list)
 
         self.overrides = set()
 

--- a/tests/metadata014.bs
+++ b/tests/metadata014.bs
@@ -1,0 +1,18 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: Makes sure that custom metadata stays in its defined order.
+Editor: Example Editor 12345, Megacorp, test@example.test
+Date: 1970-01-01
+!Foo: Foo
+!Bar: Bar
+!Baz: Baz
+!Aaa: Aaa
+!Aaa: Bbb
+!Zzz: Zzz
+</pre>

--- a/tests/metadata014.html
+++ b/tests/metadata014.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+ <head>
+  
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  
+  
+  <title>Foo</title>
+  
+
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ 
+
+ <body class="h-entry">
+
+  <div class="head">
+  
+   <p data-fill-with="logo"></p>
+  
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+  
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
+    <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+  
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard" data-editor-id="12345"><a class="p-name fn u-email email" href="mailto:test@example.test">Example Editor</a> (<span class="p-org org">Megacorp</span>)
+     <dt>Foo:
+     <dd><span>Foo</span>
+     <dt>Bar:
+     <dd><span>Bar</span>
+     <dt>Baz:
+     <dd><span>Baz</span>
+     <dt>Aaa:
+     <dd><span>Aaa</span>
+     <dd><span>Bbb</span>
+     <dt>Zzz:
+     <dd><span>Zzz</span>
+    </dl>
+   </div>
+  
+   <div data-fill-with="warning"></div>
+  
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE
+</p>
+  
+   <hr title="Separator for header">
+</div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Makes sure that custom metadata stays in its defined order.</p>
+
+</div>
+
+  <div data-fill-with="at-risk"></div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ul></div>
+
+  <main>
+
+
+
+
+</main>
+
+
+
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2></body>
+</html>


### PR DESCRIPTION
Custom metadata in the generated specification should maintain the
order by which they were defined in the input .bs file.