### PR TITLE
Make houdini specs link to only the spec's github issues (by label).

### DIFF
--- a/bikeshed/boilerplate/houdini/defaults.include
+++ b/bikeshed/boilerplate/houdini/defaults.include
@@ -2,5 +2,7 @@
 	"Mailing List": "public-houdini@w3.org",
 	"Mailing List Archives": "http://lists.w3.org/Archives/Public/public-houdini/",
 	"Repository": "w3c/css-houdini-drafts",
+	"!Issue Tracking": "<a href='https://github.com/w3c/css-houdini-drafts/labels/[VSHORTNAME]'>GitHub Issues</a>",
+	"Boilerplate": "repository-issue-tracking no",
 	"Infer CSS Dfns": "yes"
 }


### PR DESCRIPTION
Houdini specs are currently (without this patch) linking to all of the issues in the repo rather than the ones for just their spec.

This copies the approach taken for csswg specs.