### PR TITLE
Update Specref URL

### DIFF
--- a/bikeshed/update.py
+++ b/bikeshed/update.py
@@ -265,7 +265,7 @@ def updateBiblio():
     say("Downloading biblio data...")
     biblios = defaultdict(list)
     try:
-        with closing(urllib2.urlopen("https://specref.herokuapp.com/bibrefs")) as fh:
+        with closing(urllib2.urlopen("https://api.specref.org/bibrefs")) as fh:
             biblio.processSpecrefBiblioFile(unicode(fh.read(), encoding="utf-8"), biblios, order=3)
         with closing(urllib2.urlopen("https://raw.githubusercontent.com/w3c/csswg-drafts/master/biblio.ref")) as fh:
             lines = [unicode(line, encoding="utf-8") for line in fh.readlines()]


### PR DESCRIPTION
Now finally on its own domain name: https://api.specref.org/bibrefs