### PR TITLE
Fix a Python warning

### DIFF
--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1303,7 +1303,7 @@ def classifyDfns(doc, dfns):
         # wrap the contents in a <code>.
         if config.linkTypeIn(dfnType, "codelike"):
             child = hasOnlyChild(el)
-            if child and child.tag == "code":
+            if child is not None and child.tag == "code":
                 pass
             wrapContents(el, E.code())
 


### PR DESCRIPTION
When running bikeshed I got this warning:

```
__init__.py:1306: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if child and child.tag == "code":
```