### PR TITLE
Install LXML 3.6.0 from PIP for Windows

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -134,13 +134,16 @@ Tested on Windows 7, 8/8.1 & 10
 2. Run the following in an elevated command prompt
 	(change the path if your location is different)
 
-	```
-	setx /m PATH "%PATH%;C:\Python27;C:\Python27\Scripts"
-	```
+```
+setx /m PATH "%PATH%;C:\Python27;C:\Python27\Scripts"
+```
 3. If using Python 2.7.8 or older, install \[PIP](https://pip.pypa.io/en/latest/installing.html)
 	by saving [get-pip.py](https://bootstrap.pypa.io/get-pip.py)
 	and just double clicking the file.
-4. Run `$ python -m pip install pygments lxml==3.6.0`.
+4. Run the following in a command prompt to install or update lxml and Pygments
+```
+python -m pip install pygments lxml==3.6.0 --upgrade
+```
 
 From here, you can proceed to [[#install-common]].
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -140,10 +140,7 @@ Tested on Windows 7, 8/8.1 & 10
 3. Install \[PIP](https://pip.pypa.io/en/latest/installing.html)
 	by saving [get-pip.py](https://bootstrap.pypa.io/get-pip.py)
 	and just double clicking the file.
-4. Install \[LXML](https://pypi.python.org/pypi/lxml/3.4.4)
-	for your version of Python
-	(it should be lxml-3.4.0win32-py2.7.exe)
-5. Run `$ python -m pip install pygments`.
+4. Run `$ python -m pip install pygments lxml==3.6.0`.
 
 From here, you can proceed to [[#install-common]].
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -155,7 +155,7 @@ This is how to set up bikeshed on your android phone or tablet using <a href="ht
 ```
 $ apt install python2 python2-dev clang libxml2-dev libxslt-dev git
 ```
-3. Install the phython dependencies:
+3. Install the Python dependencies:
 ```
 $ pip2 install pygments lxml --upgrade
 ```

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -137,7 +137,7 @@ Tested on Windows 7, 8/8.1 & 10
 	```
 	setx /m PATH "%PATH%;C:\Python27;C:\Python27\Scripts"
 	```
-3. Install \[PIP](https://pip.pypa.io/en/latest/installing.html)
+3. If using Python 2.7.8 or older, install \[PIP](https://pip.pypa.io/en/latest/installing.html)
 	by saving [get-pip.py](https://bootstrap.pypa.io/get-pip.py)
 	and just double clicking the file.
 4. Run `$ python -m pip install pygments lxml==3.6.0`.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -130,10 +130,7 @@ Windows steps {#install-windows}
 
 Tested on Windows 7, 8/8.1 & 10
 
-1. Install the latest [Python 2.7](https://www.python.org/download/releases/2.7.8/).
-	Pick the 32bit version,
-	even on 64bit Windows,
-	as LXML only looks for the 32bit version.
+1. Install the latest [Python 2.7](https://www.python.org/downloads/release/python-2713/).
 2. Run the following in an elevated command prompt
 	(change the path if your location is different)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -418,7 +418,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
+  <meta content="Bikeshed version 12ec7228be5a01a588ae0d03ffd73bcf4e90c501" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-02-04">4 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-02-09">9 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1440,7 +1440,7 @@ svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 4 February 2017,
+In addition, as of 9 February 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1640,22 +1640,18 @@ $ sudo pip install lxml
    <p>Tested on Windows 7, 8/8.1 &amp; 10</p>
    <ol>
     <li data-md="">
-     <p>Install the latest <a href="https://www.python.org/download/releases/2.7.8/">Python 2.7</a>.
-Pick the 32bit version,
-even on 64bit Windows,
-as LXML only looks for the 32bit version.</p>
+     <p>Install the latest <a href="https://www.python.org/downloads/release/python-2713/">Python 2.7</a>.</p>
     <li data-md="">
      <p>Run the following in an elevated command prompt
 (change the path if your location is different)</p>
-<pre>	setx /m PATH "%PATH%;C:\Python27;C:\Python27\Scripts"
+<pre>setx /m PATH "%PATH%;C:\Python27;C:\Python27\Scripts"
 </pre>
     <li data-md="">
-     <p>Install <a href="https://pip.pypa.io/en/latest/installing.html">PIP</a> by saving <a href="https://bootstrap.pypa.io/get-pip.py">get-pip.py</a> and just double clicking the file.</p>
+     <p>If using Python 2.7.8 or older, install <a href="https://pip.pypa.io/en/latest/installing.html">PIP</a> by saving <a href="https://bootstrap.pypa.io/get-pip.py">get-pip.py</a> and just double clicking the file.</p>
     <li data-md="">
-     <p>Install <a href="https://pypi.python.org/pypi/lxml/3.4.4">LXML</a> for your version of Python
-(it should be lxml-3.4.0win32-py2.7.exe)</p>
-    <li data-md="">
-     <p>Run <code>$ python -m pip install pygments</code>.</p>
+     <p>Run the following in a command prompt to install or update lxml and Pygments</p>
+<pre>python -m pip install pygments lxml==3.6.0 --upgrade
+</pre>
    </ol>
    <p>From here, you can proceed to <a href="#install-common">§1.5 Common steps</a>.</p>
    <h3 class="heading settled" data-level="1.4" id="install-termux"><span class="secno">1.4. </span><span class="content">Android + Termux steps</span><a class="self-link" href="#install-termux"></a></h3>
@@ -1668,7 +1664,7 @@ as LXML only looks for the 32bit version.</p>
 <pre>$ apt install python2 python2-dev clang libxml2-dev libxslt-dev git
 </pre>
     <li data-md="">
-     <p>Install the phython dependencies:</p>
+     <p>Install the Python dependencies:</p>
 <pre>$ pip2 install pygments lxml --upgrade
 </pre>
    </ol>
@@ -2586,29 +2582,29 @@ and then strips that much whitespace from it and all following lines.</p>
 the processor automatically pulls it up onto the end of the previous line,
 so there’s no final blank line in the content.</p>
    <p>In other words, you can now write:</p>
-<pre class="highlight"><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">'example'</span><span class="nt">></span>
-  <span class="nt">&lt;p</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">'example'</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>
     An example:
 
-  <span class="nt">&lt;pre</span><span class="nt">></span>
+  <span class="p">&lt;</span><span class="nt">pre</span><span class="p">></span>
     <span class="ni">&amp;lt;</span>ul>
       <span class="ni">&amp;lt;</span>li>one
       <span class="ni">&amp;lt;</span>li>two
     <span class="ni">&amp;lt;</span>/ul>
-  <span class="nt">&lt;/pre></span>
-<span class="nt">&lt;/div></span>
+  <span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 </pre>
    <p>The preprocessor will automatically convert it into:</p>
-<pre class="highlight"><span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">'example'</span><span class="nt">></span>
-  <span class="nt">&lt;p</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">'example'</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>
     An example:
 
-  <span class="nt">&lt;pre</span><span class="nt">></span>
+  <span class="p">&lt;</span><span class="nt">pre</span><span class="p">></span>
 <span class="ni">&amp;lt;</span>ul>
   <span class="ni">&amp;lt;</span>li>one
   <span class="ni">&amp;lt;</span>li>two
-<span class="ni">&amp;lt;</span>/ul><span class="nt">&lt;/pre></span>
-<span class="nt">&lt;/div></span>
+<span class="ni">&amp;lt;</span>/ul><span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 </pre>
    <h3 class="heading settled" data-level="4.7" id="syntax-highlighting"><span class="secno">4.7. </span><span class="content">Syntax Highlighting</span><a class="self-link" href="#syntax-highlighting"></a></h3>
    <p>You can also syntax-highlight code blocks.
@@ -2623,17 +2619,17 @@ See <a href="http://pygments.org/docs/lexers/">http://pygments.org/docs/lexers/<
    <p>Propdef tables are rather large, even when correctly formatted.
 Instead, you can write the table in a simple text format similar to the spec’s metadata block,
 and let the processor automatically generate a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">table</a></code> from it:</p>
-<pre class="highlight"><span class="nt">&lt;pre</span> <span class="na">class=</span><span class="s">'propdef'</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">pre</span> <span class="na">class</span><span class="o">=</span><span class="s">'propdef'</span><span class="p">></span>
 Name: flex-basis
 Value: content | &lt;&lt;'width'>>
 Initial: auto
-Applies to: <span class="nt">&lt;a</span><span class="nt">></span>flex items<span class="nt">&lt;/a></span>
+Applies to: <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>flex items<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span>
 Inherited: no
 Computed value: as specified, with lengths made absolute
-Percentages: relative to the <span class="nt">&lt;a</span><span class="nt">></span>flex container’s<span class="nt">&lt;/a></span> inner <span class="nt">&lt;a</span><span class="nt">></span>main size<span class="nt">&lt;/a></span>
+Percentages: relative to the <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>flex container’s<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span> inner <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>main size<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span>
 Media: visual
 Animation type: length
-<span class="nt">&lt;/pre></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
 </pre>
    <p>The data block is parsed as a series of lines,
 with each line composed of one of the propdef headings, a colon, then the value.</p>
@@ -2735,9 +2731,9 @@ Sometimes there’s lots of repetitive markup that only changes in a few standar
 For whatever reason,
 Bikeshed has the ability to include additional files directly into your spec
 with a &lt;pre class=include> block:</p>
-<pre class="highlight"><span class="nt">&lt;pre</span> <span class="na">class=</span><span class="s">include</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">pre</span> <span class="na">class</span><span class="o">=</span><span class="s">include</span><span class="p">></span>
 path: relative/to/cwd
-<span class="nt">&lt;/pre></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
 </pre>
    <p>Unless <code>path</code> is absolute, bikeshed searches for the file relative to the
 current working directory, i.e. the directory in which bikeshed was launched.</p>
@@ -2752,12 +2748,12 @@ and refer to ones defined by the outer document.</p>
 and want to vary how it’s displayed,
 you can pass additional "local" text macros in the block,
 which are valid only inside the included file:</p>
-<pre class="highlight"><span class="nt">&lt;pre</span> <span class="na">class=</span><span class="s">include</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">pre</span> <span class="na">class</span><span class="o">=</span><span class="s">include</span><span class="p">></span>
 path: template.md
 macros:
   foo: bar
   baz: qux qux qux
-<span class="nt">&lt;/pre></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
 </pre>
    <p>With the above code, you can use <code>[FOO]</code> and <code>[BAZ]</code> macros inside the include file,
 and they’ll be substituted with "bar" and "qux qux qux", respectively.
@@ -2924,7 +2920,7 @@ and those win over the auto-detection.</p>
    <p>If your value doesn’t fit one of these categories,
 you’ll have to tag it manually.
 Just add the type as a boolean attribute to the definition, like</p>
-<pre class="language-html highlight">  attribute DOMString <span class="nt">&lt;dfn</span> <span class="na">attribute</span> <span class="na">for=</span><span class="s">Foo</span><span class="nt">></span>name<span class="nt">&lt;/dfn></span>;
+<pre class="language-html highlight">  attribute DOMString <span class="p">&lt;</span><span class="nt">dfn</span> <span class="na">attribute</span> <span class="na">for</span><span class="o">=</span><span class="s">Foo</span><span class="p">></span>name<span class="p">&lt;</span><span class="p">/</span><span class="nt">dfn</span><span class="p">></span>;
 </pre>
    <p>Alternately, if you’ve got several definitions of the same type that share some container element (such as a <code>&lt;pre></code> or <code>&lt;dl></code>),
 just add a <code>dfn-type="type-goes-here"</code> attribute to the container.
@@ -3003,7 +2999,7 @@ one is inserted between them.</p>
    <p>The <code>spec</code> attribute is used only for index generation, and has no effect on URL generation.</p>
    <p>Example:</p>
 <pre class="language-html highlight"><span class="c">&lt;!--</span><span class="c">line count correction 4</span><span class="c">--></span>
-<span class="nt">&lt;a</span><span class="nt">></span>ascii whitespace<span class="nt">&lt;/a></span> links now!
+<span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>ascii whitespace<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span> links now!
 </pre>
    <p>Alternately, this data can be provided in a file named <code>anchors.bsdata</code>,
 in the same folder as the spec source, but this prevents you from using <a href="https://api.csswg.org/bikeshed/">the web service</a>.</p>
@@ -3269,7 +3265,7 @@ Bikeshed has section links to handle this case more easily:</p>
 <pre class="language-html highlight">[[#heading-id]]
 </pre>
    <p>renders as:</p>
-<pre class="language-html highlight"><span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"#heading-id"</span><span class="nt">></span>§6.1 The Example Section<span class="nt">&lt;/a></span>
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">"#heading-id"</span><span class="p">></span>§6.1 The Example Section<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span>
 </pre>
    <p>Note that this is quite different from normal autolinks;
 rather than matching on text and letting Bikeshed fill in the href,
@@ -3290,8 +3286,8 @@ The syntax is a mixture of a biblio reference and a section link:</p>
 [[CSS-access-19990804#Features]]
 </pre>
    <p>which renders as:</p>
-<pre class="language-html highlight"><span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"https://drafts.csswg.org/css-flexbox-1/#auto-margins"</span><span class="nt">></span>CSS Flexbox 1 §8.1 Aligning with auto margins<span class="nt">&lt;/a></span>
-<span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">"http://www.w3.org/1999/08/NOTE-CSS-access-19990804#Features"</span><span class="nt">></span>Accessibility Features of CSS §Features<span class="nt">&lt;/a></span>
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://drafts.csswg.org/css-flexbox-1/#auto-margins"</span><span class="p">></span>CSS Flexbox 1 §8.1 Aligning with auto margins<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">"http://www.w3.org/1999/08/NOTE-CSS-access-19990804#Features"</span><span class="p">></span>Accessibility Features of CSS §Features<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span>
 </pre>
    <p>If Bikeshed knows about the spec,
 it link-checks you,
@@ -3587,9 +3583,9 @@ if your spec doesn’t define any CSS properties, for example,
 the "property-index" boilerplate won’t generate.
 If you want to suppress their generation even when they do have something to do,
 use the <a data-link-type="dfn" href="#metadata-boilerplate" id="ref-for-metadata-boilerplate-1">Boilerplate</a> metadata, like:</p>
-<pre class="highlight"><span class="nt">&lt;pre</span> <span class="na">class=</span><span class="s">"metadata"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">pre</span> <span class="na">class</span><span class="o">=</span><span class="s">"metadata"</span><span class="p">></span>
 Boilerplate: property-index no
-<span class="nt">&lt;/pre></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
 </pre>
    <h4 class="heading settled" data-level="9.3.2" id="overriding-boilerplate"><span class="secno">9.3.2. </span><span class="content">Overriding Boilerplate</span><a class="self-link" href="#overriding-boilerplate"></a></h4>
    <p>Sometimes a file-based boilerplate (see below) that is appropriate for most of the specs in your group
@@ -3645,32 +3641,32 @@ so the source file can contain only the actual spec text,
 and all specs in the same organization can look similar.</p>
    <p>Here is a basic example <code>header.include</code> file:</p>
 <pre class="language-html highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;html</span> <span class="na">lang=</span><span class="s">"en"</span><span class="nt">></span>
-<span class="nt">&lt;head</span><span class="nt">></span>
-  <span class="nt">&lt;meta</span> <span class="na">http-equiv=</span><span class="s">"Content-Type"</span> <span class="na">content=</span><span class="s">"text/html; charset=utf-8"</span><span class="nt">></span>
-  <span class="nt">&lt;title</span><span class="nt">></span>Bikeshed Documentation<span class="nt">&lt;/title></span>
-  <span class="nt">&lt;style</span><span class="nt">></span>
+<span class="p">&lt;</span><span class="nt">html</span> <span class="na">lang</span><span class="o">=</span><span class="s">"en"</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">head</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">meta</span> <span class="na">http-equiv</span><span class="o">=</span><span class="s">"Content-Type"</span> <span class="na">content</span><span class="o">=</span><span class="s">"text/html; charset=utf-8"</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;</span><span class="p">/</span><span class="nt">title</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">style</span><span class="p">></span>
   <span class="o">.</span><span class="o">.</span><span class="o">.</span>
-  <span class="nt">&lt;/style></span>
-<span class="nt">&lt;/head></span>
-<span class="nt">&lt;body</span> <span class="na">class=</span><span class="s">"h-entry"</span><span class="nt">></span>
-<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"head"</span><span class="nt">></span>
-  <span class="nt">&lt;p</span> <span class="na">data-fill-with=</span><span class="s">"logo"</span><span class="nt">></span><span class="nt">&lt;/p></span>
-  <span class="nt">&lt;h1</span> <span class="na">id=</span><span class="s">"title"</span> <span class="na">class=</span><span class="s">"p-name no-ref"</span><span class="nt">></span>Bikeshed Documentation<span class="nt">&lt;/h1></span>
-  <span class="nt">&lt;h2</span> <span class="na">id=</span><span class="s">"subtitle"</span> <span class="na">class=</span><span class="s">"no-num no-toc no-ref"</span><span class="nt">></span>Living Standard,
-    <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"dt-updated"</span><span class="nt">></span><span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">"value-title"</span> <span class="na">title=</span><span class="s">"20170204"</span><span class="nt">></span>4 February 2017<span class="nt">&lt;/span></span><span class="nt">&lt;/h2></span>
-  <span class="nt">&lt;div</span> <span class="na">data-fill-with=</span><span class="s">"spec-metadata"</span><span class="nt">></span><span class="nt">&lt;/div></span>
-  <span class="nt">&lt;div</span> <span class="na">data-fill-with=</span><span class="s">"warning"</span><span class="nt">></span><span class="nt">&lt;/div></span>
-  <span class="nt">&lt;p</span> <span class="na">class=</span><span class="s">'copyright'</span> <span class="na">data-fill-with=</span><span class="s">'copyright'</span><span class="nt">></span><span class="nt">&lt;/p></span>
-  <span class="nt">&lt;hr</span> <span class="na">title=</span><span class="s">"Separator for header"</span><span class="nt">></span>
-<span class="nt">&lt;/div></span>
+  <span class="p">&lt;</span><span class="p">/</span><span class="nt">style</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">head</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">body</span> <span class="na">class</span><span class="o">=</span><span class="s">"h-entry"</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"head"</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"logo"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">h1</span> <span class="na">id</span><span class="o">=</span><span class="s">"title"</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-name no-ref"</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;</span><span class="p">/</span><span class="nt">h1</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">h2</span> <span class="na">id</span><span class="o">=</span><span class="s">"subtitle"</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span><span class="p">></span>Living Standard,
+    <span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">></span><span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20170209"</span><span class="p">></span>9 February 2017<span class="p">&lt;</span><span class="p">/</span><span class="nt">span</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"spec-metadata"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"warning"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">'copyright'</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">'copyright'</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">hr</span> <span class="na">title</span><span class="o">=</span><span class="s">"Separator for header"</span><span class="p">></span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 
-<span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">'no-num no-toc no-ref'</span> <span class="na">id=</span><span class="s">'abstract'</span><span class="nt">></span>Abstract<span class="nt">&lt;/h2></span>
-<span class="nt">&lt;div</span> <span class="na">class=</span><span class="s">"p-summary"</span> <span class="na">data-fill-with=</span><span class="s">"abstract"</span><span class="nt">></span><span class="nt">&lt;/div></span>
-<span class="nt">&lt;div</span> <span class="na">data-fill-with=</span><span class="s">"at-risk"</span><span class="nt">></span><span class="nt">&lt;/div></span>
+<span class="p">&lt;</span><span class="nt">h2</span> <span class="na">class</span><span class="o">=</span><span class="s">'no-num no-toc no-ref'</span> <span class="na">id</span><span class="o">=</span><span class="s">'abstract'</span><span class="p">></span>Abstract<span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-summary"</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"abstract"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"at-risk"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 
-<span class="nt">&lt;h2</span> <span class="na">class=</span><span class="s">"no-num no-toc no-ref"</span> <span class="na">id=</span><span class="s">"contents"</span><span class="nt">></span>Table of Contents<span class="nt">&lt;/h2></span>
-<span class="nt">&lt;div</span> <span class="na">data-fill-with=</span><span class="s">"table-of-contents"</span><span class="nt">></span><span class="nt">&lt;/div></span>
+<span class="p">&lt;</span><span class="nt">h2</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span> <span class="na">id</span><span class="o">=</span><span class="s">"contents"</span><span class="p">></span>Table of Contents<span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"table-of-contents"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
 </pre>
    <p>This uses several of Bikeshed’s boilerplating features:</p>
    <ul>


### PR DESCRIPTION
This updates the instructions as described in tabatkins/bikeshed#923, bumps the link for 'Latest' Python to the current latest, and applies some minor cosmetic fixes I noticed while I was there.