### PR TITLE
Update WHATWG boilerplate

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -752,7 +752,7 @@ def addSpecMetadataSection(doc):
             # so this prevents code from genning an extra wrapper <dd>.
             return [E.dt({"class": "editor"}, displayKey, ":")] + vals
         elif key == "Translations":
-            ret = [E.dt(displayKey, " ", E.small("(non-normative and likely out-of-date)"), ":")]
+            ret = [E.dt(displayKey, " ", E.small("(non-normative)"), ":")]
             ret += [E.dd({}, val) for val in vals]
             return ret
         else:

--- a/bikeshed/boilerplate/whatwg/computed-metadata.include
+++ b/bikeshed/boilerplate/whatwg/computed-metadata.include
@@ -1,0 +1,14 @@
+{
+  "Title": "[SPECTITLE] Standard",
+  "Logo": "https://resources.whatwg.org/logo-[SHORTNAME].svg",
+  "!Participate": [
+    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>"
+  ],
+  "!Commits": [
+    "<a href=https://github.com/whatwg/[SHORTNAME]/commits>GitHub whatwg/[SHORTNAME]/commits</a>",
+    "[SNAPSHOT-LINK]",
+    "<a href=https://twitter.com/[TWITTER]>@[TWITTER]</a>"
+  ],
+  "!Tests": "<a href=https://github.com/w3c/web-platform-tests/tree/master/[SHORTNAME]>web-platform-tests [SHORTNAME]/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/[SHORTNAME]>ongoing work</a>)"
+}

--- a/bikeshed/boilerplate/whatwg/defaults.include
+++ b/bikeshed/boilerplate/whatwg/defaults.include
@@ -1,7 +1,10 @@
 {
-	"Default Biblio Status": "current",
-	"Issue Class": "XXX",
-	"Use Dfn Panels": "no",
-	"Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters",
-	"Complain About": "missing-example-ids yes, accidental-2119 yes"
+  "Default Biblio Status": "current",
+  "Issue Class": "XXX",
+  "Use Dfn Panels": "yes",
+  "Status": "LS",
+  "No Editor": "true",
+  "Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters, omit feedback-header, omit conformance, omit issues-index",
+  "Complain About": "missing-example-ids yes, accidental-2119 yes",
+  "Metadata Order": "Participate, Commits, Tests, *, !*"
 }

--- a/bikeshed/boilerplate/whatwg/footer.include
+++ b/bikeshed/boilerplate/whatwg/footer.include
@@ -1,10 +1,12 @@
+<p>Copyright © [YEAR] WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution
+4.0 International License</a>.
+
 </main>
-<div data-fill-with="conformance">
-	<h2 class="no-num no-ref" id="conformance">Conformance</h2>
 
-	<p>All diagrams, examples, and notes in this specification are non-normative, as are all sections explicitly marked non-normative. Everything else in this specification is normative.
-
-	<p>The key words “MUST”, “MUST NOT”, “REQUIRED”, <!--“SHALL”, “SHALL NOT”,--> “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this specification are to be interpreted as described in RFC2119. For readability, these words do not appear in all uppercase letters in this specification. [[!RFC2119]]
-
-	<p>Conformance requirements phrased as algorithms or specific steps may be implemented in any manner, so long as the end result is equivalent. (In particular, the algorithms defined in this specification are intended to be easy to follow, and not intended to be performant.)
-</div>
+<script>
+"use strict";
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/service-worker.js");
+}
+</script>

--- a/bikeshed/boilerplate/whatwg/header.include
+++ b/bikeshed/boilerplate/whatwg/header.include
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="theme-color" content="#3c790a">
-  <title>[TITLE]</title>
-  <link href="https://resources.whatwg.org/standard.css" rel="stylesheet">
-  <link href="https://resources.whatwg.org/bikeshed.css" rel="stylesheet">
-  <link href="[LOGO]" rel="icon">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="theme-color" content="#3c790a">
+<title>[TITLE]</title>
+<link href="https://resources.whatwg.org/standard.css" rel="stylesheet">
+<link href="https://resources.whatwg.org/bikeshed.css" rel="stylesheet">
+<link href="[LOGO]" rel="icon">
+<script src=https://resources.whatwg.org/file-issue.js async></script>
+<script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js async></script>
+
 <body class="h-entry status-[STATUS]">
 <div class="head">
   <p data-fill-with="logo"></p>


### PR DESCRIPTION
This uses the computed metadata features to set better defaults across all WHATWG standards, and moves certain scripts (including the service worker registration script) into the boilerplate.

As a drive-by, it removes the "likely out-of-date" for translations as it turns out we have very responsive translators for WHATWG standards and we'd like to be a bit nicer about their work.