### PR TITLE
Fix the backtick markdown shortcut.

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1564,6 +1564,7 @@ class CSSSpec(object):
             text = re.sub(r"''([^=\n]+?)''", r'<fake-maybe-placeholder>\1</fake-maybe-placeholder>', text)
 
         if codeSpanReplacements:
+            codeSpanReplacements.reverse()
             def codeSpanReviver(_):
                 # Match object is the PUA character, which I can ignore.
                 # Instead, sub back the replacement in order,

--- a/tests/markdown006.bs
+++ b/tests/markdown006.bs
@@ -1,0 +1,26 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: Test of markdown code constructs.
+Editor: Example Editor
+Date: 1970-01-01
+Markup Shorthands: markdown on
+</pre>
+
+"code1": `code1`
+
+"code2": This is `code2`.
+
+"code spaces": This one has `code spaces`.
+
+"code link": This one is <a href="#">in a `code link`</a>.
+
+"code block" (TODO: This should probably be a &lt;pre&gt; block?)
+```
+This is a code block.
+```

--- a/tests/markdown006.html
+++ b/tests/markdown006.html
@@ -1,0 +1,44 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>Foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Test of markdown code constructs.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ul>
+  </div>
+  <main>
+   <p>"code1": <code>code1</code></p>
+   <p>"code2": This is <code>code2</code>.</p>
+   <p>"code spaces": This one has <code>code spaces</code>.</p>
+   <p>"code link": This one is <a href="#">in a <code>code link</code></a>.</p>
+   <p>"code block" (TODO: This should probably be a &lt;pre> block?) <code>This is a code block.</code></p>
+  </main>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+ </body>
+</html>


### PR DESCRIPTION
The existing code built up a stack of code block replacements. It
should probably have been a queue. This patch takes the simplest
possible approach by reversing the list before processing the
replacements.

Refixes tabatkins/bikeshed#475.