### PR TITLE
<code> is an opaque element.

### DIFF
--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -333,7 +333,7 @@ def isElement(node):
     return etree.iselement(node) and isinstance(node.tag, basestring)
 
 def isOpaqueElement(el):
-    return el.tag in ('pre', 'style', 'script')
+    return el.tag in ('pre', 'code', 'style', 'script')
 
 def fixTypography(text):
     # Replace straight aposes with curly quotes for possessives and contractions.


### PR DESCRIPTION
This fixes some breakage for https://w3c.github.io/webappsec/specs/credentialmanagement/. I haven't dug into the details as to why, but I use `<code>...</code>` pretty frequently in the doc, so I can imagine it's wrapping things that would otherwise be processed?