### PR TITLE
Fix Index Out of Range error for enums with "" empty string as values

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1710,10 +1710,10 @@ def processIDL(doc):
                         forceDfn = True
                 else:
                     for linkFor in config.splitForValues(el.get('data-idl-for', '')) or [None]:
-                        ref = doc.refs.getRef(idlType, idlText,
-                                              linkFor=linkFor,
-                                              el=el,
-                                              error=False)
+                        try:
+                            ref = doc.refs.getRef(idlType, idlText, linkFor=linkFor, el=el, error=False)
+                        except IndexError:
+                            break
                         if ref:
                             url = ref.url
                             break


### PR DESCRIPTION
This is a work around fix for the IndexError. This issue is blocking us from updating to the latest bikeshed. We have to use a snapshot from last month.

Fix #692