### PR TITLE
Strip trailing whitespace when injecting a header's link.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -431,7 +431,7 @@ def fixIntraDocumentReferences(doc):
             if content is None:
                 die("Tried to generate text for a section link, but the target isn't a heading:\n{0}", outerHTML(el))
                 continue
-            text = textContent(content).rstrip()
+            text = textContent(content).strip()
             if target.get('data-level') is not None:
                 text = "§{1} {0}".format(text, target.get('data-level'))
             appendChild(el, text)

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -431,7 +431,7 @@ def fixIntraDocumentReferences(doc):
             if content is None:
                 die("Tried to generate text for a section link, but the target isn't a heading:\n{0}", outerHTML(el))
                 continue
-            text = textContent(content)
+            text = textContent(content).rstrip()
             if target.get('data-level') is not None:
                 text = "§{1} {0}".format(text, target.get('data-level'))
             appendChild(el, text)

--- a/tests/section-links002.bs
+++ b/tests/section-links002.bs
@@ -22,3 +22,13 @@ Date: 1970-01-01
 <a section href="#a"></a>
 
 [[#a]]
+
+<h2 id="c">
+  Longer titles look nicer like this
+</h2>
+
+<a section href="#c"></a>
+
+[[#c]]
+
+Inside a sentence, [[#c]] looks like this.

--- a/tests/section-links002.html
+++ b/tests/section-links002.html
@@ -57,6 +57,9 @@
    <ul class="toc" role="directory">
     <li><a href="#a"><span class="secno">1</span> <span class="content">Section <span>dfn</span></span></a>
     <li><a href="#b"><span class="secno">2</span> <span class="content">Section B</span></a>
+    <li><a href="#c"><span class="secno">3</span> <span class="content">
+  Longer titles look nicer like this
+</span></a>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ul class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
@@ -86,6 +89,23 @@
 
 
    <p><a href="#a">§1 Section dfn</a></p>
+
+
+   <h2 class="heading settled" data-level="3" id="c"><span class="secno">3. </span><span class="content">
+  Longer titles look nicer like this
+</span><a class="self-link" href="#c"></a></h2>
+
+
+   <p><a href="#c">§3 
+  Longer titles look nicer like this</a></p>
+
+
+   <p><a href="#c">§3 
+  Longer titles look nicer like this</a></p>
+
+
+   <p>Inside a sentence, <a href="#c">§3 
+  Longer titles look nicer like this</a> looks like this.</p>
 
 </main>
 

--- a/tests/section-links002.html
+++ b/tests/section-links002.html
@@ -96,16 +96,13 @@
 </span><a class="self-link" href="#c"></a></h2>
 
 
-   <p><a href="#c">§3 
-  Longer titles look nicer like this</a></p>
+   <p><a href="#c">§3 Longer titles look nicer like this</a></p>
 
 
-   <p><a href="#c">§3 
-  Longer titles look nicer like this</a></p>
+   <p><a href="#c">§3 Longer titles look nicer like this</a></p>
 
 
-   <p>Inside a sentence, <a href="#c">§3 
-  Longer titles look nicer like this</a> looks like this.</p>
+   <p>Inside a sentence, <a href="#c">§3 Longer titles look nicer like this</a> looks like this.</p>
 
 </main>
 


### PR DESCRIPTION
@timeless noted in https://lists.w3.org/Archives/Public/public-webappsec/2015Jun/0066.html that many of the header-based links have trailing whitespace. This patch pokes at that a bit. WDYT?