### PR TITLE
add internal-slot dfn type

### DIFF
--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -239,7 +239,7 @@ idlNameTypes = frozenset(["interface", "namespace", "dictionary", "enum", "typed
 functionishTypes = frozenset(["function", "method", "constructor", "stringifier"])
 idlMethodTypes = frozenset(["method", "constructor", "stringifier", "idl", "idl-name"])
 linkTypes = dfnTypes | frozenset(["propdesc", "functionish", "idl", "idl-name", "element-sub", "maybe", "biblio"])
-typesUsingFor = frozenset(["descriptor", "value", "element-attr", "attr-value", "element-state", "method", "constructor", "argument", "attribute", "const", "dict-member", "event", "enum-value", "stringifier", "serializer", "iterator", "maplike", "setlike", "state", "mode", "context", "facet"])
+typesUsingFor = frozenset(["descriptor", "value", "element-attr", "attr-value", "element-state", "method", "constructor", "argument", "attribute", "const", "dict-member", "event", "enum-value", "stringifier", "serializer", "iterator", "maplike", "setlike", "state", "mode", "context", "facet", "internal-slot"])
 typesNotUsingFor = frozenset(["property", "element", "interface", "namespace", "callback", "dictionary", "enum", "exception", "typedef", "http-header"])
 assert not(typesUsingFor & typesNotUsingFor)
 lowercaseTypes = cssTypes | markupTypes | frozenset(["propdesc", "element-sub", "maybe", "dfn", "grammar", "http-header"])

--- a/bikeshed/config.py
+++ b/bikeshed/config.py
@@ -202,6 +202,7 @@ dfnClassToType = {
     "element-statedef"   : "element-state",
     "eventdef"           : "event",
     "interfacedef"       : "interface",
+    "internal-slotdef"   : "internal-slot",
     "namespacedef"       : "namespace",
     "extendedattrdef"    : "extended-attribute",
     "constructordef"     : "constructor",


### PR DESCRIPTION
For #894.

Not making a separate type for internal-method, because "attribute" and "method" are only separate for the sake of enforcing the latter ending in `()` (as it's in `functionishTypes`). It could be added later, but with the convention being to put things outside the linking text like `[[<a>InternalMethod</a>]]()` it wouldn't work as is.