### PR TITLE
Patch from hell: Preliminary (non-working) Python 3 support.

### DIFF
--- a/bikeshed/HTMLSerializer.py
+++ b/bikeshed/HTMLSerializer.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division, unicode_literals
-import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    import StringIO
 from .htmlhelpers import childNodes, isElement, outerHTML, escapeHTML, escapeAttr, hasAttrs
 from .messages import *
 

--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -246,7 +246,7 @@ class Spec(object):
                 else:
                     with io.open(outputFilename, "w", encoding="utf-8") as f:
                         f.write(rendered)
-            except Exception, e:
+            except Exception as e:
                 die("Something prevented me from saving the output document to {0}:\n{1}", outputFilename, e)
 
     def printResultMessage(self):
@@ -284,7 +284,7 @@ class Spec(object):
             SocketServer.TCPServer.allow_reuse_address = True
             server = SocketServer.TCPServer(("", port), SilentServer)
 
-            print "Serving at port {0}".format(port)
+            print("Serving at port {0}".format(port))
             thread = threading.Thread(target = server.serve_forever)
             thread.daemon = True
             thread.start()
@@ -315,7 +315,7 @@ class Spec(object):
                     server.shutdown()
                     thread.join()
                 sys.exit(0)
-        except Exception, e:
+        except Exception as e:
             die("Something went wrong while watching the file:\n{0}", e)
 
     def fixText(self, text, moreMacros={}):

--- a/bikeshed/apiclient/apiclient/__init__.py
+++ b/bikeshed/apiclient/apiclient/__init__.py
@@ -12,4 +12,4 @@
 
 __all__ = ['apiclient', 'uritemplate']
 
-import apiclient
+from . import apiclient

--- a/bikeshed/biblio.py
+++ b/bikeshed/biblio.py
@@ -265,7 +265,7 @@ def processSpecrefBiblioFile(text, storage, order):
     import json
     try:
         datas = json.loads(text)
-    except Exception, e:
+    except Exception as e:
         die("Couldn't read the local JSON file:\n{0}", str(e))
         return storage
 

--- a/bikeshed/config/dfnTypes.py
+++ b/bikeshed/config/dfnTypes.py
@@ -47,7 +47,7 @@ dfnClassToType = {
     "http-headerdef"     : "http-header"}
 
 
-dfnTypes = frozenset(dfnClassToType.values() + ["dfn"])
+dfnTypes = frozenset(list(dfnClassToType.values()) + ["dfn"])
 maybeTypes = frozenset(["value", "type", "at-rule", "function", "selector"])
 cssTypes = frozenset(["property", "value", "at-rule", "descriptor", "type", "function", "selector"])
 markupTypes = frozenset(["element", "element-attr", "element-state", "attr-value"])

--- a/bikeshed/config/retrieve.py
+++ b/bikeshed/config/retrieve.py
@@ -40,7 +40,7 @@ def retrieveDataFile(*segs, **kwargs):
             if not quiet:
                 warn("Couldn't save the {0} file to cache. Proceeding...", filetype)
     if str:
-        return unicode(fh.read(), encoding="utf-8")
+        return fh.read() # unicode(fh.read(), encoding="utf-8")
     else:
         return fh
 

--- a/bikeshed/extensions.py
+++ b/bikeshed/extensions.py
@@ -7,6 +7,8 @@ from .messages import *
 
 
 def load(doc):
-    exec config.retrieveBoilerplateFile(doc, "bs-extensions")
+    print(config.retrieveBoilerplateFile(doc, "bs-extensions"))
+    exec(config.retrieveBoilerplateFile(doc, "bs-extensions"))
+    print(dir())
     globals()['BSPrepTR'] = BSPrepTR
     globals()['BSPublishAdditionalFiles'] = BSPublishAdditionalFiles

--- a/bikeshed/fonts.py
+++ b/bikeshed/fonts.py
@@ -59,7 +59,7 @@ class Font(object):
     def __init__(self, fontfilename=config.scriptPath("bigblocks.bsfont")):
         try:
             lines = io.open(fontfilename, 'r', encoding="utf-8").readlines()
-        except Exception, e:
+        except Exception as e:
             die("Couldn't find font file “{0}”:\n{1}", fontfilename, e)
         self.metadata, lines = parseMetadata(lines)
         self.characters = parseCharacters(self.metadata, lines)
@@ -191,5 +191,5 @@ def writeOutputLines(outputFilename, inputFilename, lines):
         else:
             with io.open(outputFilename, "w", encoding="utf-8") as f:
                 f.write(''.join(lines))
-    except Exception, e:
+    except Exception as e:
         die("Something prevented me from saving the output document to {0}:\n{1}", outputFilename, e)

--- a/bikeshed/htmlhelpers.py
+++ b/bikeshed/htmlhelpers.py
@@ -2,7 +2,11 @@
 from __future__ import division, unicode_literals
 import hashlib
 import html5lib
-import HTMLParser
+try:
+    import HTMLParser
+except ImportError as e:
+    import html.parser as HTMLParser
+    print(e)
 import re
 from collections import Counter, defaultdict
 from lxml import etree
@@ -24,7 +28,7 @@ def findAll(sel, context):
         context = context.document
     try:
         return CSSSelector(sel, namespaces={"svg":"http://www.w3.org/2000/svg"})(context)
-    except Exception, e:
+    except Exception as e:
         die("The selector '{0}' returned an error:\n{1}", sel, e)
         return []
 

--- a/bikeshed/issuelist.py
+++ b/bikeshed/issuelist.py
@@ -41,7 +41,7 @@ def printIssueList(infilename=None, outfilename=None):
                 infile = io.open(infilename + suffix, 'r', encoding="utf-8")
                 infilename += suffix
                 break
-            except Exception, e:
+            except Exception as e:
                 pass
         else:
             die("Couldn't read from the infile:\n  {0}", str(e))
@@ -62,7 +62,7 @@ def printIssueList(infilename=None, outfilename=None):
     else:
         try:
             outfile = io.open(outfilename, 'w', encoding="utf-8")
-        except Exception, e:
+        except Exception as e:
             die("Couldn't write to outfile:\n{0}", str(e))
             return
 

--- a/bikeshed/lint/brokenLinks.py
+++ b/bikeshed/lint/brokenLinks.py
@@ -25,7 +25,7 @@ def brokenLinks(doc):
             continue
         try:
             res = requests.get(href, verify=False)
-        except Exception, e:
+        except Exception as e:
             warn("The following link caused an error when I tried to request it:\n{0}\n{1}", outerHTML(el), e)
             continue
         if res.status_code >= 400:

--- a/bikeshed/messages.py
+++ b/bikeshed/messages.py
@@ -3,7 +3,7 @@ from __future__ import division, unicode_literals
 import sys
 from collections import Counter
 from lxml import html
-import config
+from . import config
 
 
 
@@ -19,16 +19,16 @@ def p(msg):
     if config.quiet == float("infinity"):
         return
     try:
-        print msg
+        print(msg)
     except UnicodeEncodeError:
         if ascii is not None:
-            print ascii.encode("ascii", "replace")
+            print(ascii.encode("ascii", "replace"))
         else:
             warning = formatMessage("warning", "Your console does not understand Unicode.\n  Messages may be slightly corrupted.")
             if warning not in messages:
-                print warning
+                print(warning)
                 messages.add(warning)
-            print msg.encode("ascii", "xmlcharrefreplace")
+            print(msg.encode("ascii", "xmlcharrefreplace"))
 
 
 def die(msg, *formatArgs, **namedArgs):

--- a/bikeshed/publish.py
+++ b/bikeshed/publish.py
@@ -20,14 +20,14 @@ def publishEchidna(doc, username, password, decision, additionalDirectories):
     os.remove(tar.name)
 
     if r.status_code == 202:
-        print "Successfully pushed to Echidna!"
-        print "Check the URL in a few seconds to see if it was published successfully:"
-        print "https://labs.w3.org/echidna/api/status?id=" + r.text
+        print("Successfully pushed to Echidna!")
+        print("Check the URL in a few seconds to see if it was published successfully:")
+        print("https://labs.w3.org/echidna/api/status?id=" + r.text)
     else:
-        print "There was an error publishing your spec. Here's some information that might help?"
-        print r.status_code
-        print r.text
-        print r.headers
+        print("There was an error publishing your spec. Here's some information that might help?")
+        print(r.status_code)
+        print(r.text)
+        print(r.headers)
 
 
 def prepareTar(doc, visibleTar=False, additionalDirectories=None):

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1188,7 +1188,7 @@ def processInclusions(doc):
                 try:
                     with io.open(config.docPath(doc, path), 'r', encoding="utf-8") as f:
                         lines = f.readlines()
-                except Exception, err:
+                except Exception as err:
                     die("Couldn't find include file '{0}'. Error was:\n{1}", path, err, el=el)
                     removeNode(el)
                     continue
@@ -1374,7 +1374,7 @@ def inlineRemoteIssues(doc):
     try:
         with io.open(config.scriptPath("spec-data", "github-issues.json"), 'w', encoding="utf-8") as f:
             f.write(unicode(json.dumps(responses, ensure_ascii=False, indent=2, sort_keys=True)))
-    except Exception, e:
+    except Exception as e:
         warn("Couldn't save GitHub Issues cache to disk.\n{0}", e)
     return
 

--- a/bikeshed/update/main.py
+++ b/bikeshed/update/main.py
@@ -57,7 +57,7 @@ def fixupDataFiles():
         localVersion = None
     try:
         remoteVersion = int(open(remotePath("version.txt"), 'r').read())
-    except IOError, err:
+    except IOError as err:
         warn("Couldn't check the datafile version. Bikeshed may be unstable.\n{0}", err)
         return
 
@@ -71,7 +71,7 @@ def fixupDataFiles():
     try:
         for filename in os.listdir(remotePath()):
             copyanything(remotePath(filename), localPath(filename))
-    except Exception, err:
+    except Exception as err:
         warn("Couldn't update datafiles from cache. Bikeshed may be unstable.\n{0}", err)
         return
 
@@ -88,7 +88,7 @@ def updateReadonlyDataFiles():
             if filename.startswith("readonly"):
                 continue
             copyanything(localPath(filename), remotePath(filename))
-    except Exception, err:
+    except Exception as err:
         warn("Error copying over the datafiles:\n{0}", err)
         return
 

--- a/bikeshed/update/updateBiblio.py
+++ b/bikeshed/update/updateBiblio.py
@@ -4,7 +4,10 @@ import io
 import json
 import re
 import os
-import urllib2
+try:
+    from urllib.request import URLError, urlopen
+except ImportError:
+    from urllib2 import URLError, urlopen
 from collections import defaultdict
 from contextlib import closing
 
@@ -28,7 +31,7 @@ def update(path, dryRun=False):
             try:
                 with io.open(os.path.join(path, "biblio", "biblio-{0}.data".format(group)), 'w', encoding="utf-8") as fh:
                     writeBiblioFile(fh, biblios)
-            except Exception, e:
+            except Exception as e:
                 die("Couldn't save biblio database to disk.\n{0}", e)
                 return
         # Save the list of all names to a file
@@ -58,7 +61,7 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "biblio-keys.json"), 'w', encoding="utf-8") as fh:
                 fh.write(unicode(json.dumps(reducedNames, indent=0, ensure_ascii=False, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save biblio database to disk.\n{0}", e)
             return
     say("Success!")
@@ -66,42 +69,42 @@ def update(path, dryRun=False):
 
 def getSpecrefData():
     try:
-        with closing(urllib2.urlopen("https://api.specref.org/bibrefs")) as fh:
+        with closing(urlopen("https://api.specref.org/bibrefs")) as fh:
             return unicode(fh.read(), encoding="utf-8")
-    except urllib2.URLError:
+    except URLError:
         # SpecRef uses SNI, which old Pythons (pre-2.7.10) don't understand.
         # First try the older herokuapp.com URL.
         try:
-            with closing(urllib2.urlopen("https://specref.herokuapp.com/bibrefs")) as fh:
+            with closing(urlopen("https://specref.herokuapp.com/bibrefs")) as fh:
                 return unicode(fh.read(), encoding="utf-8")
         except:
             # Try the CSSWG proxy.
             try:
-                with closing(urllib2.urlopen("https://api.csswg.org/bibrefs")) as fh:
+                with closing(urlopen("https://api.csswg.org/bibrefs")) as fh:
                     return unicode(fh.read(), encoding="utf-8")
             except:
                 warn("Your Python is too old (pre-2.7.10) to talk to SpecRef over HTTPS, and something's wrong with the CSSWG proxy as well. Report this to the Bikeshed repo, please?")
                 raise
                 return "{}"
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download the SpecRef biblio data.\n{0}", e)
         return "{}"
 
 
 def getWG21Data():
     try:
-        with closing(urllib2.urlopen("https://wg21.link/specref.json")) as fh:
+        with closing(urlopen("https://wg21.link/specref.json")) as fh:
             return unicode(fh.read(), encoding="utf-8")
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download the WG21 biblio data.\n{0}", e)
         return "{}"
 
 
 def getCSSWGData():
     try:
-        with closing(urllib2.urlopen("https://raw.githubusercontent.com/w3c/csswg-drafts/master/biblio.ref")) as fh:
+        with closing(urlopen("https://raw.githubusercontent.com/w3c/csswg-drafts/master/biblio.ref")) as fh:
             return [unicode(line, encoding="utf-8") for line in fh.readlines()]
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download the CSSWG biblio data.\n{0}", e)
         return []
 

--- a/bikeshed/update/updateCanIUse.py
+++ b/bikeshed/update/updateCanIUse.py
@@ -3,7 +3,10 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 from collections import OrderedDict
 from contextlib import closing
 
@@ -13,15 +16,15 @@ from ..messages import *
 def update(path, dryRun=False):
     say("Downloading Can I Use data...")
     try:
-        with closing(urllib2.urlopen("https://raw.githubusercontent.com/Fyrd/caniuse/master/fulldata-json/data-2.0.json")) as fh:
+        with closing(urlopen("https://raw.githubusercontent.com/Fyrd/caniuse/master/fulldata-json/data-2.0.json")) as fh:
             jsonString = fh.read()
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download the Can I Use data.\n{0}", e)
         return
 
     try:
         data = json.loads(unicode(jsonString), encoding="utf-8", object_pairs_hook=OrderedDict)
-    except Exception, e:
+    except Exception as e:
         die("The Can I Use data wasn't valid JSON for some reason. Try downloading again?\n{0}", e)
         return
 
@@ -93,7 +96,7 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "caniuse.json"), 'w', encoding="utf-8") as fh:
                 fh.write(unicode(json.dumps(data, indent=1, ensure_ascii=False, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save Can I Use database to disk.\n{0}", e)
             return
     say("Success!")

--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -4,7 +4,10 @@ import io
 import json
 import re
 import os
-import urllib2
+# try:
+#     from urllib.request import urlopen
+# except ImportError:
+#     from urllib2 import urlopen
 from collections import defaultdict
 from contextlib import closing
 
@@ -28,7 +31,7 @@ def update(path, dryRun=False):
             die("Unrecognized anchor-data content-type '{0}'.", res.contentType)
             return
         rawSpecData = res.data
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download anchor data.  Error was:\n{0}", str(e))
         return
 
@@ -69,31 +72,31 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "specs.json"), 'w', encoding="utf-8") as f:
                 f.write(unicode(json.dumps(specs, ensure_ascii=False, indent=2, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save spec database to disk.\n{0}", e)
             return
         try:
             for spec, specHeadings in headings.items():
                 with io.open(os.path.join(path, "headings", "headings-{0}.json".format(spec)), 'w', encoding="utf-8") as f:
                     f.write(unicode(json.dumps(specHeadings, ensure_ascii=False, indent=2, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save headings database to disk.\n{0}", e)
             return
         try:
             writeAnchorsFile(anchors, path)
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save anchor database to disk.\n{0}", e)
             return
         try:
             with io.open(os.path.join(path, "methods.json"), 'w', encoding="utf-8") as f:
                 f.write(unicode(json.dumps(methods, ensure_ascii=False, indent=2, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save methods database to disk.\n{0}", e)
             return
         try:
             with io.open(os.path.join(path, "fors.json"), 'w', encoding="utf-8") as f:
                 f.write(unicode(json.dumps(fors, ensure_ascii=False, indent=2, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save fors database to disk.\n{0}", e)
             return
 

--- a/bikeshed/update/updateLanguages.py
+++ b/bikeshed/update/updateLanguages.py
@@ -3,7 +3,10 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 from contextlib import closing
 
 from ..messages import *
@@ -11,9 +14,9 @@ from ..messages import *
 def update(path, dryRun=False):
     try:
         say("Downloading languages...")
-        with closing(urllib2.urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/languages.json")) as fh:
+        with closing(urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/languages.json")) as fh:
             data = unicode(fh.read(), encoding="utf-8")
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download languages data.\n{0}", e)
         return
 
@@ -21,7 +24,7 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "languages.json"), 'w', encoding="utf-8") as f:
                 f.write(data)
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save languages database to disk.\n{0}", e)
             return
     say("Success!")

--- a/bikeshed/update/updateLinkDefaults.py
+++ b/bikeshed/update/updateLinkDefaults.py
@@ -3,7 +3,10 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 from contextlib import closing
 
 from ..messages import *
@@ -11,9 +14,9 @@ from ..messages import *
 def update(path, dryRun=False):
     try:
         say("Downloading link defaults...")
-        with closing(urllib2.urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/link-defaults.infotree")) as fh:
+        with closing(urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/link-defaults.infotree")) as fh:
             data = unicode(fh.read(), encoding="utf-8")
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download link defaults data.\n{0}", e)
         return
 
@@ -21,7 +24,7 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "link-defaults.infotree"), 'w', encoding="utf-8") as f:
                 f.write(data)
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save link-defaults database to disk.\n{0}", e)
             return
     say("Success!")

--- a/bikeshed/update/updateTestSuites.py
+++ b/bikeshed/update/updateTestSuites.py
@@ -3,7 +3,7 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+
 from contextlib import closing
 
 from ..apiclient.apiclient import apiclient
@@ -23,7 +23,7 @@ def update(path, dryRun=False):
             die("Unrecognized test suite content-type '{0}'.", res.contentType)
             return
         rawTestSuiteData = res.data
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download test suite data.  Error was:\n{0}", str(e))
         return
 
@@ -47,6 +47,6 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "test-suites.json"), 'w', encoding="utf-8") as f:
                 f.write(unicode(json.dumps(testSuites, ensure_ascii=False, indent=2, sort_keys=True)))
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save test-suite database to disk.\n{0}", e)
     say("Success!")

--- a/bikeshed/update/updateWpt.py
+++ b/bikeshed/update/updateWpt.py
@@ -3,7 +3,10 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 from contextlib import closing
 
 from ..messages import *
@@ -11,9 +14,9 @@ from ..messages import *
 def update(path, dryRun=False):
     try:
         say("Downloading web-platform-tests data...")
-        with closing(urllib2.urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/wpt-tests.txt")) as fh:
+        with closing(urlopen("https://raw.githubusercontent.com/tabatkins/bikeshed/master/bikeshed/spec-data/readonly/wpt-tests.txt")) as fh:
             data = unicode(fh.read(), encoding="utf-8")
-    except Exception, e:
+    except Exception as e:
         die("Couldn't download web-platform-tests data.\n{0}", e)
         return
 
@@ -21,7 +24,7 @@ def update(path, dryRun=False):
         try:
             with io.open(os.path.join(path, "wpt-tests.txt"), 'w', encoding="utf-8") as f:
                 f.write(data)
-        except Exception, e:
+        except Exception as e:
             die("Couldn't save web-platform-tests data to disk.\n{0}", e)
             return
     say("Success!")

--- a/bikeshed/widlparser/widlparser/__init__.py
+++ b/bikeshed/widlparser/widlparser/__init__.py
@@ -12,4 +12,4 @@
 
 __all__ = ['parser', 'tokenizer', 'constructs', 'productions']
 
-import parser
+from . import parser

--- a/bikeshed/widlparser/widlparser/constructs.py
+++ b/bikeshed/widlparser/widlparser/constructs.py
@@ -10,8 +10,8 @@
 #  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 
-from productions import *
-from markup import MarkupGenerator
+from .productions import *
+from .markup import MarkupGenerator
 
 class Construct(ChildProduction):
     @classmethod

--- a/bikeshed/widlparser/widlparser/parser.py
+++ b/bikeshed/widlparser/widlparser/parser.py
@@ -13,8 +13,8 @@
 import re
 import itertools
 
-import tokenizer
-from constructs import *
+from . import tokenizer
+from .constructs import *
 
 
 class Parser(object):

--- a/bikeshed/widlparser/widlparser/productions.py
+++ b/bikeshed/widlparser/widlparser/productions.py
@@ -10,7 +10,7 @@
 #  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 
-import constructs, tokenizer
+from . import constructs, tokenizer
 import itertools
 
 def _name(thing):


### PR DESCRIPTION
**Nota bene: Do not merge, breaking changes.**

Figured this would be worth sending in first, then iterating through nicer ways through code review before I forget that this patch existed in the first place.

The plug-in loading code does not work in Py3, I'm suspecting it is due to a change in the class reference behavior between Py2 and Py3.

(The patch was mostly written during plenary day's bikeshed session, so mind the sloppiness.)