### PR TITLE
Add space after figure counter

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -472,7 +472,7 @@ class Spec(object):
                 counter-increment: figure;
             }
             figcaption:not(.no-marker)::before {
-                content: "Figure " counter(figure);
+                content: "Figure " counter(figure) " ";
             }'''
         self.extraScripts = defaultdict(str);
 


### PR DESCRIPTION
Figure counters are inlined, so they run into the caption without this space.