### PR TITLE
Import 'escapeAttr' from htmlhelpers in markdown.py

### DIFF
--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -3,6 +3,7 @@ from __future__ import division, unicode_literals
 import re
 from itertools import *
 from .messages import *
+from .htmlhelpers import escapeAttr
 
 
 def parse(lines, numSpacesForIndentation, features=None, opaqueElements=None, blockElements=None):


### PR DESCRIPTION
Without the import, I get this error:

```
Traceback (most recent call last):
  File "/home/kb/.local/bin/bikeshed", line 9, in <module>
    load_entry_point('Bikeshed==0.0.0', 'console_scripts', 'bikeshed')()
  File "/path/to/bikeshed/bikeshed/__init__.py", line 191, in main
    doc.preprocess()
  File "/path/to/bikeshed/bikeshed/__init__.py", line 516, in preprocess
    self.lines = markdown.parse(self.lines, self.md.indent, opaqueElements=self.md.opaqueElements, blockElements=self.md.blockElements)
  File "/path/to/bikeshed/bikeshed/markdown.py", line 9, in parse
    tokens = tokenizeLines(lines, numSpacesForIndentation, features, opaqueElements=opaqueElements, blockElements=blockElements)
  File "/path/to/bikeshed/bikeshed/markdown.py", line 84, in tokenizeLines
    classAttr = " class='language-{0}'".format(escapeAttr(lang))
NameError: global name 'escapeAttr' is not defined
```