### PR TITLE
Add a test for empty-string IDL enum

### DIFF
--- a/tests/idl001.bs
+++ b/tests/idl001.bs
@@ -11,8 +11,10 @@ Date: 1970-01-01
 </pre>
 
 <pre class=idl>
+enum BarEnum { "", "bar" };
 interface Foo {
 	attribute DOMString foo;
+ attribute BarEnum bar;
 	attribute DOMString _or;
   Promise &lt;any&gt; get(int a);
 };

--- a/tests/idl001.html
+++ b/tests/idl001.html
@@ -186,8 +186,10 @@
    </ol>
   </nav>
   <main>
-<pre class="idl def">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="foo">Foo<a class="self-link" href="#foo"></a></dfn> {
+<pre class="idl def">enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-barenum">BarEnum<a class="self-link" href="#enumdef-barenum"></a></dfn> { <dfn class="idl-code" data-dfn-for="BarEnum" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-barenum">""<a class="self-link" href="#dom-barenum"></a></dfn>, <dfn class="idl-code" data-dfn-for="BarEnum" data-dfn-type="enum-value" data-export="" data-lt="&quot;bar&quot;|bar" id="dom-barenum-bar">"bar"<a class="self-link" href="#dom-barenum-bar"></a></dfn> };
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="foo">Foo<a class="self-link" href="#foo"></a></dfn> {
   attribute DOMString <dfn class="idl-code" data-dfn-for="Foo" data-dfn-type="attribute" data-export="" data-type="DOMString" id="dom-foo-foo">foo<a class="self-link" href="#dom-foo-foo"></a></dfn>;
+ attribute <a data-link-type="idl-name" href="#enumdef-barenum">BarEnum</a> <dfn class="idl-code" data-dfn-for="Foo" data-dfn-type="attribute" data-export="" data-type="BarEnum" id="dom-foo-bar">bar<a class="self-link" href="#dom-foo-bar"></a></dfn>;
   attribute DOMString <dfn class="idl-code" data-dfn-for="Foo" data-dfn-type="attribute" data-export="" data-type="DOMString" id="dom-foo-_or">_or<a class="self-link" href="#dom-foo-_or"></a></dfn>;
   Promise &lt;any> <dfn class="idl-code" data-dfn-for="Foo" data-dfn-type="method" data-export="" data-lt="get(a)" id="dom-foo-get">get<a class="self-link" href="#dom-foo-get"></a></dfn>(<a data-link-type="idl-name">int</a> <a class="idl-code" data-link-type="argument" href="#dom-foo-get-a-a">a</a>);
 };
@@ -214,15 +216,26 @@
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
   <ul class="index">
-   <li><a href="#foo">Foo</a><span>, in §Unnumbered section</span>
+   <li><a href="#dom-barenum">""</a><span>, in §Unnumbered section</span>
+   <li>
+    bar
+    <ul>
+     <li><a href="#dom-barenum-bar">enum-value for BarEnum</a><span>, in §Unnumbered section</span>
+     <li><a href="#dom-foo-bar">attribute for Foo</a><span>, in §Unnumbered section</span>
+    </ul>
+   <li><a href="#dom-barenum-bar">"bar"</a><span>, in §Unnumbered section</span>
+   <li><a href="#enumdef-barenum">BarEnum</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-foo-foo">foo</a><span>, in §Unnumbered section</span>
+   <li><a href="#foo">Foo</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-foo-get">get(a)</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-foo-_or">_or</a><span>, in §Unnumbered section</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span></h2>
-<pre class="idl def">interface <a href="#foo">Foo</a> {
+<pre class="idl def">enum <a href="#enumdef-barenum">BarEnum</a> { <a href="#dom-barenum">""</a>, <a href="#dom-barenum-bar">"bar"</a> };
+interface <a href="#foo">Foo</a> {
   attribute DOMString <a data-type="DOMString" href="#dom-foo-foo">foo</a>;
+ attribute <a data-link-type="idl-name" href="#enumdef-barenum">BarEnum</a> <a data-type="BarEnum" href="#dom-foo-bar">bar</a>;
   attribute DOMString <a data-type="DOMString" href="#dom-foo-_or">_or</a>;
   Promise &lt;any> <a href="#dom-foo-get">get</a>(<a data-link-type="idl-name">int</a> <a class="idl-code" data-link-type="argument" href="#dom-foo-get-a-a">a</a>);
 };


### PR DESCRIPTION
WebVTT uses empty-string enums in IDL. I had an outdated bikeshed
that raised an exception for this. The current bikeshed works fine
but I figured there should be a test for it so it doesn't regress.