### PR TITLE
proper escaping of [] in serviceworkers templates

### DIFF
--- a/bikeshed/boilerplate/serviceworkers/status-CR.include
+++ b/bikeshed/boilerplate/serviceworkers/status-CR.include
@@ -12,7 +12,7 @@
   <p>[STATUSTEXT]</p>
 
   <p>
-    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>%5B[SHORTNAME]%5D</code> at the start of your email's subject.
+    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email's subject.
   </p>
  
   <p>

--- a/bikeshed/boilerplate/serviceworkers/status-ED.include
+++ b/bikeshed/boilerplate/serviceworkers/status-ED.include
@@ -10,7 +10,7 @@
   <p>[STATUSTEXT]</p>
 
   <p>
-    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>%5B[SHORTNAME]%5D</code> at the start of your email's subject.
+    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email's subject.
   </p>
   
   <p>

--- a/bikeshed/boilerplate/serviceworkers/status-WD.include
+++ b/bikeshed/boilerplate/serviceworkers/status-WD.include
@@ -10,7 +10,7 @@
   <p>[STATUSTEXT]</p>
 
   <p>
-    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>%5B[SHORTNAME]%5D</code> at the start of your email's subject.
+    Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-webapps@w3.org?subject=%5B[SHORTNAME]%5D">public-webapps@w3.org</a> (<a href="mailto:public-webapps@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>) with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email's subject.
   </p>
   
   <p>


### PR DESCRIPTION
See 3ee78e75729309d4dfc4793df74c38e4ae785832 
