### PR TITLE
Fix exit lines for stacks inside of stacks

### DIFF
--- a/bikeshed/railroaddiagrams.py
+++ b/bikeshed/railroaddiagrams.py
@@ -216,7 +216,8 @@ class Stack(DiagramItem):
         item.addTo(self)
         prevItem = item
         for item in self.items[1:]:
-            Path(x + space + prevItem.width, y).arc('ne').v(prevItem.down).arc('es') \
+            Path(x + space + prevItem.width, y + prevItem.yAdvance).arc('ne') \
+                .v(prevItem.down - prevItem.yAdvance).arc('es') \
                 .left((prevItem.width / 2) + (item.width / 2)).arc('nw').v(item.up).arc('ws').addTo(self)
             space = (width - item.width) / 2
             y += (ARC_RADIUS * 4) + prevItem.down + item.up


### PR DESCRIPTION
Not that it makes a lot of sense to do so, but this fixes stacks inside of stacks, one case I missed. (A stack inside something else inside a stack is more likely, this fixes that case too.)

Testcase:
<pre class=railroad>
Stack:
    Stack:
        T: one
        T: two
    Stack:
        T: three
        T: four
    Choice:
        Stack:
            T: aaa
            T: bbb
        T: ccc
    T: end
</pre>        
