### PR TITLE
Fold whitespace when processing `<var>`s

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -446,7 +446,7 @@ def checkVarHygiene(doc):
 
     # Look for vars that only show up once. These are probably typos.
     singularVars = []
-    varCounts = Counter((textContent(el), nearestAlgo(el)) for el in findAll("var", doc))
+    varCounts = Counter((foldWhitespace(textContent(el)), nearestAlgo(el)) for el in findAll("var", doc))
     for var,count in varCounts.items():
         if count == 1 and var[0].lower() not in doc.md.ignoredVars:
             singularVars.append(var)
@@ -755,7 +755,7 @@ def determineLinkText(el):
         # Need to fix this using the idl parser.
     else:
         linkText = contents
-    linkText = re.sub("\s+", " ", linkText)
+    linkText = foldWhitespace(linkText)
     if len(linkText) == 0:
         die("Autolink {0} has no linktext.", outerHTML(el))
     return linkText

--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -76,6 +76,10 @@ def outerHTML(el):
     return html.tostring(el, with_tail=False, encoding="unicode")
 
 
+def foldWhitespace(text):
+    return re.sub("\s+", " ", text)
+
+
 def parseHTML(text):
     doc = html5lib.parse(text, treebuilder='lxml', namespaceHTMLElements=False)
     head = doc.getroot()[0]

--- a/tests/var001.bs
+++ b/tests/var001.bs
@@ -27,3 +27,10 @@ Here's some more: foo || bar || baz || qux
 Here's |foo bar|, multi word.
 
 Here's |foo-bar|, dashed.
+
+Here's a "real" <var>foo bar</var>.
+
+Here's one with a linebreak: <var>foo
+bar with a linebreak</var>.
+
+This one has no linebreak: |foo bar with a linebreak|. This shouldn't generate a warning.

--- a/tests/var001.html
+++ b/tests/var001.html
@@ -42,6 +42,10 @@
    <p>Here’s some more: foo || bar || baz || qux</p>
    <p>Here’s <var>foo bar</var>, multi word.</p>
    <p>Here’s <var>foo-bar</var>, dashed.</p>
+   <p>Here’s a "real" <var>foo bar</var>.</p>
+   <p>Here’s one with a linebreak: <var>foo
+bar with a linebreak</var>.</p>
+   <p>This one has no linebreak: <var>foo bar with a linebreak</var>. This shouldn’t generate a warning.</p>
   </main>
   <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
  </body>


### PR DESCRIPTION
`|this is a var|` is the same as `|this\nis a var|` in an HTML document. This
patch teaches the singular-var-checker about this interesting property.