### PR TITLE
Remove the CG logo from our specs.

### DIFF
--- a/bikeshed/include/header-web-bluetooth-cg.include
+++ b/bikeshed/include/header-web-bluetooth-cg.include
@@ -8,7 +8,7 @@
 </head>
 <body class="h-entry">
 <div class="head">
-  <div data-fill-with="logo"></div>
+  <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>

--- a/bikeshed/include/logo-CG-DRAFT.include
+++ b/bikeshed/include/logo-CG-DRAFT.include
@@ -1,9 +1,0 @@
-<style>
-  body {
-    padding-left: 160px;
-    background-image: url('https://www.w3.org/community/src/css/spec/back-cg-draft.png');
-    background-position: top left;
-    background-attachment: fixed;
-    background-repeat: no-repeat;
-  }
-</style>

--- a/bikeshed/include/logo-CG-FINAL.include
+++ b/bikeshed/include/logo-CG-FINAL.include
@@ -1,9 +1,0 @@
-<style>
-  body {
-    padding-left: 160px;
-    background-image: url('https://www.w3.org/community/src/css/spec/back-cg-final.png');
-    background-position: top left;
-    background-attachment: fixed;
-    background-repeat: no-repeat;
-  }
-</style>


### PR DESCRIPTION
It gets squished by the new sidebar ToC, and the stylesheets aren't ready for
putting anything other than "W3C" where WG specs currently put their logo.

Preview at https://rawgit.com/jyasskin/web-bluetooth-1/update-bikeshed/index.html.