### PR TITLE
Add fileTypes to the tmLanguage file

### DIFF
--- a/Bikeshed.tmLanguage
+++ b/Bikeshed.tmLanguage
@@ -4,7 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string></string>
+		<string>bs</string>
 	</array>
 	<key>name</key>
 	<string>Bikeshed</string>


### PR DESCRIPTION
According to https://manual.macromates.com/en/language_grammars:

> `fileTypes` [...] is an array of file type extensions that the grammar should (by default) be used with.

It does not need to be prefixed with a full stop, so it's `bs` instead of `.bs`.