### PR TITLE
Use bikeshed git commit as version string.

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, unicode_literals
-import re
-import copy
 from collections import defaultdict
+import copy
+import os
+import re
+import subprocess
 from .messages import *
 from .htmlhelpers import *
 from .DefaultOrderedDict import DefaultOrderedDict
@@ -13,8 +15,9 @@ def addBikeshedVersion(doc):
     if "generator" not in doc.md.boilerplate:
         return
     head = find("head", doc)
+    bikeshedVersion = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.path.dirname(__file__)).rstrip()
     appendChild(head,
-                E.meta({"name": "generator", "content": "Bikeshed 1.0.0"}))
+                E.meta({"name": "generator", "content": "Bikeshed version %s" % bikeshedVersion}))
 
 
 def addHeaderFooter(doc):

--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, unicode_literals
-from collections import defaultdict
 import copy
 import os
 import re
 import subprocess
+from collections import defaultdict
 from .messages import *
 from .htmlhelpers import *
 from .DefaultOrderedDict import DefaultOrderedDict
@@ -17,7 +17,7 @@ def addBikeshedVersion(doc):
     head = find("head", doc)
     bikeshedVersion = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.path.dirname(__file__)).rstrip()
     appendChild(head,
-                E.meta({"name": "generator", "content": "Bikeshed version %s" % bikeshedVersion}))
+                E.meta({"name": "generator", "content": "Bikeshed version {0}".format(bikeshedVersion)}))
 
 
 def addHeaderFooter(doc):


### PR DESCRIPTION
Since there is no packaged release of bikeshed (i.e., you have to
check out the repository to use it), this is the best way to record
the version of bikeshed used to produce a given output.