### PR TITLE
addCustomBoilerplate had reference to undefined var 'target'

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -107,7 +107,8 @@ def addStyles(doc):
 def addCustomBoilerplate(doc):
     for el in findAll('[boilerplate]', doc):
         bType = el.get('boilerplate')
-        if bType in doc.fillContainers:
+        if bType in doc.fillContainers and len(doc.fillContainers[bType]) > 0:
+            target = doc.fillContainers[bType][0]
             replaceContents(target, el)
             removeNode(el)
 


### PR DESCRIPTION
https://github.com/tabatkins/bikeshed/commit/bdec26aaef62eaccaab681c49f76145df6700641 breaks the `addCustomBoilerplate` method since `target` is now undefined.

Not sure whether this is the right behavior now but without working `addCustomBoilerplate`, the `boilerplate-substitution001.bs` test will break.