### PR TITLE
Fix #551, a missing import of htmlhelpers.find.

### DIFF
--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -321,7 +321,7 @@ def simplifyText(text):
 
 
 def linkTextsFromElement(el, preserveCasing=False):
-    from .htmlhelpers import textContent
+    from .htmlhelpers import find, textContent
     if el.get('data-lt') == '':
         return []
     elif el.get('data-lt'):


### PR DESCRIPTION
This could really use a test, too, to make sure it doesn't regress, but I don't know your testing system well enough to do that efficiently.