### PR TITLE
Make [LEVEL] macro accessible for use

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -289,6 +289,7 @@ class MetadataManager:
             macros["statustext"] = self.statusText
         else:
             macros["statustext"] = ""
+        macros["level"] = str(self.level)
         macros["vshortname"] = self.vshortname
         if self.status == "FINDING" and self.group:
             macros["longstatus"] = "Finding of the {0}".format(self.group)

--- a/tests/metadata015.bs
+++ b/tests/metadata015.bs
@@ -1,0 +1,15 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 2.1
+Status: ED
+ED: http://example.com/foo
+Abstract: Test 1-piece Editor
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+[VSHORTNAME]
+[LEVEL]

--- a/tests/metadata015.html
+++ b/tests/metadata015.html
@@ -1,0 +1,41 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>Foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ </head>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Test 1-piece Editor</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ul>
+  </div>
+  <main>
+   <p>foo-2.1
+2.1</p>
+  </main>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span></h2>
+ </body>
+</html>


### PR DESCRIPTION
The [LEVEL] macro was NOT usable by itself and required use through the [VSHORTNAME] macro. This change allows use to the macro on its own.

Test file is also included.

This is related to #135