### PR TITLE
Bikeshed is sort of installable with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7-wheezy
+
+RUN apt-get install libxslt1-dev libxml2-dev
+
+RUN pip install pygments
+RUN pip install lxml --upgrade
+
+COPY . /usr/bikeshed
+
+RUN pip install --editable /usr/bikeshed

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  bikeshed:
+    build: .
+    working_dir: /home/bikeshed
+    volumes:
+        - $PWD:/home/bikeshed
+        - $BIKESHED_CODE_PATH:/usr/bikeshed
+        - $BIKESHED_CODE_PATH/volume/bikeshed:/usr/local/bin/bikeshed
+    

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,34 @@ If you want to run a local copy of Bikeshed rather than use the cgi version, itâ
 
 You need to install Python 2.7, PIP, and a few other support libraries before installing Bikeshed itself. Here is how to do this on Debian-based Linuxen (anything using `apt`), OS X, and Windows 7/8/10:
 
+Install steps with Docker
+-------------------------
+
+1. Install Docker
+2. Install Docker compose
+
+````bash
+git clone https://github.com/tabatkins/bikeshed.git
+cd bikeshed
+# Create environment variable used in docker-services.yml file
+# Save this to your .bashrc or something to save from doing it every time
+BIKESHED_CODE_PATH=/path/to/bikeshed/code
+docker-compose -f $BIKESHED_CODE_PATH/docker-services.yml build bikeshed
+docker-compose -f $BIKESHED_CODE_PATH/docker-services.yml run bikeshed pip install --editable /usr/bikeshed
+````
+
+````bash
+alias bikeshed='docker-compose -f $BIKESHED_CODE_PATH/docker-services.yml run bikeshed bikeshed'
+````
+
+````bash
+bikeshed update
+````
+
+
+
+
+
 Linux steps
 -----------
 

--- a/volume/bikeshed
+++ b/volume/bikeshed
@@ -1,0 +1,12 @@
+#!/usr/local/bin/python2
+# EASY-INSTALL-ENTRY-SCRIPT: 'Bikeshed','console_scripts','bikeshed'
+__requires__ = 'Bikeshed'
+import re
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(
+        load_entry_point('Bikeshed', 'console_scripts', 'bikeshed')()
+    )


### PR DESCRIPTION
Sort of follow up to https://github.com/heycam/webidl/issues/171

**Disclaimer:** I know close to nothing about Python, I know close to nothing about Bikeshed (I just discovered the .bs format <sub>which I think is a brilliant file extension, but that's for another day</sub>)

This PR adds the necessary couple of things to run bikeshed in a Docker container.

I managed to do `bikeshed update` and a `bikeshed spec` (on the webidl spec) successfully without ever having to install bikeshed directly on my machine, only inside a docker container.

Benefits:
- This shifts the [concern](https://github.com/heycam/webidl/issues/171#issuecomment-245936356) of "the "let's globally install untrusted code as root" issue" from whatever was needed to be installed globally to only Docker (which people can choose to not trust either but that's a different problem. It's sort of their job to be thoughtful about what they do as root, so I trust them)
- This removes the burden of "what Python version do I have to install/remove?". All the Bikeshed-related Python version thing and dependencies are inside the docker image. Bikeshed becomes an executable, nobody needs to know the Python version to run it. Remove the docker image, your computer will look as if bikeshed was never there.

There are a few minor downsides like the fact that the files generated by the container end up being chwon-ed by `root`. It's easily fixable, but that wasn't the priority.
Also, the container can look at files in $PWD and deeper in the hierarchy, but cannot look upwards. I don't know enough how bikeshed works to understand whether that limitations is a big deal.

This is all not perfect and a bit drafty, but I'm making the PR to spark a discussion and maybe interest. If you're interested in moving this forward, I can spend a bit more time on this. If no one cares enough, just close the PR.

> Several people have complained about wanting me to use one of the virtualization options out there, but I have no familiarity with them whatsoever, and nobody wants to put in sufficient effort to document it for me. Current instructions just install things "the normal way" that you see in the wild, which is unsafe but eh.

I'm happy to set up a call so I can share the little I know about docker, docker-compose and what is in this PR.
