### PR TITLE
Docs fix

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -6,6 +6,7 @@ Level: 1
 Status: LS
 URL: https://tabatkins.github.io/bikeshed/
 Editor: Tab Atkins-Bittner
+Issue Tracking: GitHub https://github.com/tabatkins/bikeshed/issues/
 Abstract: Bikeshed is a spec-generating tool that takes in lightly-decorated Markdown and spits out a full spec, with cross-spec autolinking, automatic generation of indexes/ToC/etc, and many other features.
 Markup Shorthands: css no, markdown yes
 Ignored Terms: h1, h2, h3, h4, h5, h6, xmp

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -848,7 +848,7 @@ Providing Custom Definitions {#custom-dfns}
 If you want to link to dfns in specs that aren't yet part of the autolinking database,
 you can provide your own definition data that Bikeshed can use.
 Within a `<pre class='anchors'>` element,
-define the anchors you need in [InfoTree format](infotree.md),
+define the anchors you need in [InfoTree format](#infotree),
 with the following keys:
 
 * **text** - the linking text for the definition. (Exactly 1 required.)
@@ -1080,9 +1080,9 @@ but you typically want to make the same choice every time the term is autolinked
 this can be done by adding Link Defaults metadata.
 
 You can either add a Link Defaults metadata line to your `<pre class=metadata>`,
-as specified in [metadata](metadata.md),
+as specified in [[#metadata]],
 or add a `<pre class='link-defaults'>` block,
-written in the [InfoTree](infotree.md) format.
+written in the [InfoTree](#infotree) format.
 For the latter,
 each piece of info must have a `spec`, `type`, and `text` line,
 and optionally a `for` line if necessary to further disambiguate.
@@ -1091,7 +1091,7 @@ Sometimes this is too fine-grained,
 and you'd actually like to completely ignore a given spec when autolinking,
 always preferring to link to something else.
 To do this, add a `<pre class='ignored-specs'>` block,
-written in the [InfoTree](infotree.md) format.
+written in the [InfoTree](#infotree) format.
 Each piece of info must have a `spec` line,
 and optionally a `replacedBy` line,
 both naming specs.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1575,7 +1575,8 @@ but if your group has specific style requirements,
 you can produce your own boilerplate files.
 This section is a basic guide to developing these files.
 
-# Header and Footer {#bp-header-footer}
+Header and Footer {#bp-header-footer}
+=================
 
 The most important part of the boilerplate is the `header.include` and `footer.include` file.
 These define the parts of the spec HTML that precede and follow your actual spec content,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1519,7 +1519,7 @@ Parts of this work may be from another specification document.  If so, those par
       <li><a href="#bp-include"><span class="secno">8.5</span> <span class="content">File-based Includes</span></a>
       <li><a href="#bp-new"><span class="secno">8.6</span> <span class="content">Creating New Boilerplate Files For Your Organization</span></a>
      </ol>
-    <li><a href="#bp-header-footer"><span class="secno">9</span> <span class="content">Header and Footer {#bp-header-footer}</span></a>
+    <li><a href="#bp-header-footer"><span class="secno">9</span> <span class="content">Header and Footer</span></a>
     <li>
      <a href="#railroad"><span class="secno">10</span> <span class="content">Railroad Diagrams</span></a>
      <ol class="toc">
@@ -2963,7 +2963,7 @@ and finally "foo.include".</p>
 but if your group has specific style requirements,
 you can produce your own boilerplate files.
 This section is a basic guide to developing these files.</p>
-   <h2 class="heading settled" data-level="9" id="bp-header-footer"><span class="secno">9. </span><span class="content">Header and Footer {#bp-header-footer}</span><a class="self-link" href="#bp-header-footer"></a></h2>
+   <h2 class="heading settled" data-level="9" id="bp-header-footer"><span class="secno">9. </span><span class="content">Header and Footer</span><a class="self-link" href="#bp-header-footer"></a></h2>
    <p>The most important part of the boilerplate is the <code>header.include</code> and <code>footer.include</code> file.
 These define the parts of the spec HTML that precede and follow your actual spec content,
 so the source file can contain only the actual spec text,

--- a/docs/index.html
+++ b/docs/index.html
@@ -2373,7 +2373,7 @@ Like the other attributes, you can instead add this to a container to have it be
    <p>If you want to link to dfns in specs that aren’t yet part of the autolinking database,
 you can provide your own definition data that Bikeshed can use.
 Within a <code>&lt;pre class='anchors'></code> element,
-define the anchors you need in <a href="infotree.md">InfoTree format</a>,
+define the anchors you need in <a href="#infotree">InfoTree format</a>,
 with the following keys:</p>
    <ul>
     <li data-md="">
@@ -2570,9 +2570,9 @@ You can do this per-link,
 but you typically want to make the same choice every time the term is autolinked;
 this can be done by adding Link Defaults metadata.</p>
    <p>You can either add a Link Defaults metadata line to your <code>&lt;pre class=metadata></code>,
-as specified in <a href="metadata.md">metadata</a>,
+as specified in <a href="#metadata">§2 Metadata</a>,
 or add a <code>&lt;pre class='link-defaults'></code> block,
-written in the <a href="infotree.md">InfoTree</a> format.
+written in the <a href="#infotree">InfoTree</a> format.
 For the latter,
 each piece of info must have a <code>spec</code>, <code>type</code>, and <code>text</code> line,
 and optionally a <code>for</code> line if necessary to further disambiguate.</p>
@@ -2580,7 +2580,7 @@ and optionally a <code>for</code> line if necessary to further disambiguate.</p>
 and you’d actually like to completely ignore a given spec when autolinking,
 always preferring to link to something else.
 To do this, add a <code>&lt;pre class='ignored-specs'></code> block,
-written in the <a href="infotree.md">InfoTree</a> format.
+written in the <a href="#infotree">InfoTree</a> format.
 Each piece of info must have a <code>spec</code> line,
 and optionally a <code>replacedBy</code> line,
 both naming specs.


### PR DESCRIPTION
Makes the Header section use setext style heading for consistency (and for keeping `{#bp-header-footer}` out of the HTML) and fixes a few stray links to old markdown files.

Add Issue tracking information to output.