### PR TITLE
Change maxToCLevel to maxToCDepth

### DIFF
--- a/bikeshed/MetadataManager.py
+++ b/bikeshed/MetadataManager.py
@@ -844,7 +844,7 @@ knownKeys = {
     "Mailing List Archives": Metadata("Mailing List Archives", "mailingListArchives", joinValue, parseLiteral),
     "Mailing List": Metadata("Mailing List", "mailingList", joinValue, parseLiteral),
     "Markup Shorthands": Metadata("Markup Shorthands", "markupShorthands", joinBoolSet, parseMarkupShorthands),
-    "Max Toc Depth": Metadata("Max ToC Depth", "maxToCLevel", joinValue, parseMaxToCDepth),
+    "Max Toc Depth": Metadata("Max ToC Depth", "maxToCDepth", joinValue, parseMaxToCDepth),
     "No Editor": Metadata("No Editor", "noEditor", joinValue, parseBoolean),
     "Note Class": Metadata("Note Class", "noteClass", joinValue, parseLiteral),
     "Opaque Elements": Metadata("Opaque Elements", "opaqueElements", joinList, parseCommaSeparated),


### PR DESCRIPTION
Otherwise we get

```py
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 5, in 
    bikeshed.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/__init__.py", line 195, in main
    doc.preprocess()
  File "/sites/api.csswg.org/bikeshed/bikeshed/__init__.py", line 506, in preprocess
    self.lines, documentMd = metadata.parse(lines=self.lines, doc=self)
  File "/sites/api.csswg.org/bikeshed/bikeshed/MetadataManager.py", line 669, in parse
    md.addData(match.group(1), match.group(2), lineNum=i + 1)
  File "/sites/api.csswg.org/bikeshed/bikeshed/MetadataManager.py", line 117, in addData
    self.addParsedData(key, val)
  File "/sites/api.csswg.org/bikeshed/bikeshed/MetadataManager.py", line 121, in addParsedData
    result = md.join(getattr(self, md.attrName), val)
AttributeError: MetadataManager instance has no attribute 'maxToCLevel'
```