### PR TITLE
Use rel=prev instead of rel=previous

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -654,7 +654,7 @@ def addSpecMetadataSection(doc):
     if doc.md.ED and doc.md.status in config.snapshotStatuses:
         md["Editor's Draft"].append(E.a({"href": doc.md.ED}, doc.md.ED))
     if len(doc.md.previousVersions):
-        md["Previous Versions"] = [E.a({"href":ver, "rel":"previous"}, ver) for ver in doc.md.previousVersions]
+        md["Previous Versions"] = [E.a({"href":ver, "rel":"prev"}, ver) for ver in doc.md.previousVersions]
     if len(doc.md.versionHistory):
         md["Version History"] = [E.a({"href":vh}, vh) for vh in doc.md.versionHistory]
     if doc.md.mailingList:


### PR DESCRIPTION
https://checker.html5.org/ gives this warning:

> Warning: Potentially bad value previous for attribute rel on element a: The keyword previous for the rel attribute should not be used. Consider using prev instead.