### PR TITLE
Remove sudo from Travis testing script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: python
 python:
  - "2.7"
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-dev python-pip libxslt1-dev libxml2-dev
- - sudo pip install pygments
- - sudo pip install flake8
+ - pip install pygments
+ - pip install flake8
 install:
- - sudo pip install --editable .
+ - pip install --editable .
 before_script:
  - flake8 --exclude=./bikeshed/requests/*,./bikeshed/apiclient/*,./bikeshed/widlparser/* ; true
 script: bikeshed test


### PR DESCRIPTION
Travis runs Python in a virtualenv, so there's no need for sudo.