### PR TITLE
Accept 'algorithm' as a bare attribute.

### DIFF
--- a/tests/var002.bs
+++ b/tests/var002.bs
@@ -1,0 +1,25 @@
+<pre class=metadata>
+Title: foo
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+Abstract: A document without any content.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+Both of the following should produce warnings. Also, the data-algorithm attributes should be correctly set.
+
+<h2 algorithm="Make a string.">
+  String creation
+</h2>
+
+Let |var| be a string.
+
+<h2 algorithm>
+  Make a non-string.
+</h2>
+
+Let |var| be anything other than a string. Really. Anything.

--- a/tests/var002.html
+++ b/tests/var002.html
@@ -1,0 +1,46 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>A document without any content.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#string-creation"><span class="secno">1</span> <span class="content"> String creation </span></a>
+    <li><a href="#make-a-non-string"><span class="secno">2</span> <span class="content"> Make a non-string. </span></a>
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ul>
+  </div>
+  <main>
+   <p>Both of the following should produce warnings. Also, the data-algorithm attributes should be correctly set.</p>
+   <h2 class="heading settled" data-algorithm="Make a string." data-level="1" id="string-creation"><span class="secno">1. </span><span class="content"> String creation </span><a class="self-link" href="#string-creation"></a></h2>
+   <p>Let <var>var</var> be a string.</p>
+   <h2 class="heading settled" data-algorithm="Make a non-string." data-level="2" id="make-a-non-string"><span class="secno">2. </span><span class="content"> Make a non-string. </span><a class="self-link" href="#make-a-non-string"></a></h2>
+   <p>Let <var>var</var> be anything other than a string. Really. Anything.</p>
+  </main>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+ </body>
+</html>


### PR DESCRIPTION
If h*@algorithm is present, but empty, the header's text will be used as the algorithm name.

This will make integrating it into my various specs a lot simpler and less repetitive. :)