### PR TITLE
Remove inline syntax highlighting styles for WHATWG

### DIFF
--- a/bikeshed/boilerplate/whatwg/defaults.include
+++ b/bikeshed/boilerplate/whatwg/defaults.include
@@ -4,7 +4,7 @@
   "Use Dfn Panels": "yes",
   "Status": "LS",
   "No Editor": "true",
-  "Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters, omit feedback-header, omit conformance, omit issues-index",
+  "Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters, omit style-syntax-highlighting, omit feedback-header, omit conformance, omit issues-index",
   "Complain About": "missing-example-ids yes, accidental-2119 yes",
   "Metadata Order": "Participate, Commits, Tests, *, !*",
   "Informative Classes": "domintro"


### PR DESCRIPTION
They will be incorporated into the shared stylesheet by https://github.com/whatwg/whatwg.org/pull/209.