### PR TITLE
Remove repo issue tracking for WG21

### DIFF
--- a/bikeshed/include/wg21/defaults.include
+++ b/bikeshed/include/wg21/defaults.include
@@ -1,3 +1,4 @@
 {
     "Default Highlight": "c++"
+,   "Boilerplate": "repository-issue-tracking off"
 }


### PR DESCRIPTION
Most WG21 people use their own repos, issue tracking is weird with WG21 and non-centralized.