### PR TITLE
Add build script for AppVeyor cloud CI system

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+# See https://packaging.python.org/appveyor/
+
+environment:
+  matrix:
+  - PYTHON: C:\\Python27
+  - PYTHON: C:\\Python27-x64
+install:
+- cmd: >-
+    %PYTHON%\\python -m pip install -U pip wheel setuptools
+
+    %PYTHON%\\python -m pip install -U pygments lxml==3.6.0
+
+    %PYTHON%\\python -m pip install -U flake8
+build_script:
+- cmd: '%PYTHON%\\python.exe -m pip install --editable .'
+test_script:
+- cmd: >-
+    %PYTHON%\\python.exe -m flake8 --exclude=./bikeshed/requests/*,./bikeshed/apiclient/*,./bikeshed/widlparser/* || cmd /c "exit /b 0"
+
+    %PYTHON%\\Scripts\\bikeshed.exe test


### PR DESCRIPTION
This runs the testsuite against both 32-bit and 64-bit Python 2.7 on Windows.

Note: [Badges](https://www.appveyor.com/docs/status-badges/) are available in AppVeyor, but the URL is only available to the project owner, so I couldn't add it as part of this push request.