### PR TITLE
Add nohighlight on the <code> elements in footer.include.

### DIFF
--- a/bikeshed/boilerplate/footer.include
+++ b/bikeshed/boilerplate/footer.include
@@ -17,7 +17,7 @@
 
         <p>
             Examples in this specification are introduced with the words “for example”
-            or are set apart from the normative text with <code>class="example"</code>, like this:
+            or are set apart from the normative text with <code nohighlight>class="example"</code>, like this:
 
         <div class="example">
             This is an example of an informative example.
@@ -25,7 +25,7 @@
 
         <p>
             Informative notes begin with the word “Note”
-            and are set apart from the normative text with <code>class="note"</code>, like this:
+            and are set apart from the normative text with <code nohighlight>class="note"</code>, like this:
 
         <p class='note'>
             Note, this is an informative note.


### PR DESCRIPTION
This prevents the "Default Highlight" setting from causing these elements to get syntax highlighting in the default highlighting language.

Note that using highlight="html" doesn't do anything useful here since it doesn't highlight attributes properly when they're not in elements, so this uses nohighlight.  That also preserves the behavior for specifications that don't set Default Highlight.