### PR TITLE
Separate out "date required" from "snapshot" statuses

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -78,7 +78,8 @@ shortToLongStatus = {
     "fido/PS": "Proposed Standard",
     "fido/FD": "Final Document"
 }
-snapshotStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO", "whatwg/RD"]
+snapshotStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO"]
+datedStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO", "whatwg/RD"]
 unlevelledStatuses = ["LS", "LD", "DREAM", "w3c/UD", "LS-COMMIT", "LS-BRANCH", "FINDING", "DRAFT-FINDING", "whatwg/RD"]
 deadlineStatuses = ["w3c/LCWD", "w3c/PR"]
 noEDStatuses = ["LS", "LS-COMMIT", "LS-BRANCH", "LD", "FINDING", "DRAFT-FINDING", "DREAM", "iso/NP", "whatwg/RD"]

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -179,8 +179,9 @@ class MetadataManager:
             requiredSingularKeys['ED'] = 'ED'
         if self.status in config.deadlineStatuses:
             requiredSingularKeys['deadline'] = 'Deadline'
-        if self.status in config.snapshotStatuses:
+        if self.status in config.datedStatuses:
             recommendedSingularKeys['date'] = 'Date'
+        if self.status in config.snapshotStatuses:
             requiredSingularKeys['TR'] = "TR"
         if self.status not in config.unlevelledStatuses:
             requiredSingularKeys['level'] = 'Level'


### PR DESCRIPTION
In particular, this allows WHATWG review drafts to require the "Date" metadata, but not require "TR".