### PR TITLE
Update issue-filing instructions for WPWG

### DIFF
--- a/bikeshed/boilerplate/webplatform/status-ED.include
+++ b/bikeshed/boilerplate/webplatform/status-ED.include
@@ -9,10 +9,7 @@
   <a href="[REPOSITORYURL]">[REPOSITORYURL]</a>.</strong>
 
 <p>
-  <a href="[REPOSITORYURL]/issues">GitHub Issues</a> are preferred for discussion of this specification.
-  When filing an issue, please put the text “[SHORTNAME]” in the title,
-  preferably like this:
-  “[<!---->[SHORTNAME]] <i>…summary of comment…</i>”.
+  <a href="[REPOSITORYURL]/issues">GitHub issues</a> are preferred for discussion of this specification.
   There is also a <a href="[MAILINGLISTARCHIVES]">historical mailing-list archive</a>.
 
 <p>

--- a/bikeshed/boilerplate/webplatform/status-FPWD.include
+++ b/bikeshed/boilerplate/webplatform/status-FPWD.include
@@ -13,10 +13,7 @@
 </p>
 
 <p>
-  <a href="[REPOSITORYURL]/issues">GitHub Issues</a> are preferred for discussion of this specification.
-  When filing an issue, please put the text “[SHORTNAME]” in the title,
-  preferably like this:
-  “[<!---->[SHORTNAME]] <i>…summary of comment…</i>”.
+  <a href="[REPOSITORYURL]/issues">GitHub issues</a> are preferred for discussion of this specification.
   There is also a <a href="[MAILINGLISTARCHIVES]">historical mailing-list archive</a>.
 
 <p>

--- a/bikeshed/boilerplate/webplatform/status-LCWD.include
+++ b/bikeshed/boilerplate/webplatform/status-LCWD.include
@@ -11,10 +11,7 @@
   as a Working Draft. This document is intended to become a W3C Recommendation.
 
 <p>
-  <a href="[REPOSITORYURL]/issues">GitHub Issues</a> are preferred for discussion of this specification.
-  When filing an issue, please put the text “[SHORTNAME]” in the title,
-  preferably like this:
-  “[<!---->[SHORTNAME]] <i>…summary of comment…</i>”.
+  <a href="[REPOSITORYURL]/issues">GitHub issues</a> are preferred for discussion of this specification.
   There is also a <a href="[MAILINGLISTARCHIVES]">historical mailing-list archive</a>.
 
 <p>

--- a/bikeshed/boilerplate/webplatform/status-WD.include
+++ b/bikeshed/boilerplate/webplatform/status-WD.include
@@ -13,10 +13,7 @@
 </p>
 
 <p>
-  <a href="[REPOSITORYURL]/issues">GitHub Issues</a> are preferred for discussion of this specification.
-  When filing an issue, please put the text “[SHORTNAME]” in the title,
-  preferably like this:
-  “[<!---->[SHORTNAME]] <i>…summary of comment…</i>”.
+  <a href="[REPOSITORYURL]/issues">GitHub issues</a> are preferred for discussion of this specification.
   There is also a <a href="[MAILINGLISTARCHIVES]">historical mailing-list archive</a>.
 
 <p>


### PR DESCRIPTION
WPWG specs use a repository per specification, so the instructions to include the repository name in the issue title are misleading.