### PR TITLE
This test doesn't produce the output I'd expect for an optional dictionary.

### DIFF
--- a/tests/idl001.bs
+++ b/tests/idl001.bs
@@ -1,0 +1,26 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: A document with IDL content.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+<pre class="idl">
+    dictionary ExcitingDictionary {
+        boolean thingOne;
+        boolean thingTwo;
+    };
+
+    interface AnInterface {
+        boolean aMethod(boolean anArg);
+        boolean aMethodToo(optional boolean anArgToo);
+        boolean aMethodThree(ExampleDictionary dict);
+        boolean aMethodFour(optional ExampleDictionary dictToo);
+    };
+</pre>

--- a/tests/idl001.html
+++ b/tests/idl001.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+ <head>
+  
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  
+  
+  <title>Foo</title>
+  
+
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ 
+
+ <body class="h-entry">
+
+  <div class="head">
+  
+   <p data-fill-with="logo"></p>
+  
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+  
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
+    <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+  
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+  
+   <div data-fill-with="warning"></div>
+  
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE
+</p>
+  
+   <hr title="Separator for header">
+</div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+
+  <div class="p-summary" data-fill-with="abstract">
+   <p>A document with IDL content.</p>
+
+</div>
+
+  <div data-fill-with="at-risk"></div>
+
+
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ul>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+   </ul></div>
+
+  <main>
+
+
+
+
+
+   <pre class="idl">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="aninterface">AnInterface<a class="self-link" href="#aninterface"></a></dfn> {
+    boolean <dfn class="idl-code" data-dfn-for="AnInterface" data-dfn-type="method" data-export="" data-lt="aMethod(anArg)" id="dom-aninterface-amethod">aMethod<a class="self-link" href="#dom-aninterface-amethod"></a></dfn>(boolean <dfn class="idl-code" data-dfn-for="AnInterface/aMethod(anArg)" data-dfn-type="argument" data-export="" id="dom-aninterface-amethod-anarg-anarg">anArg<a class="self-link" href="#dom-aninterface-amethod-anarg-anarg"></a></dfn>);
+    boolean <dfn class="idl-code" data-dfn-for="AnInterface" data-dfn-type="method" data-export="" data-lt="aMethodToo(anArgToo)|aMethodToo()" id="dom-aninterface-amethodtoo">aMethodToo<a class="self-link" href="#dom-aninterface-amethodtoo"></a></dfn>(optional boolean <dfn class="idl-code" data-dfn-for="AnInterface/aMethodToo(anArgToo), AnInterface/aMethodToo()" data-dfn-type="argument" data-export="" id="dom-aninterface-amethodtoo-anargtoo-anargtoo">anArgToo<a class="self-link" href="#dom-aninterface-amethodtoo-anargtoo-anargtoo"></a></dfn>);
+};
+</pre>
+
+</main>
+
+
+
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
+  <ul class="indexlist">
+   <li>aMethod(anArg), <a href="#dom-aninterface-amethod">Unnumbered section</a>
+   <li>aMethodToo(), <a href="#dom-aninterface-amethodtoo">Unnumbered section</a>
+   <li>aMethodToo(anArgToo), <a href="#dom-aninterface-amethodtoo">Unnumbered section</a>
+   <li>anArg, <a href="#dom-aninterface-amethod-anarg-anarg">Unnumbered section</a>
+   <li>anArgToo, <a href="#dom-aninterface-amethodtoo-anargtoo-anargtoo">Unnumbered section</a>
+   <li>AnInterface, <a href="#aninterface">Unnumbered section</a></ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span></h2>
+  <pre class="idl">interface <a href="#aninterface">AnInterface</a> {
+    boolean <a href="#dom-aninterface-amethod">aMethod</a>(boolean <a href="#dom-aninterface-amethod-anarg-anarg">anArg</a>);
+    boolean <a href="#dom-aninterface-amethodtoo">aMethodToo</a>(optional boolean <a href="#dom-aninterface-amethodtoo-anargtoo-anargtoo">anArgToo</a>);
+};
+
+</pre></body>
+</html>


### PR DESCRIPTION
Not sure if this is a bug in my understanding of IDL (see below), the IDL parser, or Bikeshed. Regardless, this cod (and the optional dictionary member on line 24 in particular) doesn't produce the output I'd expect.

https://heycam.github.io/webidl/#dfn-optional-argument-default-value says:

> If the type of an argument is a dictionary type or a union type that has a dictionary type as one of its flattened member types, and that dictionary type and its ancestors have no required members, and the argument is either the final argument or is followed only by optional arguments, then the argument must be specified as optional. Such arguments are always considered to have a default value of an empty dictionary, unless otherwise specified.

My reading of that is that single-argument methods with dictionary arguments should mark the arguments as optional. *shrug* I Have No Idea What I'm Doing, though.