### PR TITLE
Add [STATUSTEXT] to remaining status includes.

### DIFF
--- a/bikeshed/include/status-dap-CR.include
+++ b/bikeshed/include/status-dap-CR.include
@@ -52,3 +52,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-dap-ED.include
+++ b/bikeshed/include/status-dap-ED.include
@@ -35,3 +35,6 @@
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
 </p>
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-dap-FPWD.include
+++ b/bikeshed/include/status-dap-FPWD.include
@@ -46,3 +46,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-dap-LCWD.include
+++ b/bikeshed/include/status-dap-LCWD.include
@@ -50,3 +50,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-dap-WD.include
+++ b/bikeshed/include/status-dap-WD.include
@@ -44,3 +44,6 @@
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
 </p>
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-fxtf-CR.include
+++ b/bikeshed/include/status-fxtf-CR.include
@@ -52,3 +52,6 @@
 	and at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time>.
 	See the section <a href="#cr-exit-criteria">“CR
 	exit criteria”</a> for more details.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-fxtf-ED.include
+++ b/bikeshed/include/status-fxtf-ED.include
@@ -30,3 +30,6 @@
 	An individual who has actual knowledge of a patent which the individual believes contains
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-fxtf-FPWD.include
+++ b/bikeshed/include/status-fxtf-FPWD.include
@@ -40,3 +40,6 @@
 	An individual who has actual knowledge of a patent which the individual believes contains
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-fxtf-LCWD.include
+++ b/bikeshed/include/status-fxtf-LCWD.include
@@ -44,3 +44,6 @@
 	to the <a href="http://lists.w3.org/Archives/Public/public-fx/">public-fx</a>
 	mailing list</strong> as described above. The <strong>deadline for
 	comments</strong> is <strong><time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time></strong>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-fxtf-WD.include
+++ b/bikeshed/include/status-fxtf-WD.include
@@ -37,3 +37,6 @@
 	An individual who has actual knowledge of a patent which the individual believes contains
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-personal-DREAM.include
+++ b/bikeshed/include/status-personal-DREAM.include
@@ -6,3 +6,6 @@
 	and should not be taken as "official" or even "unofficial, but planned".
 	Its publication here does not imply endorsement of its contents by W3C. 
 	Don't cite this document other than as a collection of interesting ideas.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-personal.include
+++ b/bikeshed/include/status-personal.include
@@ -3,3 +3,6 @@
 	It is provided for discussion only and may change at any moment.
 	Its publication here does not imply endorsement of its contents by W3C. 
 	Don't cite this document other than as work in progress.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-ricg-WD.include
+++ b/bikeshed/include/status-ricg-WD.include
@@ -9,3 +9,6 @@
 	If any changes are made that would affect the behavior of existing implementations,
 	it will be done only after consulting with existing implementations
 	to ensure that such a change is acceptable and compatible with existing usage.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-ricg.include
+++ b/bikeshed/include/status-ricg.include
@@ -3,3 +3,6 @@
 	It is provided for discussion only and may change at any moment.
 	Its publication here does not imply endorsement of its contents by W3C.
 	Don't cite this document other than as work in progress.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-svg-ED.include
+++ b/bikeshed/include/status-svg-ED.include
@@ -39,3 +39,6 @@
 	A list of current W3C Recommendations and other technical documents can be found at
 	<a href="http://www.w3.org/TR/">http://www.w3.org/TR/</a>. W3C publications may be updated, replaced, or
 	obsoleted by other documents at any time.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-svg-WD.include
+++ b/bikeshed/include/status-svg-WD.include
@@ -44,3 +44,6 @@
 	A list of current W3C Recommendations and other technical documents can be found at
 	<a href="http://www.w3.org/TR/">http://www.w3.org/TR/</a>. W3C publications may be updated, replaced, or
 	obsoleted by other documents at any time.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-web-bluetooth-cg.include
+++ b/bikeshed/include/status-web-bluetooth-cg.include
@@ -18,3 +18,6 @@
   <a href="mailto:public-web-bluetooth@w3.org">public-web-bluetooth@w3.org</a>
   (<a href="mailto:public-web-bluetooth-request@w3.org?subject=subscribe">subscribe</a>,
   <a href="http://lists.w3.org/Archives/Public/public-web-bluetooth/">archives</a>).</p>
+
+<p>
+  [STATUSTEXT]

--- a/bikeshed/include/status-webappsec-CR.include
+++ b/bikeshed/include/status-webappsec-CR.include
@@ -46,3 +46,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-webappsec-ED.include
+++ b/bikeshed/include/status-webappsec-ED.include
@@ -34,3 +34,5 @@
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
 
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-webappsec-FPWD.include
+++ b/bikeshed/include/status-webappsec-FPWD.include
@@ -44,3 +44,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-webappsec-LCWD.include
+++ b/bikeshed/include/status-webappsec-LCWD.include
@@ -48,3 +48,6 @@
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-webappsec-PR.include
+++ b/bikeshed/include/status-webappsec-PR.include
@@ -35,3 +35,5 @@
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
 
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status-webappsec-WD.include
+++ b/bikeshed/include/status-webappsec-WD.include
@@ -42,3 +42,5 @@
 <p>
   This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
 
+<p>
+	[STATUSTEXT]

--- a/bikeshed/include/status.include
+++ b/bikeshed/include/status.include
@@ -1,0 +1,2 @@
+<p>
+	[STATUSTEXT]


### PR DESCRIPTION
This adds the [STATUSTEXT] macro to the status*.include files that don't
currently have it, and fixes the remainders of issue #330.