### PR TITLE
Correct processing of Markdown code spans & blocks

### DIFF
--- a/bikeshed/markdown.py
+++ b/bikeshed/markdown.py
@@ -76,18 +76,6 @@ def tokenizeLines(lines, numSpacesForIndentation, features=None, opaqueElements=
 
         # We're either in a nesting raw element or not in a raw element at all,
         # so check if the line starts a new element.
-        match = re.match("\s*(`{3,}|~{3,})([^`]*)$", rawline)
-        if match:
-            rawStack.append({"type":"fenced", "tag":match.group(1), "nest":False})
-            infoString = match.group(2).strip()
-            if infoString:
-                # For now, I only care about lang
-                lang = infoString.split(" ")[0]
-                classAttr = " class='language-{0}'".format(escapeAttr(lang))
-            else:
-                classAttr = ""
-            tokens.append({'type':'raw', 'raw':'<xmp{0}>'.format(classAttr), 'prefixlen':float('inf'), 'line':i + lineCountCorrection})
-            continue
         match = re.match(r"\s*<({0})[ >]".format(rawElements), rawline)
         if match:
             tokens.append({'type':'raw', 'raw':rawline, 'prefixlen':float('inf'), 'line':i + lineCountCorrection})
@@ -101,6 +89,20 @@ def tokenizeLines(lines, numSpacesForIndentation, features=None, opaqueElements=
         if rawStack:
             tokens.append({'type':'raw', 'raw':rawline, 'prefixlen':float('inf'), 'line':i + lineCountCorrection})
             continue
+
+        match = re.match("\s*(`{3,}|~{3,})([^`]*)$", rawline)
+        if match:
+            rawStack.append({"type":"fenced", "tag":match.group(1), "nest":False})
+            infoString = match.group(2).strip()
+            if infoString:
+                # For now, I only care about lang
+                lang = infoString.split(" ")[0]
+                classAttr = " class='language-{0}'".format(escapeAttr(lang))
+            else:
+                classAttr = ""
+            tokens.append({'type':'raw', 'raw':'<xmp{0}>'.format(classAttr), 'prefixlen':float('inf'), 'line':i + lineCountCorrection})
+            continue
+
 
         line = rawline.strip()
         match = re.match("<!--line count correction (-?\d+)-->", line)

--- a/tests/markdown006.bs
+++ b/tests/markdown006.bs
@@ -16,7 +16,13 @@ Markup Shorthands: markdown on
 
 "code2": This is `code2`.
 
+"code text": This one has `an apostrophe ' which might be tempting to replace`.
+
 "code spaces": This one has `code spaces`.
+
+"code spaces collapsed": This one has `many  code    spaces`.
+
+"code multiple": This one has `more` `than` `one`.
 
 "code link": This one is <a href="#">in a `code link`</a>.
 
@@ -27,6 +33,8 @@ Markup Shorthands: markdown on
 "code block"
 ```
 This is a code block.
+
+Whitespace is  not   collapsed     here.
 ```
 
 "tilda code block"
@@ -35,8 +43,6 @@ this code block has tildas,
 ```
 and isn't closed by backticks
 ```
-TODO: move fixText() into the markdown handler, so it doesn't operate on raw lines;
-TODO: right now it'll make replacements in scripts, which is obviously bad :(
 ~~~
 
 

--- a/tests/markdown006.html
+++ b/tests/markdown006.html
@@ -5,18 +5,23 @@
   <h1>Foo</h1>
   <p>"code1": <code>code1</code></p>
   <p>"code2": This is <code>code2</code>.</p>
+  <p>"code text": This one has <code>an apostrophe ' which might be tempting to replace</code>.</p>
   <p>"code spaces": This one has <code>code spaces</code>.</p>
+  <p>"code spaces collapsed": This one has <code>many code spaces</code>.</p>
+  <p>"code multiple": This one has <code>more</code> <code>than</code> <code>one</code>.</p>
   <p>"code link": This one is <a href="#">in a <code>code link</code></a>.</p>
   <p>"not code": Here’s some `literal backticks`</p>
   <p>"multi-backtick code": This code is <code>delimited ``` by two `s</code>, so it can include single or triple backticks.</p>
   <p>"code block"</p>
 <pre>This is a code block.
+
+Whitespace is  not   collapsed     here.
 </pre>
   <p>"tilda code block"</p>
 <pre>this code block has tildas,
-&lt;code data-opaque>and isn't closed by backticks&lt;/code>
-TODO: move fixText() into the markdown handler, so it doesn’t operate on raw lines;
-TODO: right now it’ll make replacements in scripts, which is obviously bad :(
+```
+and isn't closed by backticks
+```
 </pre>
   <p>foo</p>
   <p>"long code block"</p>

--- a/tests/markdown013.bs
+++ b/tests/markdown013.bs
@@ -1,0 +1,97 @@
+<h1>Foo</h1>
+
+<pre class=metadata>
+Group: test
+Shortname: foo
+Level: 1
+Status: LS
+ED: http://example.com/foo
+Abstract: Test of markdown inline link constructs
+Editor: Example Editor
+Date: 1970-01-01
+Markup Shorthands: markdown on
+</pre>
+
+<pre>
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+</pre>
+
+<xmp>
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+</xmp>
+
+<script>
+/*
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+*/
+</script>
+
+<style>
+/*
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+*/
+</style>

--- a/tests/markdown013.html
+++ b/tests/markdown013.html
@@ -1,0 +1,258 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Foo</title>
+  <link href="http://example.com/foo" rel="canonical">
+<style>
+/*
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+*/
+</style>
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1>Foo</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="1970-01-01">1 January 1970</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="http://example.com/foo">http://example.com/foo</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><span class="p-name fn">Example Editor</span>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">COPYRIGHT GOES HERE </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>Test of markdown inline link constructs</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+  </nav>
+  <main>
+<pre>Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+</pre>
+<pre>Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+</pre>
+<script>
+/*
+Fragment {#fragment}
+========
+
+This text has *emphasis*; this text is **strong**; this text is `code`. This
+text is [a link]().
+
+- a list
+- with dashes
+
+* a list
+* with asterisks
+
+```
+fenced
+ code
+  block
+```
+*/
+</script>
+  </main>


### PR DESCRIPTION
Ensure that the text content of "opaque" elements is not transformed.
Do not apply "code span" transformations to code blocks.

This is intended to resolve gh-1038.