### PR TITLE
Update WG Note patent policy boilerplate

### DIFF
--- a/bikeshed/boilerplate/dap/status-WG-NOTE.include
+++ b/bikeshed/boilerplate/dap/status-WG-NOTE.include
@@ -23,14 +23,9 @@
   It is inappropriate to cite this document as other than work in progress.
 </p>
 
-<p>
-	This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel=disclosure>public list of any patent disclosures</a>
-	made in connection with the deliverables of the group;
-	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+<p data-deliverer="43696">
+	This document was produced by a group operating under the
+	<a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
 </p>
 
 <p>


### PR DESCRIPTION
The required patent policy boilerplate for WG Notes has been simplified.
See https://github.com/w3c/specberus/pull/707 for more details