### PR TITLE
Make [LEVEL] macro accessible for use

### DIFF
--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -68,10 +68,10 @@ def tokenizeLines(lines, numSpacesForIndentation, features=None, opaqueElements=
 			if match:
 				token['id'] = match.group(1)
 		elif re.match(r"\d+\.\s", line):
-			match = re.match(r"\d+\.\s+(.*)", line)
-			token = {'type':'numbered', 'text': match.group(1), 'raw':rawline}
-		elif re.match(r"\d+\.$", line):
-			token = {'type':'numbered', 'text': "", 'raw':rawline}
+			match = re.match(r"(\d+)\.\s+(.*)", line)
+			token = {'type':'numbered', 'number': match.group(1), 'text': match.group(2), 'raw':rawline}
+		elif re.match(r"(\d+)\.$", line):
+			token = {'type':'numbered', 'number': match.group(1), 'text': "", 'raw':rawline}
 		elif re.match(r"[*+-]\s", line):
 			match = re.match(r"[*+-]\s+(.*)", line)
 			token = {'type':'bulleted', 'text': match.group(1), 'raw':rawline}
@@ -291,7 +291,8 @@ def parseBulleted(stream):
 
 def parseNumbered(stream):
 	prefixLen = stream.currprefixlen()
-        numSpacesForIndentation = stream.numSpacesForIndentation
+	numSpacesForIndentation = stream.numSpacesForIndentation
+	firstNumber = stream.currnumber()
 
 	def parseItem(stream):
 		# Assumes it's being called with curr being a numbered line.
@@ -325,7 +326,10 @@ def parseNumbered(stream):
 				stream.advance()
 			yield parseItem(stream)
 
-	lines = ["<ol>"]
+	if firstNumber == '1':
+		lines = ["<ol>"]
+	else:
+		lines = ["<ol start='{0}'>".format(firstNumber)]
 	for li_lines in getItems(stream):
 		lines.append("<li data-md>")
 		lines.extend(parse(li_lines, numSpacesForIndentation))

--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -68,10 +68,10 @@ def tokenizeLines(lines, numSpacesForIndentation, features=None, opaqueElements=
 			if match:
 				token['id'] = match.group(1)
 		elif re.match(r"\d+\.\s", line):
-			match = re.match(r"(\d+)\.\s+(.*)", line)
-			token = {'type':'numbered', 'number': match.group(1), 'text': match.group(2), 'raw':rawline}
-		elif re.match(r"(\d+)\.$", line):
-			token = {'type':'numbered', 'number': match.group(1), 'text': "", 'raw':rawline}
+			match = re.match(r"\d+\.\s+(.*)", line)
+			token = {'type':'numbered', 'text': match.group(1), 'raw':rawline}
+		elif re.match(r"\d+\.$", line):
+			token = {'type':'numbered', 'text': "", 'raw':rawline}
 		elif re.match(r"[*+-]\s", line):
 			match = re.match(r"[*+-]\s+(.*)", line)
 			token = {'type':'bulleted', 'text': match.group(1), 'raw':rawline}
@@ -291,8 +291,7 @@ def parseBulleted(stream):
 
 def parseNumbered(stream):
 	prefixLen = stream.currprefixlen()
-	numSpacesForIndentation = stream.numSpacesForIndentation
-	firstNumber = stream.currnumber()
+        numSpacesForIndentation = stream.numSpacesForIndentation
 
 	def parseItem(stream):
 		# Assumes it's being called with curr being a numbered line.
@@ -326,10 +325,7 @@ def parseNumbered(stream):
 				stream.advance()
 			yield parseItem(stream)
 
-	if firstNumber == '1':
-		lines = ["<ol>"]
-	else:
-		lines = ["<ol start='{0}'>".format(firstNumber)]
+	lines = ["<ol>"]
 	for li_lines in getItems(stream):
 		lines.append("<li data-md>")
 		lines.extend(parse(li_lines, numSpacesForIndentation))

--- a/tests/markdown001.bs
+++ b/tests/markdown001.bs
@@ -110,6 +110,23 @@ Mixed Lists
 
 	* bulleted two
 
+Numbered List Starting at 5
+===========================
+
+5. Five
+6. Six
+7. Seven
+
+Nested Numbered List
+====================
+
+1. One
+	1. One One
+	2. One Two
+2. Two
+	4. Two Four
+	5. Two Five
+
 DL
 ===
 

--- a/tests/markdown001.bs
+++ b/tests/markdown001.bs
@@ -110,23 +110,6 @@ Mixed Lists
 
 	* bulleted two
 
-Numbered List Starting at 5
-===========================
-
-5. Five
-6. Six
-7. Seven
-
-Nested Numbered List
-====================
-
-1. One
-	1. One One
-	2. One Two
-2. Two
-	4. Two Four
-	5. Two Five
-
 DL
 ===
 

--- a/tests/markdown001.html
+++ b/tests/markdown001.html
@@ -58,11 +58,9 @@
     <li><a href="#nested-lists-with-opening-text"><span class="secno">7</span> <span class="content">Nested Lists with Opening Text</span></a>
     <li><a href="#numbered-list"><span class="secno">8</span> <span class="content">Numbered List</span></a>
     <li><a href="#mixed-lists"><span class="secno">9</span> <span class="content">Mixed Lists</span></a>
-    <li><a href="#numbered-list-starting-at-5"><span class="secno">10</span> <span class="content">Numbered List Starting at 5</span></a>
-    <li><a href="#nested-numbered-list"><span class="secno">11</span> <span class="content">Nested Numbered List</span></a>
-    <li><a href="#dl"><span class="secno">12</span> <span class="content">DL</span></a>
-    <li><a href="#paragraphs-in-lists"><span class="secno">13</span> <span class="content">Paragraphs In Lists</span></a>
-    <li><a href="#interruptible-paragraphs"><span class="secno">14</span> <span class="content">Interruptible Paragraphs</span></a>
+    <li><a href="#dl"><span class="secno">10</span> <span class="content">DL</span></a>
+    <li><a href="#paragraphs-in-lists"><span class="secno">11</span> <span class="content">Paragraphs In Lists</span></a>
+    <li><a href="#interruptible-paragraphs"><span class="secno">12</span> <span class="content">Interruptible Paragraphs</span></a>
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul>
   </div>
@@ -174,35 +172,7 @@ one</p>
        <p>bulleted two</p>
      </ul>
    </ol>
-   <h2 class="heading settled" data-level="10" id="numbered-list-starting-at-5"><span class="secno">10. </span><span class="content">Numbered List Starting at 5</span><a class="self-link" href="#numbered-list-starting-at-5"></a></h2>
-   <ol start="5">
-    <li data-md="">
-     <p>Five</p>
-    <li data-md="">
-     <p>Six</p>
-    <li data-md="">
-     <p>Seven</p>
-   </ol>
-   <h2 class="heading settled" data-level="11" id="nested-numbered-list"><span class="secno">11. </span><span class="content">Nested Numbered List</span><a class="self-link" href="#nested-numbered-list"></a></h2>
-   <ol>
-    <li data-md="">
-     <p>One</p>
-     <ol>
-      <li data-md="">
-       <p>One One</p>
-      <li data-md="">
-       <p>One Two</p>
-     </ol>
-    <li data-md="">
-     <p>Two</p>
-     <ol start="4">
-      <li data-md="">
-       <p>Two Four</p>
-      <li data-md="">
-       <p>Two Five</p>
-     </ol>
-   </ol>
-   <h2 class="heading settled" data-level="12" id="dl"><span class="secno">12. </span><span class="content">DL</span><a class="self-link" href="#dl"></a></h2>
+   <h2 class="heading settled" data-level="10" id="dl"><span class="secno">10. </span><span class="content">DL</span><a class="self-link" href="#dl"></a></h2>
    <dl>
     <dt data-md="">
      <p>foo</p>
@@ -225,7 +195,7 @@ continues on the next line</p>
        <p>nested foo stuff</p>
      </dl>
    </dl>
-   <h2 class="heading settled" data-level="13" id="paragraphs-in-lists"><span class="secno">13. </span><span class="content">Paragraphs In Lists</span><a class="self-link" href="#paragraphs-in-lists"></a></h2>
+   <h2 class="heading settled" data-level="11" id="paragraphs-in-lists"><span class="secno">11. </span><span class="content">Paragraphs In Lists</span><a class="self-link" href="#paragraphs-in-lists"></a></h2>
    <dl>
     <dt>foo 
     <dd>
@@ -234,7 +204,7 @@ continues on the next line</p>
      <p>Second para.
 		Two lines.</p>
    </dl>
-   <h2 class="heading settled" data-level="14" id="interruptible-paragraphs"><span class="secno">14. </span><span class="content">Interruptible Paragraphs</span><a class="self-link" href="#interruptible-paragraphs"></a></h2>
+   <h2 class="heading settled" data-level="12" id="interruptible-paragraphs"><span class="secno">12. </span><span class="content">Interruptible Paragraphs</span><a class="self-link" href="#interruptible-paragraphs"></a></h2>
    <p>foo foo foo</p>
    <ul>
     <li data-md="">

--- a/tests/markdown001.html
+++ b/tests/markdown001.html
@@ -58,9 +58,11 @@
     <li><a href="#nested-lists-with-opening-text"><span class="secno">7</span> <span class="content">Nested Lists with Opening Text</span></a>
     <li><a href="#numbered-list"><span class="secno">8</span> <span class="content">Numbered List</span></a>
     <li><a href="#mixed-lists"><span class="secno">9</span> <span class="content">Mixed Lists</span></a>
-    <li><a href="#dl"><span class="secno">10</span> <span class="content">DL</span></a>
-    <li><a href="#paragraphs-in-lists"><span class="secno">11</span> <span class="content">Paragraphs In Lists</span></a>
-    <li><a href="#interruptible-paragraphs"><span class="secno">12</span> <span class="content">Interruptible Paragraphs</span></a>
+    <li><a href="#numbered-list-starting-at-5"><span class="secno">10</span> <span class="content">Numbered List Starting at 5</span></a>
+    <li><a href="#nested-numbered-list"><span class="secno">11</span> <span class="content">Nested Numbered List</span></a>
+    <li><a href="#dl"><span class="secno">12</span> <span class="content">DL</span></a>
+    <li><a href="#paragraphs-in-lists"><span class="secno">13</span> <span class="content">Paragraphs In Lists</span></a>
+    <li><a href="#interruptible-paragraphs"><span class="secno">14</span> <span class="content">Interruptible Paragraphs</span></a>
     <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
    </ul>
   </div>
@@ -172,7 +174,35 @@ one</p>
        <p>bulleted two</p>
      </ul>
    </ol>
-   <h2 class="heading settled" data-level="10" id="dl"><span class="secno">10. </span><span class="content">DL</span><a class="self-link" href="#dl"></a></h2>
+   <h2 class="heading settled" data-level="10" id="numbered-list-starting-at-5"><span class="secno">10. </span><span class="content">Numbered List Starting at 5</span><a class="self-link" href="#numbered-list-starting-at-5"></a></h2>
+   <ol start="5">
+    <li data-md="">
+     <p>Five</p>
+    <li data-md="">
+     <p>Six</p>
+    <li data-md="">
+     <p>Seven</p>
+   </ol>
+   <h2 class="heading settled" data-level="11" id="nested-numbered-list"><span class="secno">11. </span><span class="content">Nested Numbered List</span><a class="self-link" href="#nested-numbered-list"></a></h2>
+   <ol>
+    <li data-md="">
+     <p>One</p>
+     <ol>
+      <li data-md="">
+       <p>One One</p>
+      <li data-md="">
+       <p>One Two</p>
+     </ol>
+    <li data-md="">
+     <p>Two</p>
+     <ol start="4">
+      <li data-md="">
+       <p>Two Four</p>
+      <li data-md="">
+       <p>Two Five</p>
+     </ol>
+   </ol>
+   <h2 class="heading settled" data-level="12" id="dl"><span class="secno">12. </span><span class="content">DL</span><a class="self-link" href="#dl"></a></h2>
    <dl>
     <dt data-md="">
      <p>foo</p>
@@ -195,7 +225,7 @@ continues on the next line</p>
        <p>nested foo stuff</p>
      </dl>
    </dl>
-   <h2 class="heading settled" data-level="11" id="paragraphs-in-lists"><span class="secno">11. </span><span class="content">Paragraphs In Lists</span><a class="self-link" href="#paragraphs-in-lists"></a></h2>
+   <h2 class="heading settled" data-level="13" id="paragraphs-in-lists"><span class="secno">13. </span><span class="content">Paragraphs In Lists</span><a class="self-link" href="#paragraphs-in-lists"></a></h2>
    <dl>
     <dt>foo 
     <dd>
@@ -204,7 +234,7 @@ continues on the next line</p>
      <p>Second para.
 		Two lines.</p>
    </dl>
-   <h2 class="heading settled" data-level="12" id="interruptible-paragraphs"><span class="secno">12. </span><span class="content">Interruptible Paragraphs</span><a class="self-link" href="#interruptible-paragraphs"></a></h2>
+   <h2 class="heading settled" data-level="14" id="interruptible-paragraphs"><span class="secno">14. </span><span class="content">Interruptible Paragraphs</span><a class="self-link" href="#interruptible-paragraphs"></a></h2>
    <p>foo foo foo</p>
    <ul>
     <li data-md="">


### PR DESCRIPTION
The [LEVEL] macro was NOT usable by itself and required use through the [VSHORTNAME] macro. This change allows use to the macro on its own.

Test file is also included.

This is related to #135 