### PR TITLE
Fix FXTF status include files

### DIFF
--- a/bikeshed/include/fxtf/status-CR.include
+++ b/bikeshed/include/fxtf/status-CR.include
@@ -5,11 +5,9 @@
 		can be found in the <a href="http://www.w3.org/TR/">W3C technical reports index at http://www.w3.org/TR/.</a></em>
 
 <p>
-	This document was produced by the <a href="http://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
-	href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> (part of the
-	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>) as a
-	<a href="http://www.w3.org/2005/10/Process-20051014/tr.html#maturity-levels">Candidate
+	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> as
+	a <a href="https://www.w3.org/2005/10/Process-20051014/tr.html#maturity-levels">Candidate
 	Recommendation</a>.
 
 <p>

--- a/bikeshed/include/fxtf/status-ED.include
+++ b/bikeshed/include/fxtf/status-ED.include
@@ -15,10 +15,8 @@
 	“[<!---->[SHORTNAME]] <em>…summary of comment…</em>”
 
 <p>
-	This document was produced by the <a href="http://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
-	href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> (part of the
-	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under

--- a/bikeshed/include/fxtf/status-FPWD.include
+++ b/bikeshed/include/fxtf/status-FPWD.include
@@ -25,10 +25,8 @@
 	“[<!---->[SHORTNAME]] <em>…summary of comment…</em>”
 
 <p>
-	This document was produced by the <a href="http://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
-	href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> (part of the
-	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under

--- a/bikeshed/include/fxtf/status-LCWD.include
+++ b/bikeshed/include/fxtf/status-LCWD.include
@@ -22,10 +22,8 @@
 	“[<!---->[SHORTNAME]] <em>…summary of comment…</em>”
 
 <p>
-	This document was produced by the <a href="http://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
-	href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> (part of the
-	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under

--- a/bikeshed/include/fxtf/status-WD.include
+++ b/bikeshed/include/fxtf/status-WD.include
@@ -22,10 +22,8 @@
 	“[<!---->[SHORTNAME]] <em>…summary of comment…</em>”
 
 <p>
-	This document was produced by the <a href="http://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	(part of the <a href="http://www.w3.org/Style/">Style Activity</a>) and the <a
-	href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> (part of the
-	<a href="http://www.w3.org/Graphics/">Graphics Activity</a>).
+	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under


### PR DESCRIPTION
This updates the FXTF status include files to appease specberus.

Specifically this regex:
https://github.com/w3c/specberus/blob/f16f7ce5f7970934cadcc13f8d87082c7e34ac95/lib/rules/sotd/pp.js#L49

This involves dropping the "(part of the ...)" parenthicals, as well as replacing "produced by" with "published by".

At the same time this updates the URLs in this paragraph to use https.