### PR TITLE
Add support for displaying Can I Use compat data summaries in specs

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -54,6 +54,7 @@ class MetadataManager:
         self.h1 = None
         self.ignoredTerms = []
         self.ignoredVars = []
+        self.includeCanIUsePanels = False
         self.indent = 4
         self.inlineGithubIssues = False
         self.issueClass = "issue"
@@ -808,6 +809,7 @@ knownKeys = {
     "Ignored Terms": Metadata("Ignored Terms", "ignoredTerms", joinList, parseCommaSeparated),
     "Ignored Vars": Metadata("Ignored Vars", "ignoredVars", joinList, parseCommaSeparated),
     "Indent": Metadata("Indent", "indent", joinValue, parseInteger),
+    "Include Can I Use Panels": Metadata("Include Can I Use Panels", "includeCanIUsePanels", joinValue, parseBoolean),
     "Inline Github Issues": Metadata("Inline Github Issues", "inlineGithubIssues", joinValue, parseBoolean),
     "Issue Class": Metadata("Issue Class", "issueClass", joinValue, parseLiteral),
     "Issue Tracker Template": Metadata("Issue Tracker Template", "issueTrackerTemplate", joinValue, parseLiteral),

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import division, unicode_literals
 import re
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import io
 import os
 import sys
@@ -96,6 +96,7 @@ def main():
     updateParser = subparsers.add_parser('update', help="Update supporting files (those in /spec-data).", epilog="If no options are specified, everything is downloaded.")
     updateParser.add_argument("--anchors", action="store_true", help="Download crossref anchor data.")
     updateParser.add_argument("--biblio", action="store_true", help="Download biblio data.")
+    updateParser.add_argument("--caniuse", action="store_true", help="Download Can I Use... data.")
     updateParser.add_argument("--link-defaults", dest="linkDefaults", action="store_true", help="Download link default data.")
     updateParser.add_argument("--test-suites", dest="testSuites", action="store_true", help="Download test suite data.")
 
@@ -182,7 +183,7 @@ def main():
 
     update.fixupDataFiles()
     if options.subparserName == "update":
-        update.update(anchors=options.anchors, biblio=options.biblio, linkDefaults=options.linkDefaults, testSuites=options.testSuites)
+        update.update(anchors=options.anchors, biblio=options.biblio, caniuse=options.caniuse, linkDefaults=options.linkDefaults, testSuites=options.testSuites)
     elif options.subparserName == "spec":
         doc = Spec(inputFilename=options.infile, debug=options.debug, token=options.ghToken, lineNumbers=options.lineNumbers)
         doc.md = metadata.fromCommandLine(extras, doc)
@@ -325,6 +326,7 @@ class Spec(object):
         self.md = metadata.MetadataManager(doc=self)
         self.biblios = {}
         self.macros = defaultdict(lambda x: "???")
+        self.canIUse = json.loads(config.retrieveDataFile("caniuse.json", quiet=True, str=True), object_pairs_hook=OrderedDict)
         self.widl = parser.Parser(ui=IDLSilent())
         self.testSuites = json.loads(config.retrieveDataFile("test-suites.json", quiet=True, str=True))
         self.languages = json.loads(config.retrieveDataFile("languages.json", quiet=True, str=True))
@@ -561,6 +563,7 @@ class Spec(object):
         formatArgumentdefTables(self)
         formatElementdefTables(self)
         processAutolinks(self)
+        addCanIUsePanels(self)
         boilerplate.addIndexSection(self)
         boilerplate.addExplicitIndexes(self)
         boilerplate.addStyles(self)
@@ -1612,6 +1615,143 @@ def addDfnPanels(doc, dfns):
 
         .dfn-paneled { cursor: pointer; }
         '''
+
+def addCanIUsePanels(doc):
+    # Constructs "Can I Use panels" which show a compatibility data summary
+    # for a term's feature.
+    if not doc.md.includeCanIUsePanels:
+        return
+
+    features = doc.canIUse["data"]
+    lastUpdated = datetime.utcfromtimestamp(doc.canIUse["updated"]).date().isoformat()
+
+    # e.g. 'ios_saf' -> 'iOS Safari'
+    codeNameToFullName = OrderedDict( # sorted by full name
+        sorted(
+            [
+                (agentCodeName, agent["browser"])
+                for agentCodeName, agent
+                in doc.canIUse["agents"].iteritems()
+            ],
+            key=lambda p: p[1]
+        )
+    )
+    atLeastOnePanel = False
+    caniuseDfnElementsSelector = ",".join(
+        selector + "[caniuse]"
+        for selector in config.dfnElementsSelector.split(",")
+    )
+    for dfn in findAll(caniuseDfnElementsSelector, doc):
+        featId = dfn.get("caniuse")
+        if not featId:
+            continue
+        del dfn.attrib["caniuse"]
+
+        featId = featId.lower()
+        if featId not in features:
+            die("Unrecognized Can I Use feature ID: {0}", featId)
+        feature = features[featId]
+
+        addClass(dfn, "caniuse-paneled")
+        panel = canIUsePanelFor(codeNameToFullName, featId, feature['stats'], lastUpdated)
+        appendChild(dfn, panel)
+        atLeastOnePanel = True
+
+    if atLeastOnePanel:
+        doc.extraScripts['script-caniuse-panel'] = '''
+        document.body.addEventListener("click", function(e) {
+            if(e.target.classList.contains("caniuse-panel-btn")) {
+                e.target.parentNode.classList.toggle("wrapped");
+            }
+        });
+        '''
+        doc.extraStyles['style-caniuse-panel'] = ''
+
+
+def canIUsePanelFor(codeNameToFullName, featId, featStats, lastUpdated):
+    panel = E.div({"class": "status", "data-deco": ""})
+    appendChild(panel, E.input({"value": u"\u22F0", "type": "button", "class":"caniuse-panel-btn"}))
+    mainPara = E.p({"class": "support"})
+    strong = E.strong({}, "Support:")
+    appendChild(mainPara, strong)
+    for browserCodeName, browserFullName in codeNameToFullName.iteritems():
+        statusCode, minVersion = compatSummaryFor(featStats[browserCodeName])
+        if statusCode == "u":
+            continue
+        appendChild(
+            mainPara,
+            browserCompatSpan(browserCodeName, browserFullName, statusCode, minVersion))
+    appendChild(panel, mainPara)
+    attribution = E.p({"class": "caniuse"}, "Source: ")
+    anchor = E.a({"href": "http://caniuse.com/#feat=" + featId}, "caniuse.com")
+    anchor.tail = " as of " + lastUpdated
+    appendChild(attribution, anchor)
+    appendChild(panel, attribution)
+    return panel
+
+
+def compatSummaryFor(versionToStatus):
+    bestStatusYet = "u"
+    lowestGoodVersion = None
+    versionsDescending = versionToStatus.keys()
+    versionsDescending.reverse()  # In the original JSON, they're in ascending order.
+    for version in versionsDescending:
+        status = versionToStatus[version]
+        if "u" in status:
+            continue
+        # Simplify vendor-prefi(x)ed/(d)isabled-by-default/(p)olyfilled to u(n)supported
+        # And remove notes etc. by canonicalizing to single char.
+        if "x" in status or "d" in status or "n" in status or "p" in status:
+            status = "n"
+        elif "a" in status:
+            status = "a"
+        elif "y" in status:
+            status = "y"
+        # assert status in "nay"
+
+        if bestStatusYet == "u":
+            # 1st datapoint
+            bestStatusYet = status
+            lowestGoodVersion = version
+            continue
+
+        if "n" in status:  # It Got Worse (or is still unsupported)
+            break
+
+        if status == bestStatusYet:
+            # New winner
+            lowestGoodVersion = version
+        else:
+            # Either: Old version was buggy, new version is fixed.
+            # Or: New version introduced bug(s); you can be no better than your last release.
+            break
+
+    return bestStatusYet, lowestGoodVersion
+
+
+def browserCompatSpan(browserCodeName, browserFullName, statusCode, minVersion=None):
+    if statusCode == "n" or minVersion is None:
+        minVersion = "None"
+    elif minVersion == "all":
+        minVersion = "All"
+    else:
+        # If the version is a range (e.g. "9.0-9.2"), just use the lower bound (e.g. "9.0").
+        minVersion = minVersion.partition('-')[0] + "+"
+    # browserCodeName: e.g. and_chr, ios_saf, ie, etc...
+    # browserFullName: e.g. "Chrome for Android"
+    statusClass = {"y": "yes", "n": "no", "a": "partial"}[statusCode]
+    outer = E.span({"class": "{} {}".format(browserCodeName, statusClass)})
+    nameSpan = E.span({}, browserFullName)
+    if statusCode == "a":
+        nameSpan.tail = " (limited)"
+        nameWrapper = E.span()
+        appendChild(nameWrapper, nameSpan)
+        appendChild(outer, nameWrapper)
+    else:
+        appendChild(outer, nameSpan)
+    versionSpan = E.span({}, minVersion)
+    appendChild(outer, versionSpan)
+    return outer
 
 
 class DebugMarker(object):

--- a/bikeshed/update.py
+++ b/bikeshed/update.py
@@ -14,14 +14,15 @@ from .messages import *
 
 from .apiclient.apiclient import apiclient
 
-
-def update(anchors=False, biblio=False, linkDefaults=False, testSuites=False):
+def update(anchors=False, biblio=False, caniuse=False, linkDefaults=False, testSuites=False):
     # If all are False, update everything
-    updateAnyway = not (anchors or biblio or linkDefaults or testSuites)
+    updateAnyway = not (anchors or biblio or caniuse or linkDefaults or testSuites)
     if anchors or updateAnyway:
         updateCrossRefs()
     if biblio or updateAnyway:
         updateBiblio()
+    if caniuse or updateAnyway:
+        updateCanIUse()
     if linkDefaults or updateAnyway:
         updateLinkDefaults()
     if testSuites or updateAnyway:
@@ -281,6 +282,26 @@ def updateBiblio():
                 fh.write(unicode(json.dumps(allNames, indent=0, ensure_ascii=False, sort_keys=True)))
         except Exception, e:
             die("Couldn't save biblio database to disk.\n{0}", e)
+            return
+    say("Success!")
+
+
+def updateCanIUse():
+    say("Downloading Can I Use data...")
+    try:
+        with closing(urllib2.urlopen("https://raw.githubusercontent.com/Fyrd/caniuse/master/fulldata-json/data-2.0.json")) as fh:
+            jsonString = fh.read()
+        # Check that the data is valid JSON
+        json.loads(jsonString)
+    except Exception, e:
+        die("Couldn't download the Can I Use data.\n{0}", e)
+        return
+    if not config.dryRun:
+        try:
+            with closing(io.open(config.scriptPath + "/spec-data/caniuse.json", 'wb')) as fh:
+                fh.write(jsonString)
+        except Exception, e:
+            die("Couldn't save Can I Use database to disk.\n{0}", e)
             return
     say("Success!")
 

--- a/tests/caniuse001.bs
+++ b/tests/caniuse001.bs
@@ -1,0 +1,18 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: LS
+ED: http://example.com/foo
+Abstract: Testing Can I Use panel generation.
+Editor: Example Editor
+Date: 1970-01-01
+Include Can I Use Panels: yes
+</pre>
+
+<p>The
+<dfn caniuse="insert-adjacent"><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>
+method has a rich history. Place the <var>element</var> <var>where</var> ever
+you want!</p>

--- a/tests/caniuse001.html
+++ b/tests/caniuse001.html
@@ -1,0 +1,204 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Foo</title>
+  <meta content="Bikeshed 1.0.0" name="generator">
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
+<style>/* style-caniuse-panel */
+</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1>Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>Testing Can I Use panel generation.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ol>
+   </ol>
+  </nav>
+  <main>
+   <p>The <dfn class="caniuse-paneled css" data-dfn-type="function" data-export="" data-lt="insertAdjacentElement()" id="funcdef-insertadjacentelement"><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code><div class="status" data-deco=""><input class="caniuse-panel-btn" type="button" value="⋰"><p class="support"><strong>Support:</strong><span class="android yes"><span>Android Browser</span><span>2.3+</span></span><span class="bb yes"><span>Blackberry Browser</span><span>7+</span></span><span class="chrome yes"><span>Chrome</span><span>4+</span></span><span class="and_chr yes"><span>Chrome for Android</span><span>51+</span></span><span class="edge yes"><span>Edge</span><span>12+</span></span><span class="firefox yes"><span>Firefox</span><span>48+</span></span><span class="and_ff yes"><span>Firefox for Android</span><span>48+</span></span><span class="ie yes"><span>IE</span><span>6+</span></span><span class="ie_mob yes"><span>IE Mobile</span><span>10+</span></span><span class="opera yes"><span>Opera</span><span>9.5+</span></span><span class="op_mini yes"><span>Opera Mini</span><span>All</span></span><span class="op_mob yes"><span>Opera Mobile</span><span>10+</span></span><span class="safari yes"><span>Safari</span><span>3.1+</span></span><span class="samsung yes"><span>Samsung Internet</span><span>4+</span></span><span class="and_uc yes"><span>UC Browser for Android</span><span>9.9+</span></span><span class="ios_saf yes"><span>iOS Safari</span><span>3.2+</span></span></p><p class="caniuse">Source: <a href="http://caniuse.com/#feat=insert-adjacent">caniuse.com</a> as of 2016-09-28</p></div><a class="self-link" href="#funcdef-insertadjacentelement"></a></dfn> method has a rich history. Place the <var>element</var> <var>where</var> ever
+you want!</p>
+  </main>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
+  <ul class="index">
+   <li><a href="#funcdef-insertadjacentelement">insertAdjacentElement()</a><span>, in §Unnumbered section</span>
+  </ul>
+<script>/* script-caniuse-panel */
+
+        document.body.addEventListener("click", function(e) {
+            if(e.target.classList.contains("caniuse-panel-btn")) {
+                e.target.parentNode.classList.toggle("wrapped");
+            }
+        });
+        </script>


### PR DESCRIPTION
Fixes #645. I've tried to take all the suggestions from there into account.
This currently generates the same DOM structure as the panels in the WHATWG HTML spec.
Due to licensing uncertainties, this does not include the CSS snippet from WHATWG HTML.