### PR TITLE
Markup 'Assert:' as an assertion box.

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -35,6 +35,7 @@ class MetadataManager:
         self.rawStatus = None
 
         # optional metadata
+        self.assertionClass = "assertion"
         self.advisementClass = "advisement"
         self.atRisk = []
         self.audience = []
@@ -666,6 +667,9 @@ def parseDoc(doc):
     for el in findAll(".replace-with-issue-class", doc):
         removeClass(el, "replace-with-issue-class")
         addClass(el, doc.md.issueClass)
+    for el in findAll(".replace-with-assertion-class", doc):
+        removeClass(el, "replace-with-assertion-class")
+        addClass(el, doc.md.assertionClass)
     for el in findAll(".replace-with-advisement-class", doc):
         removeClass(el, "replace-with-advisement-class")
         addClass(el, doc.md.advisementClass)
@@ -710,6 +714,7 @@ parseLiteralList = lambda k,v,l: [v]
 knownKeys = {
     "Abstract": Metadata("Abstract", "abstract", joinList, parseLiteralList),
     "Advisement Class": Metadata("Advisement Class", "advisementClass", joinValue, parseLiteral),
+    "Assertion Class": Metadata("Assertion Class", "assertionClass", joinValue, parseLiteral),
     "At Risk": Metadata("At Risk", "atRisk", joinList, parseLiteralList),
     "Audience": Metadata("Audience", "audience", joinList, parseAudience),
     "Block Elements": Metadata("Block Elements", "blockElements", joinList, parseCommaSeparated),

--- a/bikeshed/include/stylesheet.include
+++ b/bikeshed/include/stylesheet.include
@@ -29,6 +29,7 @@
  *   - .note       for informative notes             (div, p, span, aside, details)
  *   - .example    for informative examples          (div, p, pre, span)
  *   - .issue      for issues                        (div, p, span)
+ *   - .assertion  for assertions                    (div, p, span)
  *   - .advisement for loud normative statements     (div, p, strong)
  *   - .annoying-warning for spec obsoletion notices (div, aside, details)
  *
@@ -592,7 +593,7 @@
 /*                             Colored Boxes                                  */
 /******************************************************************************/
 
-	.issue, .note, .example, .advisement, blockquote {
+	.issue, .note, .example, .assertion, .advisement, blockquote {
 		padding: .5em;
 		border: .5em;
 		border-left-style: solid;
@@ -607,6 +608,7 @@
 	.note,
 	.example,
 	.advisement,
+	.assertion,
 	blockquote {
 		margin: 1em auto;
 	}
@@ -684,6 +686,14 @@
 	}
 	details.note[open] > summary {
 		border-bottom: 1px silver solid;
+	}
+
+/** Assertion Box *************************************************************/
+	/*  for assertions in algorithms */
+
+	.assertion {
+		border-color: #AAA;
+		background: #EEE;
 	}
 
 /** Advisement Box ************************************************************/

--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -337,6 +337,8 @@ def parseParagraph(stream):
 	elif line.lower().startswith("issue:"):
 		line = line[6:]
 		p = "<p class='replace-with-issue-class'>"
+	elif line.lower().startswith("assert:"):
+		p = "<p class='replace-with-assertion-class'>"
 	elif line.lower().startswith("advisement:"):
 		line = line[11:]
 		p = "<strong class='replace-with-advisement-class'>"


### PR DESCRIPTION
@tabatkins: WDYT? I've started using `Assert: This is an assertion!` in algorithms, and I've seen them pop up in other specs (like HTML) as well; it would be nice to highlight them somehow. Here I've just copied the advisement styling, but perhaps you CSS folks have a sense of style that might guide you to something prettier?

You can see the way it looks in https://w3c.github.io/webappsec-secure-contexts/#settings-object.