### PR TITLE
Minor fixes to the project name and favicon for WG14 and WG21 boilerplate

### DIFF
--- a/bikeshed/boilerplate/wg14/defaults.include
+++ b/bikeshed/boilerplate/wg14/defaults.include
@@ -2,5 +2,6 @@
     "Default Highlight": "c"
 ,   "Editor Term": "Author, Authors"
 ,   "Boilerplate": "repository-issue-tracking off"
-,   "!Project": "ISO JTC1/SC22/WG14: Programming Language C"
+,   "!Project": "ISO/IEC JTC1/SC22/WG14 9899: Programming Language — C"
+,   "Favicon": "https://isocpp.org/favicon.ico"
 }

--- a/bikeshed/boilerplate/wg21/defaults.include
+++ b/bikeshed/boilerplate/wg21/defaults.include
@@ -2,6 +2,6 @@
     "Default Highlight": "c++"
 ,   "Editor Term": "Author, Authors"
 ,   "Boilerplate": "repository-issue-tracking off"
-,   "!Project": "ISO JTC1/SC22/WG21: Programming Language C++"
+,   "!Project": "ISO/IEC JTC1/SC22/WG21 14882: Programming Language — C++"
 ,   "Favicon": "https://isocpp.org/favicon.ico"
 }


### PR DESCRIPTION
* Correct the project for WG14 and WG21 boilerplate (include "IEC", add spec #s, add emdash). We wouldn't want IEC to think we forgot them!
* Add ISO favicon to WG14 boilerplate.