### PR TITLE
Homebrew Python defaults to Python 3.x now

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -83,7 +83,7 @@ OS X steps {#install-osx}
 
 Note: If you're on a relatively modern Mac you should be able to proceed directly to [[#install-common]].
 
-These instructions assume that you have [Mac Ports](https://www.macports.org/) or [Homebrew](http://brew.sh/) installed. If you successfully install Bikeshed using some other method, please contribute to this documentation.
+These instructions assume that you have [Mac Ports](https://www.macports.org/) or [Homebrew](https://brew.sh/) installed. If you successfully install Bikeshed using some other method, please contribute to this documentation.
 
 
 ### Mac ports ### {#install-macports}
@@ -108,7 +108,7 @@ sudo port select --set python python27
 Install the Homebrew version of Python and Pip:
 
 ```
-brew install python
+brew install python@2
 ```
 
 Install the XCode command-line tools:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1176,9 +1176,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 3e39d9c47c1692f20ab3d915ce57d67ec14e5565" name="generator">
+  <meta content="Bikeshed version 66a76cd06d4fa9e491630583356008a71a166760" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="3e39d9c47c1692f20ab3d915ce57d67ec14e5565" name="document-revision">
+  <meta content="66a76cd06d4fa9e491630583356008a71a166760" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1479,7 +1479,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-01-04">4 January 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-03-03">3 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1494,7 +1494,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 4 January 2018,
+In addition, as of 3 March 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1698,7 +1698,7 @@ $ sudo pip install lxml
    <p>From here, you can proceed to <a href="#install-common">§1.5 Common steps</a>.</p>
    <h3 class="heading settled" data-level="1.2" id="install-osx"><span class="secno">1.2. </span><span class="content">OS X steps</span><a class="self-link" href="#install-osx"></a></h3>
    <p class="note" role="note"><span>Note:</span> If you’re on a relatively modern Mac you should be able to proceed directly to <a href="#install-common">§1.5 Common steps</a>.</p>
-   <p>These instructions assume that you have <a href="https://www.macports.org/">Mac Ports</a> or <a href="http://brew.sh/">Homebrew</a> installed. If you successfully install Bikeshed using some other method, please contribute to this documentation.</p>
+   <p>These instructions assume that you have <a href="https://www.macports.org/">Mac Ports</a> or <a href="https://brew.sh/">Homebrew</a> installed. If you successfully install Bikeshed using some other method, please contribute to this documentation.</p>
    <h4 class="heading settled" data-level="1.2.1" id="install-macports"><span class="secno">1.2.1. </span><span class="content">Mac ports</span><a class="self-link" href="#install-macports"></a></h4>
    <p>First, get the right packages installed onto your system:</p>
 <pre>sudo port install python27 py27-pip py27-lxml py27-html5lib py27-cssselect py27-libxslt py27-libxml2 py27-pygments
@@ -1709,7 +1709,7 @@ $ sudo pip install lxml
    <p>(If you get <code>ImportError: No module named six</code> when you first run Bikeshed, additionally run <code>sudo port install py27-six</code>.)</p>
    <h4 class="heading settled" data-level="1.2.2" id="install-homebrew"><span class="secno">1.2.2. </span><span class="content">Homebrew</span><a class="self-link" href="#install-homebrew"></a></h4>
    <p>Install the Homebrew version of Python and Pip:</p>
-<pre>brew install python
+<pre>brew install python@2
 </pre>
    <p>Install the XCode command-line tools:</p>
 <pre>xcode-select --install
@@ -2357,6 +2357,8 @@ which is usually what you want.</p>
      <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-noexport="" id="metadata-tr">TR<a class="self-link" href="#metadata-tr"></a></dfn> must contain a link that points to the latest version on /TR.</p>
     <li data-md="">
      <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-noexport="" id="metadata-canonicalurl">canonicalURL<a class="self-link" href="#metadata-canonicalurl"></a></dfn> defines the canonical URL (as used by search engines) for the document; it can be set to "TR" (the default value if TR is defined), "ED", or a specific URL.</p>
+    <li data-md="">
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-noexport="" id="metadata-favicon">favicon<a class="self-link" href="#metadata-favicon"></a></dfn> defines the favicon URL for the document; it only supports one single URL.</p>
     <li data-md="">
      <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-noexport="" id="metadata-former-editor">Former Editor<a class="self-link" href="#metadata-former-editor"></a></dfn> must contain a former editor’s information, in the same format as <a data-link-type="dfn" href="#metadata-editor" id="ref-for-metadata-editor①">Editor</a>.</p>
     <li data-md="">
@@ -4097,7 +4099,7 @@ and all specs in the same organization can look similar.</p>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"logo"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h1</span> <span class="na">id</span><span class="o">=</span><span class="s">"title"</span> <span class="na">class</span><span class="o">=</span><span class="s">"p-name no-ref"</span><span class="p">></span>Bikeshed Documentation<span class="p">&lt;/</span><span class="nt">h1</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">h2</span> <span class="na">id</span><span class="o">=</span><span class="s">"subtitle"</span> <span class="na">class</span><span class="o">=</span><span class="s">"no-num no-toc no-ref"</span><span class="p">></span>Living Standard,
-	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20180104"</span><span class="p">></span>4 January 2018<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
+	<span class="p">&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"dt-updated"</span><span class="p">>&lt;</span><span class="nt">span</span> <span class="na">class</span><span class="o">=</span><span class="s">"value-title"</span> <span class="na">title</span><span class="o">=</span><span class="s">"20180303"</span><span class="p">></span>3 March 2018<span class="p">&lt;/</span><span class="nt">span</span><span class="p">>&lt;/</span><span class="nt">h2</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"spec-metadata"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">div</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">"warning"</span><span class="p">>&lt;/</span><span class="nt">div</span><span class="p">></span>
   <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">'copyright'</span> <span class="na">data-fill-with</span><span class="o">=</span><span class="s">'copyright'</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
@@ -4627,6 +4629,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-ed">ED</a><span>, in §4</span>
    <li><a href="#metadata-editor">Editor</a><span>, in §4</span>
    <li><a href="#metadata-editor-term">Editor Term</a><span>, in §4</span>
+   <li><a href="#metadata-favicon">favicon</a><span>, in §4</span>
    <li><a href="#metadata-former-editor">Former Editor</a><span>, in §4</span>
    <li><a href="#metadata-group">Group</a><span>, in §4</span>
    <li><a href="#metadata-h1">H1</a><span>, in §4</span>


### PR DESCRIPTION
This commit changes the installation docs in the Homebrew section to `python@2`, because the `python` formula was upgraded to Python 3.x.

Also change a link to HTTPS.

See also: https://brew.sh/2018/01/19/homebrew-1.5.0/