### PR TITLE
Editorial fixes

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1544,7 +1544,7 @@ There are several types for CSS values:
 * value (any value that goes inside of a property, at-rule, etc.)
 * type (an abstract type for CSS grammars, like `<length>` or `<image>`)
 * at-rule
-* function (like counter() or linear-gradient())
+* function (like `counter()` or `linear-gradient()`)
 * selector
 
 There are additional types for WebIDL definitions:
@@ -1643,7 +1643,7 @@ Specifically:
 * "argument" definitions must define what method or constructor they're relative to.
 * "dict-member" definitions must define what dictionary they're relative to.
 * "except-field" and "exception-code" definitions must define what exception they're relative to.
-* "enum-value" definitions must define what enum they're relative to
+* "enum-value" definitions must define what enum they're relative to.
 * "element-attr" and "element-state" definitions must define what element they're relative to.
 * "attr-value" definitions must define what element and attribute they're relative to.
 * "descriptor" definitions must define what at-rule they're relative to.
@@ -1698,7 +1698,7 @@ The `spec` attribute is used only for index generation, and has no effect on URL
 
 Example:
 
-```html
+<xmp highlight=html>
 <pre class="anchors">
 urlPrefix: https://encoding.spec.whatwg.org/; type: dfn; spec: ENCODING
 	text: ascii whitespace
@@ -1707,7 +1707,7 @@ url: http://www.unicode.org/reports/tr46/#ToASCII; type: dfn; text: toascii
 </pre>
 
 <a>ascii whitespace</a> links now!
-```
+</xmp>
 
 Alternately, this data can be provided in a file named `anchors.bsdata`,
 in the same folder as the spec source, but this prevents you from using
@@ -2739,7 +2739,7 @@ urlPrefix: https://encoding.spec.whatwg.org/; type: dfn
 	text: utf-8
 ```
 
-Just like the previous, this defines two entries, each with three key/value pairs
+Just like the previous, this defines two entries, each with three key/value pairs.
 Now it's clearer, though, that the two entries share their `urlPrefix` and `type` data,
 and you only have to maintain the common data in one place.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1176,7 +1176,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 0ed25e3fa4c717226b1b404aa7dd5ce7d87bf986" name="generator">
+  <meta content="Bikeshed version aa692b5bb18791d7660cd494994fd0ac2ec23132" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1426,7 +1426,7 @@ svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-04-18">18 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-04-20">20 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1441,7 +1441,7 @@ svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 18 April 2017,
+In addition, as of 20 April 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2910,7 +2910,7 @@ so you can define, for example, both a property and a term with the same linking
     <li data-md="">
      <p>at-rule</p>
     <li data-md="">
-     <p>function (like counter() or linear-gradient())</p>
+     <p>function (like <code>counter()</code> or <code>linear-gradient()</code>)</p>
     <li data-md="">
      <p>selector</p>
    </ul>
@@ -3040,7 +3040,7 @@ This is specified with a <code>for</code> attribute on the definition.</p>
     <li data-md="">
      <p>"except-field" and "exception-code" definitions must define what exception they’re relative to.</p>
     <li data-md="">
-     <p>"enum-value" definitions must define what enum they’re relative to</p>
+     <p>"enum-value" definitions must define what enum they’re relative to.</p>
     <li data-md="">
      <p>"element-attr" and "element-state" definitions must define what element they’re relative to.</p>
     <li data-md="">
@@ -3093,7 +3093,13 @@ If neither <code>urlPrefix</code> nor <code>url</code> had a "#" character in th
 one is inserted between them.</p>
    <p>The <code>spec</code> attribute is used only for index generation, and has no effect on URL generation.</p>
    <p>Example:</p>
-<pre class="language-html highlight"><span class="c">&lt;!--</span><span class="c">line count correction 4</span><span class="c">--></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">pre</span> <span class="na">class</span><span class="o">=</span><span class="s">"anchors"</span><span class="p">></span>
+urlPrefix: https://encoding.spec.whatwg.org/; type: dfn; spec: ENCODING
+  text: ascii whitespace
+  text: decoder
+url: http://www.unicode.org/reports/tr46/#ToASCII; type: dfn; text: toascii
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">pre</span><span class="p">></span>
+
 <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>ascii whitespace<span class="p">&lt;</span><span class="p">/</span><span class="nt">a</span><span class="p">></span> links now!
 </pre>
    <p>Alternately, this data can be provided in a file named <code>anchors.bsdata</code>,
@@ -3755,7 +3761,7 @@ and all specs in the same organization can look similar.</p>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"logo"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h1</span> <span class="na">id</span><span class="o">=</span><span class="s">"title"</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-name no-ref"</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;</span><span class="p">/</span><span class="nt">h1</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h2</span> <span class="na">id</span><span class="o">=</span><span class="s">"subtitle"</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span><span class="p">></span>Living Standard,
-    <span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">></span><span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20170418"</span><span class="p">></span>18 April 2017<span class="p">&lt;</span><span class="p">/</span><span class="nt">span</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
+    <span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">></span><span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20170420"</span><span class="p">></span>20 April 2017<span class="p">&lt;</span><span class="p">/</span><span class="nt">span</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">h2</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"spec-metadata"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"warning"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">'copyright'</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">'copyright'</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
@@ -4091,7 +4097,7 @@ but using nesting to share their common information:</p>
 	text: ascii whitespace
 	text: utf-8
 </pre>
-   <p>Just like the previous, this defines two entries, each with three key/value pairs
+   <p>Just like the previous, this defines two entries, each with three key/value pairs.
 Now it’s clearer, though, that the two entries share their <code>urlPrefix</code> and <code>type</code> data,
 and you only have to maintain the common data in one place.</p>
    <h3 class="heading settled" id="infotree-comments"><span class="content">Comments</span><a class="self-link" href="#infotree-comments"></a></h3>


### PR DESCRIPTION
* Use `<xmp>` for the example in the custom definitions section, since it doesn't render correctly with Markdown code fencing;
* Other editorial fixes.