### PR TITLE
Temporary fix for PutForwards incorrect linking

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1217,8 +1217,7 @@ class IDLMarker(object):
 
         # The name in [PutForwards=foo] is an attribute of the same interface.
         if construct.idlType == "extended-attribute" and construct.name == "PutForwards":
-            interface = construct.parent.parent.name
-            return ('<a data-link-type="attribute" for="{0}">'.format(interface), "</a>")
+            return (None, None)
 
         return ('<a data-link-type="idl-name">', '</a>')
 


### PR DESCRIPTION
Per @tabatkins in issue #582 reverting the previous PutForwards change #559.

Now disabling all linking for PutForwards for the time being until #582 is fully addressed.