### PR TITLE
Add missing self argument to Repository.formatIssueUrl()

### DIFF
--- a/bikeshed/repository.py
+++ b/bikeshed/repository.py
@@ -21,7 +21,7 @@ class Repository(object):
 		else:
 			self.type = "unknown"
 
-	def formatIssueUrl(*args, **kwargs):
+	def formatIssueUrl(self, *args, **kwargs):
 		# Dunno how to format an arbitrary issue url,
 		# so give up and just point to the repo.
 		return self.url


### PR DESCRIPTION
Triggered by adding 'Repository: whatwg/mediasession/' to the config as per
https://github.com/tabatkins/bikeshed/issues/477#issuecomment-137526035

To be recognized as GitHub a full URL is needed, it seems.