### PR TITLE
Fix stdout fails when redirected or piped

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -640,7 +640,7 @@ class Spec(object):
         if not config.dryRun:
             try:
                 if outputFilename == "-":
-                    sys.stdout.write(rendered)
+                    sys.stdout.write(rendered.encode("utf-8"))
                 else:
                     with io.open(outputFilename, "w", encoding="utf-8") as f:
                         f.write(rendered)


### PR DESCRIPTION
This patch fixes when stdout is redirected or piped; e.g.,

$ bikeshed spec Overview.bs - > a

FATAL ERROR: Something prevented me from saving the output document to -:
'ascii' codec can't encode character u'\xa7' in position 729: ordinal not in range(128)
WARNING: Your console does not understand Unicode.
  Messages may be slightly corrupted.
 &#10008;  Did not generate, due to fatal errors