### PR TITLE
Export conformant user agent and server

### DIFF
--- a/bikeshed/boilerplate/audiowg/footer.include
+++ b/bikeshed/boilerplate/audiowg/footer.include
@@ -43,10 +43,10 @@
 
 <h3 id="conformance-classes" class="no-ref no-num">Conformance Classes</h3>
 
-    <p>A <dfn>conformant user agent</dfn> must implement all the requirements
+    <p>A <dfn export>conformant user agent</dfn> must implement all the requirements
     listed in this specification that are applicable to user agents.</p>
 
-    <p>A <dfn>conformant server</dfn> must implement all the requirements listed
+    <p>A <dfn export>conformant server</dfn> must implement all the requirements listed
     in this specification that are applicable to servers.</p>
 </div>
 </body>


### PR DESCRIPTION
Fix these warnings from bikeshed when building the WebAudio spec:

WARNING: Unexported dfn that's not referenced locally - did you mean to export it?
+<dfn data-dfn-type="dfn" id="conformant-user-agent" data-lt="conformant user agent" data-noexport="">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn>
+WARNING: Unexported dfn that's not referenced locally - did you mean to export it?
+<dfn data-dfn-type="dfn" id="conformant-server" data-lt="conformant
server" data-noexport="">conformant server<a class="self-link" href="#conformant-server"></a></dfn>