### PR TITLE
Don't include dfn panel styles in WHATWG RDs

### DIFF
--- a/bikeshed/boilerplate/whatwg/defaults-RD.include
+++ b/bikeshed/boilerplate/whatwg/defaults-RD.include
@@ -2,7 +2,7 @@
   "Default Biblio Status": "current",
   "Use Dfn Panels": "no",
   "No Editor": "true",
-  "Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters, omit style-syntax-highlighting, omit feedback-header, omit conformance, omit issues-index",
+  "Boilerplate": "omit style-md-lists, omit style-autolinks, omit style-selflinks, omit style-counters, omit style-syntax-highlighting, omit style-dfn-panel, omit feedback-header, omit conformance, omit issues-index",
   "Complain About": "missing-example-ids yes, accidental-2119 yes",
   "Informative Classes": "domintro",
   "Metadata Include": "Translations no",


### PR DESCRIPTION
DFN panels are not included anyway.

(I wonder if "Use Dfn Panels: No" should do this automatically?)