### PR TITLE
Link to correct patent disclosures for Web Platform group.

### DIFF
--- a/bikeshed/include/footer-webplatform.include
+++ b/bikeshed/include/footer-webplatform.include
@@ -1,4 +1,5 @@
 </main>
+<div data-fill-with="conformance">
 <h2 id="conformance" class="no-ref no-num">Conformance</h2>
 
 <h3 id="conventions" class="no-ref no-num">Document conventions</h3>
@@ -40,7 +41,7 @@
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
-
+</div>
 </body>
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
 </html>

--- a/bikeshed/include/status-webplatform-ED.include
+++ b/bikeshed/include/status-webplatform-ED.include
@@ -25,7 +25,7 @@
 <p>
   This document was produced by a group operating under
   the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
-  W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/49309/status" rel=disclosure>public list of any patent disclosures</a>
+  W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/83482/status" rel=disclosure>public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>


### PR DESCRIPTION
Also make it possible to omit the default conformance section to enable for example the FileAPI to provide their own different conformance section.