### PR TITLE
WebAppSec: Presubmit bits and pieces for Echidna.

### DIFF
--- a/bikeshed/include/webappsec/bs-extensions.include
+++ b/bikeshed/include/webappsec/bs-extensions.include
@@ -1,0 +1,12 @@
+def BSPrepTR(doc):
+  for el in findAll("link", doc):
+    # Make sure the W3C stylesheet is after all other styles.
+    if el.get("href").startswith("https://www.w3.org/StyleSheets/TR"):
+      appendChild(find("head", doc), el)
+  # TODO(mkwst): Uncomment this once https://github.com/w3c/echidna/issues/282 is fixed.
+  #  for el in findAll("a[href]", doc):
+  #    if el.get("href").startswith("http://www.w3.org") or el.get("href").startswith("http://lists.w3.org"):
+  #      el.set("href", "https" + el.get("href")[4:])
+
+def BSPublishAdditionalFiles(defaultFiles):
+  return defaultFiles


### PR DESCRIPTION
WDYT, @tabatkins? This seems to work for me locally (https://www.w3.org/TR/2016/WD-CSP3-20160621/ went through, anyway...).