### PR TITLE
tests/markdown011.bs: no more underscore em/strong, #826

### DIFF
--- a/tests/markdown011.html
+++ b/tests/markdown011.html
@@ -178,7 +178,7 @@
   </nav>
   <main>
    <p>Text is <em>wonderful</em>. <strong>Amazing</strong> even.</p>
-   <p>Text is <em>wonderful</em>. <strong>Amazing</strong> even.</p>
+   <p>Text is _wonderful_. __Amazing__ even.</p>
    <p><strong>SO GREAT</strong></p>
    <p>un<em>frigging</em>believable</p>
    <p><strong>High-light 1337! @twitter #hashtag ☃</strong></p>


### PR DESCRIPTION
Can be reenabled when/if there's a proper fix but not changing the test
makes Travis CI sad.