### PR TITLE
Updated HTML boilerplate to point to Web Platform WG resources

### DIFF
--- a/bikeshed/include/status-html-WD.include
+++ b/bikeshed/include/status-html-WD.include
@@ -11,15 +11,13 @@
     provided as part of the introduction.
   </p>
   <p>
-    This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a>
+    This document was published by the <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
     as a Working Draft.
 
-    If you wish to make comments regarding this document, please send them to
-    <a href="mailto:public-html@w3.org">public-html@w3.org</a>
-    (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
-    <a href="http://lists.w3.org/Archives/Public/public-html/">archives</a>).
-
-    All comments are welcome.
+    Feedback and comments on this specification are welcome. Please use
+    <a href="https://github.com/w3c/html/issues">Github issues</a>
+    Historical discussions can be found in the
+    <a href="http://lists.w3.org/Archives/Public/public-html/">public-html@w3.org archives</a>.
   </p>
   <p>
     Publication as a Working Draft does not imply endorsement by the


### PR DESCRIPTION
Changed reference to HTML WG to Web Platform WG, and updated the instructions for providing feedback to point to the W3C HTML repo on Github.