### PR TITLE
Clarify the effects of `.example`

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1237,24 +1237,11 @@ The Markdown processor specially recognizes paragraphs starting with
 "Assertion: ",
 "Note: ",
 or "Note, ",
-and will add a matching class to the paragraph automatically.
-These classes default to `.issue`, `.advisement`, `.assertion`, and `.note`,
-but can be customized with the metadatas
-<a>Issue Class</a>, <a>Advisement Class</a>, <a>Assertion Class</a>, and <a>Note Class</a>.
-(However, the default classes receive styling from the default stylesheet,
-so make sure you provide your own styling if you change them.)
+and will add a matching class to the paragraph automatically. These classes default to `.issue`, `.advisement`, `.assertion`, and `.note`, but can be customized with the metadatas <a>Issue Class</a>, <a>Advisement Class</a>, <a>Assertion Class</a>, and <a>Note Class</a>. (However, the default classes receive styling from the default stylesheet, so make sure you provide your own styling if you change them.)
 
-The default styling of these blocks includes a generated-content "header"
-containing the word "NOTE:", etc.
-If you'd like to provide your own custom header,
-write out the container element yourself
-(rather than using the Markdown shorthand,
-just create any element with the appropriate class),
-and add a `heading="YOUR TEXT HERE"` attribute to the container.
-It will automatically have "NOTE: "/etc prepended to it.
-This also works on elements with the `.example` class.
-(This is used by [[#remote-issues]] to put the GitHub issue title on the issue containers.)
+The default styling of these blocks includes a generated-content "header" containing the word "NOTE:", etc. If you'd like to provide your own custom header, write out the container element yourself (rather than using the Markdown shorthand, just create any element with the appropriate class), and add a `heading="YOUR TEXT HERE"` attribute to the container. It will automatically have "NOTE: "/etc prepended to it. (This is used by [[#remote-issues]] to put the GitHub issue title on the issue containers.)
 
+Elements with the `.example` class will also be given a generated-content "header" in the format `EXAMPLE n` with an auto-incrementing number, and have self-links created to allow linking directly to the example.
 
 
 Typography Fixes {#typography}

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1237,11 +1237,27 @@ The Markdown processor specially recognizes paragraphs starting with
 "Assertion: ",
 "Note: ",
 or "Note, ",
-and will add a matching class to the paragraph automatically. These classes default to `.issue`, `.advisement`, `.assertion`, and `.note`, but can be customized with the metadatas <a>Issue Class</a>, <a>Advisement Class</a>, <a>Assertion Class</a>, and <a>Note Class</a>. (However, the default classes receive styling from the default stylesheet, so make sure you provide your own styling if you change them.)
+and will add a matching class to the paragraph automatically. 
+These classes default to `.issue`, `.advisement`, `.assertion`, and `.note`, 
+but can be customized with the metadatas 
+<a>Issue Class</a>, <a>Advisement Class</a>, <a>Assertion Class</a>, and <a>Note Class</a>. 
+(However, the default classes receive styling from the default stylesheet, 
+so make sure you provide your own styling if you change them.)
 
-The default styling of these blocks includes a generated-content "header" containing the word "NOTE:", etc. If you'd like to provide your own custom header, write out the container element yourself (rather than using the Markdown shorthand, just create any element with the appropriate class), and add a `heading="YOUR TEXT HERE"` attribute to the container. It will automatically have "NOTE: "/etc prepended to it. (This is used by [[#remote-issues]] to put the GitHub issue title on the issue containers.)
+The default styling of these blocks includes a generated-content "header" 
+containing the word "NOTE:", etc. 
+If you'd like to provide your own custom header, 
+write out the container element yourself 
+(rather than using the Markdown shorthand, 
+just create any element with the appropriate class), 
+and add a `heading="YOUR TEXT HERE"` attribute to the container. 
+It will automatically have "NOTE: "/etc prepended to it. 
+(This is used by [[#remote-issues]] to put the GitHub issue title on the issue containers.)
 
-Elements with the `.example` class will also be given a generated-content "header" in the format `EXAMPLE n` with an auto-incrementing number, and have self-links created to allow linking directly to the example.
+Elements with the `.example` class will also be given a generated-content "header" 
+in the format `EXAMPLE n` 
+with an auto-incrementing number, 
+and have self-links created to allow linking directly to the example.
 
 
 Typography Fixes {#typography}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,4 @@
+
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
@@ -1176,9 +1177,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 51aaf72c21ff9e692b3ec22f4338e7f0bc1e3268" name="generator">
+  <meta content="Bikeshed version d2317bc18d20999eb90426152d7665c9717690e9" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="51aaf72c21ff9e692b3ec22f4338e7f0bc1e3268" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1479,7 +1479,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-10-28">28 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-11-21">21 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1494,7 +1494,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 28 October 2017,
+In addition, as of 21 November 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2744,21 +2744,9 @@ as I get closer to adhering to the CommonMark specification.</p>
 "Assertion: ",
 "Note: ",
 or "Note, ",
-and will add a matching class to the paragraph automatically.
-These classes default to <code>.issue</code>, <code>.advisement</code>, <code>.assertion</code>, and <code>.note</code>,
-but can be customized with the metadatas <a data-link-type="dfn" href="#metadata-issue-class" id="ref-for-metadata-issue-class">Issue Class</a>, <a data-link-type="dfn" href="#metadata-advisement-class" id="ref-for-metadata-advisement-class">Advisement Class</a>, <a data-link-type="dfn" href="#metadata-assertion-class" id="ref-for-metadata-assertion-class">Assertion Class</a>, and <a data-link-type="dfn" href="#metadata-note-class" id="ref-for-metadata-note-class">Note Class</a>.
-(However, the default classes receive styling from the default stylesheet,
-so make sure you provide your own styling if you change them.)</p>
-   <p>The default styling of these blocks includes a generated-content "header"
-containing the word "NOTE:", etc.
-If you’d like to provide your own custom header,
-write out the container element yourself
-(rather than using the Markdown shorthand,
-just create any element with the appropriate class),
-and add a <code>heading="YOUR TEXT HERE"</code> attribute to the container.
-It will automatically have "NOTE: "/etc prepended to it.
-This also works on elements with the <code>.example</code> class.
-(This is used by <a href="#remote-issues">§5.10 Remote Issues</a> to put the GitHub issue title on the issue containers.)</p>
+and will add a matching class to the paragraph automatically. These classes default to <code>.issue</code>, <code>.advisement</code>, <code>.assertion</code>, and <code>.note</code>, but can be customized with the metadatas <a data-link-type="dfn" href="#metadata-issue-class" id="ref-for-metadata-issue-class">Issue Class</a>, <a data-link-type="dfn" href="#metadata-advisement-class" id="ref-for-metadata-advisement-class">Advisement Class</a>, <a data-link-type="dfn" href="#metadata-assertion-class" id="ref-for-metadata-assertion-class">Assertion Class</a>, and <a data-link-type="dfn" href="#metadata-note-class" id="ref-for-metadata-note-class">Note Class</a>. (However, the default classes receive styling from the default stylesheet, so make sure you provide your own styling if you change them.)</p>
+   <p>The default styling of these blocks includes a generated-content "header" containing the word "NOTE:", etc. If you’d like to provide your own custom header, write out the container element yourself (rather than using the Markdown shorthand, just create any element with the appropriate class), and add a <code>heading="YOUR TEXT HERE"</code> attribute to the container. It will automatically have "NOTE: "/etc prepended to it. (This is used by <a href="#remote-issues">§5.10 Remote Issues</a> to put the GitHub issue title on the issue containers.)</p>
+   <p>Elements with the <code>.example</code> class will also be given a generated-content "header" in the format <code>EXAMPLE n</code> with an auto-incrementing number, and have self-links created to allow linking directly to the example.</p>
    <h3 class="heading settled" data-level="5.3" id="typography"><span class="secno">5.3. </span><span class="content">Typography Fixes</span><a class="self-link" href="#typography"></a></h3>
    <p>Bikeshed will automatically handle a few typographic niceties for you, ones that it can reliably detect:</p>
    <ul>
@@ -4064,7 +4052,7 @@ and all specs in the same organization can look similar.</p>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"logo"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h1</span> <span class="na">id</span><span class="o">=</span><span class="s">"title"</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-name no-ref"</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;/</span><span class="nt">h1</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h2</span> <span class="na">id</span><span class="o">=</span><span class="s">"subtitle"</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span><span class="p">></span>Living Standard,
-	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20171028"</span><span class="p">></span>28 October 2017<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
+	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20171121"</span><span class="p">></span>21 November 2017<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"spec-metadata"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"warning"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">'copyright'</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">'copyright'</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version d2317bc18d20999eb90426152d7665c9717690e9" name="generator">
+  <meta content="Bikeshed version 6aa3aaa1336714f1530c976b6df9a86c683d5968" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1479,7 +1479,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-11-21">21 November 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2017-11-24">24 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1494,7 +1494,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 21 November 2017,
+In addition, as of 24 November 2017,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2744,9 +2744,23 @@ as I get closer to adhering to the CommonMark specification.</p>
 "Assertion: ",
 "Note: ",
 or "Note, ",
-and will add a matching class to the paragraph automatically. These classes default to <code>.issue</code>, <code>.advisement</code>, <code>.assertion</code>, and <code>.note</code>, but can be customized with the metadatas <a data-link-type="dfn" href="#metadata-issue-class" id="ref-for-metadata-issue-class">Issue Class</a>, <a data-link-type="dfn" href="#metadata-advisement-class" id="ref-for-metadata-advisement-class">Advisement Class</a>, <a data-link-type="dfn" href="#metadata-assertion-class" id="ref-for-metadata-assertion-class">Assertion Class</a>, and <a data-link-type="dfn" href="#metadata-note-class" id="ref-for-metadata-note-class">Note Class</a>. (However, the default classes receive styling from the default stylesheet, so make sure you provide your own styling if you change them.)</p>
-   <p>The default styling of these blocks includes a generated-content "header" containing the word "NOTE:", etc. If you’d like to provide your own custom header, write out the container element yourself (rather than using the Markdown shorthand, just create any element with the appropriate class), and add a <code>heading="YOUR TEXT HERE"</code> attribute to the container. It will automatically have "NOTE: "/etc prepended to it. (This is used by <a href="#remote-issues">§5.10 Remote Issues</a> to put the GitHub issue title on the issue containers.)</p>
-   <p>Elements with the <code>.example</code> class will also be given a generated-content "header" in the format <code>EXAMPLE n</code> with an auto-incrementing number, and have self-links created to allow linking directly to the example.</p>
+and will add a matching class to the paragraph automatically. 
+These classes default to <code>.issue</code>, <code>.advisement</code>, <code>.assertion</code>, and <code>.note</code>, 
+but can be customized with the metadatas <a data-link-type="dfn" href="#metadata-issue-class" id="ref-for-metadata-issue-class">Issue Class</a>, <a data-link-type="dfn" href="#metadata-advisement-class" id="ref-for-metadata-advisement-class">Advisement Class</a>, <a data-link-type="dfn" href="#metadata-assertion-class" id="ref-for-metadata-assertion-class">Assertion Class</a>, and <a data-link-type="dfn" href="#metadata-note-class" id="ref-for-metadata-note-class">Note Class</a>. 
+(However, the default classes receive styling from the default stylesheet, 
+so make sure you provide your own styling if you change them.)</p>
+   <p>The default styling of these blocks includes a generated-content "header"
+containing the word "NOTE:", etc. 
+If you’d like to provide your own custom header, 
+write out the container element yourself 
+(rather than using the Markdown shorthand, 
+just create any element with the appropriate class), 
+and add a <code>heading="YOUR TEXT HERE"</code> attribute to the container. 
+It will automatically have "NOTE: "/etc prepended to it. 
+(This is used by <a href="#remote-issues">§5.10 Remote Issues</a> to put the GitHub issue title on the issue containers.)</p>
+   <p>Elements with the <code>.example</code> class will also be given a generated-content "header"
+in the format <code>EXAMPLE n</code> with an auto-incrementing number, 
+and have self-links created to allow linking directly to the example.</p>
    <h3 class="heading settled" data-level="5.3" id="typography"><span class="secno">5.3. </span><span class="content">Typography Fixes</span><a class="self-link" href="#typography"></a></h3>
    <p>Bikeshed will automatically handle a few typographic niceties for you, ones that it can reliably detect:</p>
    <ul>
@@ -4052,7 +4066,7 @@ and all specs in the same organization can look similar.</p>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"logo"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h1</span> <span class="na">id</span><span class="o">=</span><span class="s">"title"</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-name no-ref"</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;/</span><span class="nt">h1</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h2</span> <span class="na">id</span><span class="o">=</span><span class="s">"subtitle"</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span><span class="p">></span>Living Standard,
-	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20171121"</span><span class="p">></span>21 November 2017<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
+	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20171124"</span><span class="p">></span>24 November 2017<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"spec-metadata"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"warning"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">'copyright'</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">'copyright'</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>


### PR DESCRIPTION
While notes, issues, and examples are mentioned in the same heading, it is not clear what results you get by adding the `.example` class to an element.