### PR TITLE
linkTextVariations should kick in only if no direct match is found

### DIFF
--- a/bikeshed/ReferenceManager.py
+++ b/bikeshed/ReferenceManager.py
@@ -226,16 +226,20 @@ class ReferenceManager(object):
             return None
 
         # Local refs always get precedence, no matter what.
-        localRefs = self.getLocalRef(linkType, text, linkFor, linkForHint, el)
+        # At first let's try with "exact=true"...
+        localRefs = self.getLocalRef(linkType, text, linkFor, linkForHint, el, True)
+        # ... then if we don't find what we need, we can extend to inexact matches
+        if len(localRefs) == 0: localRefs = self.getLocalRef(linkType, text, linkFor, linkForHint, el, False)
+        # If any of those yielded something, return it
         if len(localRefs) == 1:
             return localRefs[0]
         elif len(localRefs) > 1:
             if error:
                 warn("Multiple possible '{0}' local refs for '{1}'.\nArbitrarily chose the one with type '{2}' and for '{3}'.",
-                     linkType,
-                     text,
-                     localRefs[0].type,
-                     "' or '".join(localRefs[0].for_))
+                    linkType,
+                    text,
+                    localRefs[0].type,
+                    "' or '".join(localRefs[0].for_))
             return localRefs[0]
 
         # Take defaults into account

--- a/bikeshed/ReferenceManager.py
+++ b/bikeshed/ReferenceManager.py
@@ -236,10 +236,10 @@ class ReferenceManager(object):
         elif len(localRefs) > 1:
             if error:
                 warn("Multiple possible '{0}' local refs for '{1}'.\nArbitrarily chose the one with type '{2}' and for '{3}'.",
-                    linkType,
-                    text,
-                    localRefs[0].type,
-                    "' or '".join(localRefs[0].for_))
+                     linkType,
+                     text,
+                     localRefs[0].type,
+                     "' or '".join(localRefs[0].for_))
             return localRefs[0]
 
         # Take defaults into account


### PR DESCRIPTION
Proposed patch for ReferenceManager.
I didn't test if that works, but I remember you have a test suite, so that should do the trick :D