### PR TITLE
Describe the TR link as the "latest published version".

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -535,7 +535,7 @@ def addSpecMetadataSection(doc):
     if mac.get('version'):
         md["This version"].append(E.a({"href":mac['version'], "class":"u-url"}, mac['version']))
     if doc.md.TR:
-        md["Latest version"].append(E.a({"href": doc.md.TR}, doc.md.TR))
+        md["Latest published version"].append(E.a({"href": doc.md.TR}, doc.md.TR))
     if doc.md.ED and doc.md.status in config.TRStatuses:
         md["Editor's Draft"].append(E.a({"href": doc.md.ED}, doc.md.ED))
     if len(doc.md.previousVersions):

--- a/tests/metadata016.bs
+++ b/tests/metadata016.bs
@@ -1,0 +1,13 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: ED
+ED: http://example.com/foo
+TR: https://example.com/TR/foo
+Abstract: Test TR link from ED.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>

--- a/tests/metadata016.html
+++ b/tests/metadata016.html
@@ -1,0 +1,38 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt>Latest published version:
+     <dd><a href="https://example.com/TR/foo">https://example.com/TR/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Test TR link from ED.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ol>
+  </nav>
+  <main></main>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>

--- a/tests/metadata017.bs
+++ b/tests/metadata017.bs
@@ -1,0 +1,13 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: WD
+ED: http://example.com/foo
+TR: https://example.com/TR/foo
+Abstract: Test ED link from WD.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>

--- a/tests/metadata017.html
+++ b/tests/metadata017.html
@@ -1,0 +1,40 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://www.w3.org/TR/1970/WD-foo-1-19700101/">http://www.w3.org/TR/1970/WD-foo-1-19700101/</a>
+     <dt>Latest published version:
+     <dd><a href="https://example.com/TR/foo">https://example.com/TR/foo</a>
+     <dt>Editor's Draft:
+     <dd><a href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Test ED link from WD.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+   </ol>
+  </nav>
+  <main></main>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>


### PR DESCRIPTION
Since usually the ED will be more "latest" than the TR. This matches
ReSpec's wording.