### PR TITLE
adding FIDO status messages

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -69,7 +69,13 @@ shortToLongStatus = {
     "iso/D-AMD": "Draft Amendment",
     "iso/FD-AMD": "Final Draft Amendment",
     "iso/PRF-AMD": "Proof Amendment",
-    "iso/AMD": "Amendment"
+    "iso/AMD": "Amendment",
+    "fido/ED": "Editor's Draft",
+    "fido/WD": "Working Draft",
+    "fido/RD": "Review Draft",
+    "fido/ID": "Implementation Draft",
+    "fido/PS": "Proposed Standard",
+    "fido/FD": "Final Document"
 }
 snapshotStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO"]
 unlevelledStatuses = ["LS", "LD", "DREAM", "w3c/UD", "LS-COMMIT", "LS-BRANCH", "FINDING", "DRAFT-FINDING"]
@@ -80,6 +86,7 @@ megaGroups = {
     "w3c": frozenset(["act-framework", "audiowg", "csswg", "dap", "fxtf", "geolocation", "houdini", "html", "i18n", "mediacapture", "ricg", "serviceworkers", "svg", "texttracks", "uievents", "web-bluetooth-cg", "webappsec", "webauthn", "web-payments", "webperf", "webplatform", "webspecs", "webvr", "wicg"]),
     "tc39": frozenset(["tc39"]),
     "iso": frozenset(["wg21"]),
+    "fido": frozenset(["fido"]),
     "priv-sec": frozenset(["audiowg", "csswg", "dap", "fxtf", "geolocation", "houdini", "html", "mediacapture", "ricg", "svg", "texttracks", "uievents", "web-bluetooth-cg", "webappsec", "webplatform", "webspecs", "whatwg"])
 }
 


### PR DESCRIPTION
Added some new status messages to `status.py` as well as a new `megaGroup` for FIDO -- hopefully that's the right thing to do, but I can update this PR if there needs to be changes. I did test out our statuses with our Bikeshed-based documents and they seem to work as expected. Not sure if there need to be automated tests for statuses or not.

I looked at adding new boilerplate for the status messages, but honestly I think we can just live with the `LONGSTATUS` for now. If we do need boilerplate for statuses we can probably use file-based includes until the text is stable enough to submit our boilerplate to be part of the bikeshed repo.

Comments / questions / feedback / proposed changes / etc. would be welcomed.