### PR TITLE
Fixed access issues #922 with temp file on Windows

### DIFF
--- a/bikeshed/publish.py
+++ b/bikeshed/publish.py
@@ -16,6 +16,7 @@ def publishEchidna(doc, username, password, decision, additionalDirectories):
     tar = prepareTar(doc, visibleTar=False, additionalDirectories=additionalDirectories)
     # curl 'https://labs.w3.org/echidna/api/request' --user '<username>:<password>' -F "tar=@/some/path/spec.tar" -F "decision=<decisionUrl>"
     r = requests.post("https://labs.w3.org/echidna/api/request", auth=(username, password), data={"decision": decision}, files={"tar": tar.read()})
+    tar.close()
     os.remove(tar.name)
 
     if r.status_code == 202:


### PR DESCRIPTION
Windows leave's the temp file open while creating the tar which is causing the issue. Closing it makes the error go away and the rest of the process to resume.