### PR TITLE
Add link to process document from FXTF includes

### DIFF
--- a/bikeshed/include/fxtf/status-CR.include
+++ b/bikeshed/include/fxtf/status-CR.include
@@ -44,6 +44,8 @@
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
 	6 of the W3C Patent Policy</a>.
 
+  <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>.
+
 <p>
 	A test suite and implementation report for [TITLE] will be developed during
 	the Candidate Recommendation phase, which will last a minimum of six months,

--- a/bikeshed/include/fxtf/status-ED.include
+++ b/bikeshed/include/fxtf/status-ED.include
@@ -29,5 +29,7 @@
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
+  <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>.
+
 <p>
 	[STATUSTEXT]

--- a/bikeshed/include/fxtf/status-FPWD.include
+++ b/bikeshed/include/fxtf/status-FPWD.include
@@ -39,5 +39,7 @@
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
+  <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>.
+
 <p>
 	[STATUSTEXT]

--- a/bikeshed/include/fxtf/status-LCWD.include
+++ b/bikeshed/include/fxtf/status-LCWD.include
@@ -43,5 +43,7 @@
 	mailing list</strong> as described above. The <strong>deadline for
 	comments</strong> is <strong><time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time></strong>.
 
+  <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>.
+
 <p>
 	[STATUSTEXT]

--- a/bikeshed/include/fxtf/status-WD.include
+++ b/bikeshed/include/fxtf/status-WD.include
@@ -36,5 +36,7 @@
 	<a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
+  <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 W3C Process Document</a>.
+
 <p>
 	[STATUSTEXT]


### PR DESCRIPTION
This too is for specberus. I just copied what we had in the CSS includes.