### PR TITLE
htmlserializer has moved

### DIFF
--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -3,7 +3,7 @@ from __future__ import division, unicode_literals
 import hashlib
 import html5lib
 from html5lib import treewalkers
-from html5lib.serializer import htmlserializer
+from html5lib import serializer
 from lxml import html
 from lxml import etree
 from lxml.cssselect import CSSSelector


### PR DESCRIPTION
html5lib/html5lib-python@6c30d0bd7d5dfa4722368a8dabc637d057350185
(first released in html5lib 0.99999999) changed the location of the
serializer namespace, causing bikeshed to break.  This updates bikeshed
to use the new location of the namespace.