### PR TITLE
Do not generate the obsolete "Media" entry in propdef tables

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -489,7 +489,7 @@ def addPropertyIndex(doc):
             *[E.td(prop.get(column,"")) for column in columns[1:]])
     if len(props):
         # Set up the initial table columns for properties
-        columns = ["Name", "Value", "Initial", "Applies to", "Inherited", "Percentages", "Media"]
+        columns = ["Name", "Value", "Initial", "Applies to", "Inherited", "Percentages"]
         # Add any additional keys used in the document.
         allKeys = set()
         for prop in props:

--- a/bikeshed/datablocks.py
+++ b/bikeshed/datablocks.py
@@ -229,7 +229,7 @@ def transformPropdef(lines, doc, firstLine, lineNum=None, **kwargs):
     elif "shorthand" in firstLine:
         attrs["Name"] = None
         attrs["Value"] = None
-        for defaultKey in ["Initial", "Applies to", "Inherited", "Percentages", "Media", "Computed value", "Animation type"]:
+        for defaultKey in ["Initial", "Applies to", "Inherited", "Percentages", "Computed value", "Animation type"]:
             attrs[defaultKey] = "see individual properties"
         attrs["Canonical order"] = "per grammar"
         ret = ["<table class='def propdef'{forHint}{lineNumAttr}>".format(forHint=forHint, lineNumAttr=lineNumAttr)]
@@ -240,7 +240,6 @@ def transformPropdef(lines, doc, firstLine, lineNum=None, **kwargs):
         attrs["Applies to"] = "all elements"
         attrs["Inherited"] = None
         attrs["Percentages"] = "n/a"
-        attrs["Media"] = "visual"
         attrs["Computed value"] = "as specified"
         attrs["Canonical order"] = "per grammar"
         attrs["Animation type"] = "discrete"

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1612,7 +1612,6 @@ and let the processor automatically generate a <{table}> from it:
 	Inherited: no
 	Computed value: as specified, with lengths made absolute
 	Percentages: relative to the <a>flex container's</a> inner <a>main size</a>
-	Media: visual
 	Animation type: length
 	</pre>
 </xmp>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1058,9 +1058,10 @@ Possible extra rowspan handling
 			   comprising the first items of each top-level section. */
 			margin-top: 1.1rem;
 		}
-		#toc .secno {
+		#toc#toc .secno { /* Ugh, need more specificity to override base.css */
 			grid-column: 1;
 			width: auto;
+			margin-left: 0;
 		}
 		#toc .content {
 			grid-column: 2;
@@ -1211,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version ee4bd4642f06996491f80990f7b1050ff9dcf622" name="generator">
+  <meta content="Bikeshed version fcc415631048dc853fb05bf76f2b421987cae69b" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="ee4bd4642f06996491f80990f7b1050ff9dcf622" name="document-revision">
+  <meta content="fcc415631048dc853fb05bf76f2b421987cae69b" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1524,7 +1525,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-07-01">1 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-07-06">6 July 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1539,7 +1540,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 1 July 2018,
+In addition, as of 6 July 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -3103,7 +3104,6 @@ Applies to: <span class="p">&lt;</span><span class="nt">a</span><span class="p">
 Inherited: no
 Computed value: as specified, with lengths made absolute
 Percentages: relative to the <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>flex container’s<span class="p">&lt;/</span><span class="nt">a</span><span class="p">></span> inner <span class="p">&lt;</span><span class="nt">a</span><span class="p">></span>main size<span class="p">&lt;/</span><span class="nt">a</span><span class="p">></span>
-Media: visual
 Animation type: length
 <span class="p">&lt;/</span><span class="nt">pre</span><span class="p">></span>
 </pre>

--- a/tests/github/WICG/aspect-ratio/overview.html
+++ b/tests/github/WICG/aspect-ratio/overview.html
@@ -1485,9 +1485,6 @@ the aspect-ratio property which allows you to do this.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>same as specified value 
      <tr>
@@ -1496,6 +1493,9 @@ the aspect-ratio property which allows you to do this.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>discrete 
+     <tr>
+      <th>Media:
+      <td>visual 
    </table>
    <p class="note" role="note"><span>Note:</span> The term "min or max constraints" refers to <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-min-width" id="ref-for-propdef-min-width">min-width</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-max-width" id="ref-for-propdef-max-width">max-width</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-min-height" id="ref-for-propdef-min-height">min-height</a>, and <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-max-height" id="ref-for-propdef-max-height">max-height</a>, 
  whichever is appropriate for the dimension in question.</p>
@@ -1849,10 +1849,10 @@ Aspect based sizing: the aspect-ratio property</a> <a href="#ref-for-valdef-page
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-aspect-ratio" id="ref-for-propdef-aspect-ratio①④">aspect-ratio</a>
@@ -1861,10 +1861,10 @@ Aspect based sizing: the aspect-ratio property</a> <a href="#ref-for-valdef-page
       <td>block level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>same as specified value
+      <td>visual
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>

--- a/tests/github/WICG/logical-sizing-properties/index.html
+++ b/tests/github/WICG/logical-sizing-properties/index.html
@@ -1482,14 +1482,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
       <th>Canonical order:
       <td>per grammar 
+     <tr>
+      <th>Media:
+      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>see individual properties 
@@ -1555,9 +1555,6 @@ If both <a class="property" data-link-type="propdesc">inline-size-dimension</a> 
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>same as specified value 
      <tr>
@@ -1566,6 +1563,9 @@ If both <a class="property" data-link-type="propdesc">inline-size-dimension</a> 
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>discrete 
+     <tr>
+      <th>Media:
+      <td>visual 
    </table>
    <p class="note" role="note"><span>Note:</span> The term "min or max constraints" refers to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-min-width" id="ref-for-propdef-min-width">min-width</a>, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-max-width" id="ref-for-propdef-max-width">max-width</a>, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-min-height" id="ref-for-propdef-min-height">min-height</a>, and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-max-height" id="ref-for-propdef-max-height">max-height</a>, whichever is appropriate for the dimension in question.</p>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef-aspect-ratio" id="ref-for-propdef-aspect-ratio⑧">aspect-ratio</a> property controls the resolution of underspecified values for the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width" id="ref-for-propdef-width">width</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-height" id="ref-for-propdef-height">height</a> properties of elements in CSS, such that the ratio of the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size" id="ref-for-propdef-inline-size⑦">inline-size</a> and '<a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-logical-1/#propdef-block-size" id="ref-for-propdef-block-size⑦">block-size</a> is a specific value.</p>
@@ -1966,11 +1966,11 @@ Aspect based sizing: the aspect-ratio property</a> <a href="#ref-for-valdef-page
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-aspect-ratio" id="ref-for-propdef-aspect-ratio②①">aspect-ratio</a>
@@ -1979,11 +1979,11 @@ Aspect based sizing: the aspect-ratio property</a> <a href="#ref-for-valdef-page
       <td>block level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
       <td>same as specified value
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-size" id="ref-for-propdef-size②">size</a>
       <td>&lt;sizing> &lt;‘box-sizing’>?
@@ -1991,11 +1991,11 @@ Aspect based sizing: the aspect-ratio property</a> <a href="#ref-for-valdef-page
       <td>see individual properties
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>
       <td>per grammar
       <td>see individual properties
+      <td>visual
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>

--- a/tests/github/WICG/overscroll-behavior/index.html
+++ b/tests/github/WICG/overscroll-behavior/index.html
@@ -1633,14 +1633,14 @@ use <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dom-event-prevent
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
       <th>Canonical order:
       <td><abbr title="follows order of property value definition">per grammar</abbr>
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>no
@@ -1670,14 +1670,14 @@ axis should be considered independently.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
       <th>Canonical order:
       <td><abbr title="follows order of property value definition">per grammar</abbr>
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>no
@@ -1930,10 +1930,10 @@ cause a scroll.
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior" id="ref-for-propdef-overscroll-behavior⑤">overscroll-behavior</a>
@@ -1942,10 +1942,10 @@ cause a scroll.
       <td>scroll container elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>see individual properties
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior-x" id="ref-for-propdef-overscroll-behavior-x①">overscroll-behavior-x</a>
       <td>contain | none | auto
@@ -1953,10 +1953,10 @@ cause a scroll.
       <td>scroll container elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-overscroll-behavior-y" id="ref-for-propdef-overscroll-behavior-y①">overscroll-behavior-y</a>
       <td>contain | none | auto
@@ -1964,10 +1964,10 @@ cause a scroll.
       <td>scroll container elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
+      <td>visual
    </table>
   </div>
   <aside class="dfn-panel" data-for="scroll-chaining">

--- a/tests/github/WICG/scroll-animations/Overview.html
+++ b/tests/github/WICG/scroll-animations/Overview.html
@@ -750,9 +750,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-animation-timel
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
      <tr>
@@ -761,6 +758,9 @@ the <a class="property" data-link-type="propdesc" href="#propdef-animation-timel
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>no
+     <tr>
+      <th>Media:
+      <td>interactive
    </table>
    <p><dfn class="dfn-paneled css" data-dfn-type="type" data-export="" id="typedef-single-animation-timeline">&lt;single-animation-timeline></dfn> = auto | scroll([element(<a class="production css" data-link-type="type" href="https://drafts.csswg.org/selectors-4/#typedef-id-selector" id="ref-for-typedef-id-selector">&lt;id-selector></a>)[, <a class="production css" data-link-type="type" href="#typedef-scroll-direction" id="ref-for-typedef-scroll-direction">&lt;scroll-direction></a>[, <a class="production css" data-link-type="type" href="#typedef-scroll-offset" id="ref-for-typedef-scroll-offset">&lt;scroll-offset></a>[, <span class="production">&lt;scroll-offset></span>[, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css2/aural.html#value-def-time" id="ref-for-value-def-time" title="Expands to: s | ms">&lt;time></a>[, <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-fill-mode" id="ref-for-typedef-single-animation-fill-mode">&lt;single-animation-fill-mode></a>]]]]]])</p>
    <p><dfn class="dfn-paneled css" data-dfn-type="type" data-export="" id="typedef-scroll-direction">&lt;scroll-direction></dfn> = auto | block | inline | horizontal | vertical</p>
@@ -1355,10 +1355,10 @@ on this subject.</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-animation-timeline" id="ref-for-propdef-animation-timeline⑤">animation-timeline</a>
@@ -1367,10 +1367,10 @@ on this subject.</p>
       <td>all elements, ::before and ::after pseudo-elements
       <td>none
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
+      <td>interactive
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>

--- a/tests/github/WICG/spatial-navigation/index.html
+++ b/tests/github/WICG/spatial-navigation/index.html
@@ -2635,9 +2635,6 @@ when <var>distance</var> is defined as follows:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3622,7 +3619,6 @@ Interface NavigationEvent</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3634,7 +3630,6 @@ Interface NavigationEvent</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview-2.bs
+++ b/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview-2.bs
@@ -1,3 +1,6 @@
+<pre class=metadata>
+Repository: https://github.com/tabatkins/bikeshed
+</pre>
 Introduction {#introduction}
 ============================
 

--- a/tests/github/w3c/csswg-drafts/css-align-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-align-3/Overview.bs
@@ -864,7 +864,6 @@ The 'justify-content' And 'align-content' Properties</h3>
 	Applies to: block containers, multicol containers, flex containers, and grid containers
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -876,7 +875,6 @@ The 'justify-content' And 'align-content' Properties</h3>
 	Applies to: multicol containers, flex containers, and grid containers
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1044,7 +1042,6 @@ Content-Distribution Shorthand: the 'place-content' property</h3>
 	Applies to: block containers, flex containers, and grid containers
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: see individual properties
 	Animatable: no
 	</pre>
@@ -1167,7 +1164,6 @@ Inline/Main-Axis Alignment: the 'justify-self' property</h3>
 	Applies to: block-level boxes, absolutely-positioned boxes, and grid items
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1416,7 +1412,6 @@ Block/Cross-Axis Alignment: the 'align-self' property</h3>
 	Applies to: flex items, grid items, and absolutely-positioned boxes
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1628,7 +1623,6 @@ Self-Alignment Shorthand: the 'place-self' property</h3>
 	Applies to: block-level boxes, absolutely-positioned boxes, and grid items
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: see individual properties
 	Animatable: no
 	</pre>
@@ -1701,7 +1695,6 @@ Inline/Main-Axis Alignment: the 'justify-items' property</h3>
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value, except for ''justify-items/legacy'' (see prose)
 	Animatable: no
 	</pre>
@@ -1739,7 +1732,6 @@ Block/Cross-Axis Alignment: the 'align-items' property</h3>
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1760,7 +1752,6 @@ Self-Alignment Shorthand: the 'place-items' property</h3>
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: see individual properties
 	Animatable: no
 	</pre>
@@ -1809,7 +1800,6 @@ Row and Column Gutters: the 'row-gap' and 'column-gap' properties</h3>
 	Applies to: <a>multi-column elements</a>, <a>flex containers</a>, <a>grid containers</a>
 	Inherited: no
 	Percentages: refer to corresponding dimension of the content area
-	Media: visual
 	Computed value: as specified, with <<length>>s made absolute
 	Animatable: as length, percentage, or calc
 	</pre>
@@ -1902,7 +1892,6 @@ Gap Shorthand: the 'gap' property</h3>
 	Applies to: <a>multi-column elements</a>, <a>flex containers</a>, <a>grid containers</a>
 	Inherited: no
 	Percentages: refer to corresponding dimension of the content area
-	Media: visual
 	Computed value: see individual properties
 	Animatable: as length, percentage, or calc
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-align-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-align-3/Overview.html
@@ -916,9 +916,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -948,9 +945,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1097,9 +1091,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -1192,9 +1183,6 @@ whichever they end up equivalent to.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1404,9 +1392,6 @@ but <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1591,9 +1576,6 @@ but <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -1652,9 +1634,6 @@ but <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value, except for <a class="css" data-link-type="maybe" href="#valdef-justify-items-legacy" id="ref-for-valdef-justify-items-legacy③">legacy</a> (see prose) 
      <tr>
@@ -1704,9 +1683,6 @@ but <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1741,9 +1717,6 @@ but <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -1791,9 +1764,6 @@ and <a href="http://www.w3.org/TR/css-grid/">grid layout</a>.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to corresponding dimension of the content area 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>s made absolute 
@@ -1882,9 +1852,6 @@ and a used value of <span class="css">0px</span> in all other contexts.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to corresponding dimension of the content area 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -3381,7 +3348,6 @@ Baseline Alignment Details</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3393,7 +3359,6 @@ Baseline Alignment Details</a>
       <td>block containers, multicol containers, flex containers, and grid containers
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -3404,7 +3369,6 @@ Baseline Alignment Details</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -3415,7 +3379,6 @@ Baseline Alignment Details</a>
       <td>flex items, grid items, and absolutely-positioned boxes
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -3426,7 +3389,6 @@ Baseline Alignment Details</a>
       <td>multi-column elements, flex containers, grid containers
       <td>no
       <td>refer to corresponding dimension of the content area
-      <td>visual
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with &lt;length>s made absolute
@@ -3437,7 +3399,6 @@ Baseline Alignment Details</a>
       <td>multi-column elements, flex containers, grid containers
       <td>no
       <td>refer to corresponding dimension of the content area
-      <td>visual
       <td>as length, percentage, or calc
       <td>per grammar
       <td>see individual properties
@@ -3448,7 +3409,6 @@ Baseline Alignment Details</a>
       <td>multicol containers, flex containers, and grid containers
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -3459,7 +3419,6 @@ Baseline Alignment Details</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value, except for legacy (see prose)
@@ -3470,7 +3429,6 @@ Baseline Alignment Details</a>
       <td>block-level boxes, absolutely-positioned boxes, and grid items
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -3481,7 +3439,6 @@ Baseline Alignment Details</a>
       <td>block containers, flex containers, and grid containers
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>see individual properties
@@ -3492,7 +3449,6 @@ Baseline Alignment Details</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>see individual properties
@@ -3503,7 +3459,6 @@ Baseline Alignment Details</a>
       <td>block-level boxes, absolutely-positioned boxes, and grid items
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>see individual properties
@@ -3514,7 +3469,6 @@ Baseline Alignment Details</a>
       <td>multi-column elements, flex containers, grid containers
       <td>no
       <td>refer to corresponding dimension of the content area
-      <td>visual
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with &lt;length>s made absolute

--- a/tests/github/w3c/csswg-drafts/css-animations-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-animations-1/Overview.bs
@@ -498,7 +498,6 @@ The 'animation-name' property</h3>
 	Inherited: none
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -531,7 +530,6 @@ The 'animation-duration' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -588,7 +586,6 @@ The 'animation-timing-function' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -622,7 +619,6 @@ The 'animation-iteration-count' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -665,7 +661,6 @@ The 'animation-direction' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -712,7 +707,6 @@ The 'animation-play-state' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -752,7 +746,6 @@ The 'animation-delay' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -796,7 +789,6 @@ The 'animation-fill-mode' property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>
@@ -847,7 +839,6 @@ The 'animation' shorthand property</h3>
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: interactive
 	Computed value: As specified
 	Canonical order: per grammar
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
@@ -787,9 +787,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
      <tr>
@@ -831,9 +828,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
@@ -888,9 +882,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
      <tr>
@@ -934,9 +925,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
@@ -985,9 +973,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
@@ -1039,9 +1024,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
      <tr>
@@ -1090,9 +1072,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
@@ -1148,9 +1127,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
      <tr>
@@ -1203,9 +1179,6 @@ handlers on elements, <code>Document</code> objects, and <code>Window</code> obj
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified 
@@ -2424,7 +2397,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2436,7 +2408,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2447,7 +2418,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2458,7 +2428,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2469,7 +2438,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2480,7 +2448,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2491,7 +2458,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2502,7 +2468,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>none
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2513,7 +2478,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified
@@ -2524,7 +2488,6 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
       <td>all elements, ::before and ::after pseudo-elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified

--- a/tests/github/w3c/csswg-drafts/css-animations-2/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-animations-2/Overview.bs
@@ -312,7 +312,6 @@ Applies to: all elements, ::before and ::after pseudo-elements
 Inherited: none
 Animatable: no
 Percentages: N/A
-Media: interactive
 Computed value: As specified
 Canonical order: per grammar
 </pre>

--- a/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
@@ -589,9 +589,6 @@ it must be set to true.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
      <tr>
@@ -1393,7 +1390,6 @@ elem<span class="p">.</span>getAnimations<span class="p">()[</span><span class="
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1405,7 +1401,6 @@ elem<span class="p">.</span>getAnimations<span class="p">()[</span><span class="
       <td>all elements, ::before and ::after pseudo-elements
       <td>none
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>As specified

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.bs
@@ -211,9 +211,6 @@ the background created by the background properties.
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed value:
       <td>the computed color
     <tr>
@@ -254,9 +251,6 @@ value associated with the bottom-most background image layer.
     <tr>
       <th>Percentages:
       <td>N/A
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>as specified, but with URIs made absolute
@@ -343,9 +337,6 @@ other, fully opaque images).
     <tr>
       <th>Percentages:
       <td>N/A
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>A list, each item consisting of:
@@ -503,9 +494,6 @@ layer.
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed value:
       <td>as specified
     <tr>
@@ -614,9 +602,6 @@ layer.
       <th>Percentages:
       <td>refer to size of <span class=index>background positioning
       area</span> <em>minus</em> size of background image; see text
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>A list, each item consisting of:
@@ -804,9 +789,6 @@ image layer.
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed value:
       <td>as specified
     <tr>
@@ -875,9 +857,6 @@ layer.
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed value:
       <td>as specified
     <tr>
@@ -942,9 +921,6 @@ layer.
     <tr>
       <th>Percentages:
       <td>see text
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>as specified, but with lengths made absolute and omitted ''background-size/auto'' keywords filled in
@@ -1158,9 +1134,6 @@ layer.
     <tr>
       <th>Percentages:
       <td>see individual properties
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>see individual properties
@@ -1410,9 +1383,6 @@ color ('border-color'), and thickness ('border-width') of the border.
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>the computed color
   <tr>
@@ -1439,9 +1409,6 @@ color ('border-color'), and thickness ('border-width') of the border.
   <tr>
     <th>Percentages:
     <td>N/A
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>see individual properties
@@ -1486,9 +1453,6 @@ also the same as top.
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>specified value
   <tr>
@@ -1515,9 +1479,6 @@ also the same as top.
   <tr>
     <th>Percentages:
     <td>N/A
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>see individual properties
@@ -1642,9 +1603,6 @@ the padding is less than the radius of the corner.
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed&nbsp;value:
       <td>absolute length; zero if the border style is ''border-style/none'' or ''hidden''
     <tr>
@@ -1671,9 +1629,6 @@ the padding is less than the radius of the corner.
     <tr>
       <th>Percentages:
       <td>see individual properties
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed&nbsp;value:
       <td>see individual properties
@@ -1731,9 +1686,6 @@ style is ''border-style/none'' and therefore the used width is 0.
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>see individual properties
   <tr>
@@ -1766,9 +1718,6 @@ values are set to their initial values.
   <tr>
     <th>Percentages:
     <td>N/A
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>see individual properties
@@ -1866,9 +1815,6 @@ the 'color' property. The fact that the
     <td>Refer to corresponding dimension of the
         <a href="https://www.w3.org/TR/CSS2/box.html#box-dimensions">border box</a>.
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>two absolute <<length>> or percentages
   <tr>
@@ -1896,9 +1842,6 @@ the 'color' property. The fact that the
     <th>Percentages:
     <td>Refer to corresponding dimension of the
         <a href="https://www.w3.org/TR/CSS2/box.html#box-dimensions">border box</a>.
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>see individual properties
@@ -2275,9 +2218,6 @@ this:
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>''border-image-source/none'' or the image with its URI made absolute
   <tr>
@@ -2314,9 +2254,6 @@ and the border image is drawn as described in the sections below.
   <tr>
     <th>Percentages:
     <td>refer to size of the border image
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>as four values, each a number or percentage, and optionally a ''fill'' keyword
@@ -2399,9 +2336,6 @@ with no <i>specified size</i> and the <i>border image area</i> as the <i>default
     <th>Percentages:
     <td>Relative to width/height of the <a>border image area</a>
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>four values, each a percentage, number, ''border-image-width/auto'' keyword, or <<length>> made absolute
   <tr>
@@ -2475,9 +2409,6 @@ them by <var>f</var>.
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>four values, each a number or <<length>> made absolute
   <tr>
@@ -2532,9 +2463,6 @@ viewport.
   <tr>
     <th>Percentages:
     <td>N/A
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>two keywords, one for each axis
@@ -2673,9 +2601,6 @@ in four steps:
     <th>Percentages:
     <td>N/A
   <tr>
-    <th>Media:
-    <td>visual
-  <tr>
     <th>Computed value:
     <td>See individual properties
   <tr>
@@ -2730,9 +2655,6 @@ has been moved to the <a href="https://www.w3.org/TR/css3-break/">CSS Fragmentat
   <tr>
     <th>Percentages:
     <td>N/A
-  <tr>
-    <th>Media:
-    <td>visual
   <tr>
     <th>Computed value:
     <td>any <<length>> made absolute; any specified color computed; otherwise as specified

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.html
@@ -518,9 +518,6 @@ the background created by the background properties. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>the computed color 
      <tr>
@@ -556,9 +553,6 @@ color is drawn behind any background images. </p>
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>as specified, but with URIs made absolute 
@@ -626,9 +620,6 @@ other, fully opaque images). </p>
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>A list, each item consisting of:
@@ -744,9 +735,6 @@ layer. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>as specified 
      <tr>
@@ -835,9 +823,6 @@ layer. </p>
       <th>Percentages: 
       <td>refer to size of <span class="index">background positioning
       area</span> <em>minus</em> size of background image; see text 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>A list, each item consisting of:
@@ -990,9 +975,6 @@ image layer. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>as specified 
      <tr>
@@ -1044,9 +1026,6 @@ layer. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>as specified 
      <tr>
@@ -1096,9 +1075,6 @@ layer. </p>
      <tr>
       <th>Percentages: 
       <td>see text 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>as specified, but with lengths made absolute and omitted <a class="css" data-link-type="maybe" href="#valdef-background-size-auto" id="ref-for-valdef-background-size-auto">auto</a> keywords filled in 
@@ -1264,9 +1240,6 @@ layer. </p>
      <tr>
       <th>Percentages: 
       <td>see individual properties 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -1447,9 +1420,6 @@ color (<a class="property" data-link-type="propdesc" href="#propdef-border-color
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>the computed color 
      <tr>
@@ -1476,9 +1446,6 @@ color (<a class="property" data-link-type="propdesc" href="#propdef-border-color
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -1515,9 +1482,6 @@ also the same as top. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>specified value 
      <tr>
@@ -1544,9 +1508,6 @@ also the same as top. </p>
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -1634,9 +1595,6 @@ the padding is less than the radius of the corner. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>absolute length; zero if the border style is <a class="css" data-link-type="maybe" href="#valdef-line-style-none" id="ref-for-valdef-line-style-none①">none</a> or <span class="css">hidden</span> 
      <tr>
@@ -1663,9 +1621,6 @@ the padding is less than the radius of the corner. </p>
      <tr>
       <th>Percentages: 
       <td>see individual properties 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -1709,9 +1664,6 @@ style is <a class="css" data-link-type="maybe" href="#valdef-line-style-none" id
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>see individual properties 
      <tr>
@@ -1741,9 +1693,6 @@ values are set to their initial values. </p>
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -1818,9 +1767,6 @@ the <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/cs
       <th>Percentages: 
       <td>Refer to corresponding dimension of the <a href="https://www.w3.org/TR/CSS2/box.html#box-dimensions">border box</a>. 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>two absolute <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#length-value" id="ref-for-length-value③" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> or percentages 
      <tr>
@@ -1847,9 +1793,6 @@ the <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/cs
      <tr>
       <th>Percentages: 
       <td>Refer to corresponding dimension of the <a href="https://www.w3.org/TR/CSS2/box.html#box-dimensions">border box</a>. 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -2156,9 +2099,6 @@ this: </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td><span class="css">none</span> or the image with its URI made absolute 
      <tr>
@@ -2192,9 +2132,6 @@ and the border image is drawn as described in the sections below. </p>
      <tr>
       <th>Percentages: 
       <td>refer to size of the border image 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>as four values, each a number or percentage, and optionally a <a class="css" data-link-type="maybe" href="#border-image-slice-fill" id="ref-for-border-image-slice-fill①">fill</a> keyword 
@@ -2264,9 +2201,6 @@ then it is sized using the <a href="https://www.w3.org/TR/css3-images/#default-s
       <th>Percentages: 
       <td>Relative to width/height of the <a data-link-type="dfn" href="#border-image-area" id="ref-for-border-image-area②">border image area</a> 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>four values, each a percentage, number, <a class="css" data-link-type="maybe" href="#valdef-border-image-width-auto" id="ref-for-valdef-border-image-width-auto">auto</a> keyword, or <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#length-value" id="ref-for-length-value④" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> made absolute 
      <tr>
@@ -2327,9 +2261,6 @@ them by <var>f</var>. </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>four values, each a number or <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#length-value" id="ref-for-length-value⑥" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> made absolute 
      <tr>
@@ -2376,9 +2307,6 @@ viewport. </p>
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>two keywords, one for each axis 
@@ -2512,9 +2440,6 @@ in four steps: </p>
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>See individual properties 
      <tr>
@@ -2557,9 +2482,6 @@ has been moved to the <a href="https://www.w3.org/TR/css3-break/">CSS Fragmentat
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>any <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#length-value" id="ref-for-length-value⑧" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> made absolute; any specified color computed; otherwise as specified 
@@ -3770,7 +3692,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Applies to
       <th scope="col">Com­puted value
@@ -3783,7 +3704,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -3795,7 +3715,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>as specified
@@ -3807,7 +3726,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>as specified
@@ -3819,7 +3737,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as color
       <td>
       <td>the computed color
@@ -3831,7 +3748,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>as specified, but with URIs made absolute
@@ -3843,7 +3759,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>as specified
@@ -3856,7 +3771,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>refer to size of background positioning
       area minus size of background image; see text
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>
       <td>A list, each item consisting of:
@@ -3870,7 +3784,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>A list, each item consisting of:
@@ -3883,7 +3796,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>see text
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc and keywords
       <td>
       <td>as specified, but with lengths made absolute and omitted auto keywords filled in
@@ -3897,7 +3809,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -3911,7 +3822,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -3923,7 +3833,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as color
       <td>
       <td>the computed color
@@ -3936,7 +3845,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>Refer to corresponding dimension of the
         border box.
-      <td>visual
       <td>as two values of length, percentage, or calc
       <td>
       <td>two absolute &lt;length> or percentages
@@ -3949,7 +3857,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>Refer to corresponding dimension of the
         border box.
-      <td>visual
       <td>as two values of length, percentage, or calc
       <td>
       <td>two absolute &lt;length> or percentages
@@ -3961,7 +3868,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>specified value
@@ -3973,7 +3879,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>
       <td>no
       <td>N/A
-      <td>visual
       <td>as length
       <td>all elements
       <td>
@@ -3985,7 +3890,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4001,7 +3905,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>See individual properties
       <td>no
       <td>N/A
-      <td>visual
       <td>See individual properties
       <td>
       <td>See individual properties
@@ -4014,7 +3917,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     collapse
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>four values, each a number or &lt;length> made absolute
@@ -4027,7 +3929,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     collapse
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>two keywords, one for each axis
@@ -4040,7 +3941,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     collapse
       <td>no
       <td>refer to size of the border image
-      <td>visual
       <td>no
       <td>
       <td>as four values, each a number or percentage, and optionally a fill keyword
@@ -4053,7 +3953,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     collapse
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>none or the image with its URI made absolute
@@ -4066,7 +3965,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     collapse
       <td>no
       <td>Relative to width/height of the border image area
-      <td>visual
       <td>no
       <td>
       <td>four values, each a percentage, number, auto keyword, or &lt;length> made absolute
@@ -4080,7 +3978,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4092,7 +3989,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as color
       <td>
       <td>the computed color
@@ -4104,7 +4000,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>specified value
@@ -4116,7 +4011,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>
       <td>no
       <td>N/A
-      <td>visual
       <td>as length
       <td>all elements
       <td>
@@ -4129,7 +4023,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>Refer to corresponding dimension of the
         border box.
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4143,7 +4036,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4155,7 +4047,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as color
       <td>
       <td>the computed color
@@ -4167,7 +4058,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>specified value
@@ -4179,7 +4069,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>
       <td>no
       <td>N/A
-      <td>visual
       <td>as length
       <td>all elements
       <td>
@@ -4191,7 +4080,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4205,7 +4093,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>see individual properties
@@ -4217,7 +4104,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as color
       <td>
       <td>the computed color
@@ -4230,7 +4116,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>Refer to corresponding dimension of the
         border box.
-      <td>visual
       <td>as two values of length, percentage, or calc
       <td>
       <td>two absolute &lt;length> or percentages
@@ -4243,7 +4128,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>no
       <td>Refer to corresponding dimension of the
         border box.
-      <td>visual
       <td>as two values of length, percentage, or calc
       <td>
       <td>two absolute &lt;length> or percentages
@@ -4255,7 +4139,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>specified value
@@ -4267,7 +4150,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>
       <td>no
       <td>N/A
-      <td>visual
       <td>as length
       <td>all elements
       <td>
@@ -4279,7 +4161,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>all elements
       <td>
@@ -4291,7 +4172,6 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as shadow list
       <td>
       <td>any &lt;length> made absolute; any specified color computed; otherwise as specified

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.bs
@@ -180,9 +180,6 @@ Painting Area: the 'background-clip' property</h3>
 	    <th>Percentages:
 	    <td>N/A
 	  <tr>
-	    <th>Media:
-	    <td>visual
-	  <tr>
 	    <th>Computed value:
 	    <td>the computed color
 	  <tr>
@@ -209,9 +206,6 @@ Painting Area: the 'background-clip' property</h3>
 	  <tr>
 	    <th>Percentages:
 	    <td>N/A
-	  <tr>
-	    <th>Media:
-	    <td>visual
 	  <tr>
 	    <th>Computed value:
 	    <td>see individual properties

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.html
@@ -357,9 +357,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>see individual properties 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -421,9 +418,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to width of background positioning area <em>minus</em> width of background image 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword 
      <tr>
@@ -455,9 +449,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of background positioning area <em>minus</em> height of background image 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword 
@@ -491,9 +482,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to inline-size of background positioning area <em>minus</em> inline-size of background image 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword 
      <tr>
@@ -525,9 +513,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to size of background positioning area <em>minus</em> size of background image 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword 
@@ -584,9 +569,6 @@ on screen, on paper, in speech, etc.
       <th>Percentages: 
       <td>N/A 
      <tr>
-      <th>Media: 
-      <td>visual 
-     <tr>
       <th>Computed value: 
       <td>the computed color 
      <tr>
@@ -613,9 +595,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>see individual properties 
@@ -669,9 +648,6 @@ border-color: skyblue orange yellowgreen indianred, black yellow;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -703,9 +679,6 @@ border-color: skyblue orange yellowgreen indianred, black yellow;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -767,9 +740,6 @@ border-color: skyblue orange yellowgreen indianred, black yellow;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>see individual properties 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -824,9 +794,6 @@ corners: bevel 0.25em 0.25em 0 0 / 50% 50% 0 0;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to border-box 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -896,9 +863,6 @@ corners: bevel 0.25em 0.25em 0 0 / 50% 50% 0 0;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to length of border-edge side 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td><span class="css">normal</span>, or a list consisting of absolute lengths, or percentages as specified 
@@ -1548,7 +1512,6 @@ The border-clip properties</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1557,7 +1520,6 @@ The border-clip properties</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-background-position" id="ref-for-propdef-background-position③">background-position</a>
       <td>&lt;position>#
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -1573,7 +1535,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to size of background positioning area minus size of background image
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1585,7 +1546,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to inline-size of background positioning area minus inline-size of background image
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1597,7 +1557,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to width of background positioning area minus width of background image
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1609,7 +1568,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to height of background positioning area minus height of background image
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1621,7 +1579,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>See prose
       <td>
       <td>
@@ -1633,7 +1590,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to length of border-edge side
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1645,7 +1601,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to length of border-edge side
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1657,7 +1612,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to length of border-edge side
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1669,7 +1623,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to length of border-edge side
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1681,7 +1634,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>refer to length of border-edge side
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1693,7 +1645,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>
@@ -1705,7 +1656,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>See prose
       <td>
       <td>
@@ -1718,7 +1668,6 @@ The border-clip properties</a>
       <td>all elements, except table element when border-collapse is collapse
       <td>no
       <td>relative to border-box
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1730,7 +1679,6 @@ The border-clip properties</a>
       <td>all elements, except table element when border-collapse is collapse
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1742,7 +1690,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>See prose
       <td>
       <td>
@@ -1754,7 +1701,6 @@ The border-clip properties</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>See prose
       <td>
       <td>
@@ -1766,7 +1712,6 @@ The border-clip properties</a>
       <td>all elements, except table element when border-collapse is collapse
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1774,7 +1719,6 @@ The border-clip properties</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-corners" id="ref-for-propdef-corners③">corners</a>
       <td>&lt;‘corner-shape’> || &lt;‘border-radius’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties

--- a/tests/github/w3c/csswg-drafts/css-box-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-box-3/Overview.bs
@@ -1144,7 +1144,6 @@ Applies to: all elements
 Inherited: no
 Animatable: yes
 Percentages: width* of containing block
-Media: visual
 Computed value: see individual properties
 Canonical order: N/A
 </pre>
@@ -1161,7 +1160,6 @@ Applies to: all elements
 Inherited: no
 Animatable: yes
 Percentages: width* of containing block
-Media: visual
 Computed value: &lt;length&gt;
 Canonical order: N/A
 </pre>
@@ -1208,7 +1206,6 @@ Applies to: see text
 Inherited: no
 Animatable: yes
 Percentages: width* of containing block
-Media: visual
 Computed value: the percentage as specified or the
   absolute length or ''auto''
 Canonical order: N/A
@@ -1225,7 +1222,6 @@ Applies to: see text
 Inherited: no
 Animatable: yes
 Percentages: width* of containing block
-Media: visual
 Computed value: see individual properties
 Canonical order: N/A
 </pre>
@@ -1356,7 +1352,6 @@ Applies to: all elements but non-replaced inline
 Inherited: no
 Animatable: yes
 Percentages: refer to width of containing block
-Media: visual
 Computed value: the specified keyword; or the specified
     percentage (with ''border-box'' or ''content-box'' if present); or
     the absolute length (with ''border-box'' or ''content-box'' if
@@ -1376,7 +1371,6 @@ Applies to: all elements but non-replaced inline
 Inherited: no
 Animatable: yes
 Percentages: see prose
-Media: visual
 Computed value: the specified keywords, the specified
     percentage (see prose under &lt;percentage>) or the absolute
     length; ''auto'' if the property does not apply
@@ -1548,7 +1542,6 @@ Inherited: no
 Animatable: yes
 Percentages: refer to width, resp. height of
     containing block
-Media: visual
 Computed value: the percentage as specified (with
     ''border-box'' or ''content-box'', if present), the keyword as
     specified, or the absolute length (with ''border-box'' or
@@ -1569,7 +1562,6 @@ Inherited: no
 Animatable: yes
 Percentages: refer to width, resp. height of
     containing block
-Media: visual
 Computed value: the percentage as specified (with
     ''border-box'' or ''content-box'', if present); the keyword as
     specified; the absolute length (with ''border-box'' or
@@ -2771,7 +2763,6 @@ Applies to: all, but see text
 Inherited: no 
 Animatable: no
 Percentages: N/A 
-Media: visual 
 Computed value: as specified
 Canonical order: order of grammar
 </pre>
@@ -3182,7 +3173,6 @@ Applies to: <a>block-level</a> elements
 Inherited: no
 Animatable: no
 Percentages: N/A
-Media: visual 
 Computed value: as specified
 Canonical order: N/A
 </pre>
@@ -3203,7 +3193,6 @@ Applies to:      block-level elements
 Inherited:      no
 Animatable:      no
 Percentages:      N/A
-Media:      visual
 Computed value:      specified value
 Canonical order:      N/A
 </pre>
@@ -3411,7 +3400,6 @@ Applies to: non-replaced <em>block-level</em> elements
 Inherited: no
 Animatable: no
 Percentages: N/A
-Media: visual
 Computed value: as specified, except 'visible', see text
 Canonical order: N/A
 </pre>
@@ -3426,7 +3414,6 @@ Applies to: non-replaced <em>block-level</em> elements
 Inherited: no
 Animatable: no
 Percentages: N/A
-Media: visual
 Computed value: as specified, except 'visible', see text
 Canonical order: N/A
 </pre>
@@ -3671,7 +3658,6 @@ Applies to: all elements
 Inherited: yes
 Animatable: no
 Percentages: N/A
-Media: visual
 Computed value: as specified
 Canonical order: N/A
 </pre>
@@ -3990,7 +3976,6 @@ Applies to:      all block-level elements
 Inherited:      yes
 Animatable:      no
 Percentages:      N/A
-Media:      visual
 Computed value:      Same as specified value
 Canonical order:      N/A
 </pre>
@@ -4066,7 +4051,6 @@ Applies to:      all elements with a block-level inner formatting context.
 Inherited:      no
 Animatable:      yes
 Percentages:      n/a
-Media:      visual
 Computed value:      specified value
 Canonical order:      N/A
 </pre>
@@ -4107,7 +4091,6 @@ Applies to:      all block-level elements
 Inherited:      yes
 Animatable:      no
 Percentages:      N/A
-Media:      visual
 Computed value:      Same as specified value
 Canonical order:      N/A
 </pre>
@@ -4234,7 +4217,6 @@ Applies to:      all block-level elements
 Inherited:      no
 Animatable:      no
 Percentages:      N/A
-Media:      visual
 Computed value:      Same as specified value
 Canonical order:      N/A
 </pre>

--- a/tests/github/w3c/csswg-drafts/css-box-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-box-3/Overview.html
@@ -1083,9 +1083,6 @@ edge</span> of the <a data-link-type="dfn" href="#containing-block" id="ref-for-
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>width* of containing block
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1123,9 +1120,6 @@ block</em> is <em>horizontal,</em> otherwise the height </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>width* of containing block
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1185,9 +1179,6 @@ between boxes. </p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>width* of containing block
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1226,9 +1217,6 @@ block</em> is <em>horizontal,</em> otherwise the height </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>width* of containing block
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1339,9 +1327,6 @@ elements, table rows, and row groups
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to width of containing block
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the specified keyword; or the specified
 percentage (with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-border-box" id="ref-for-valdef-shape-box-border-box">border-box</a> or <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-content-box" id="ref-for-valdef-shape-box-content-box">content-box</a> if present); or
@@ -1377,9 +1362,6 @@ elements, table columns, and column groups
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see prose
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the specified keywords, the specified
@@ -1511,9 +1493,6 @@ inline elements, table rows, and row groups
       <td>refer to width, resp. height of
 containing block
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the percentage as specified (with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-border-box" id="ref-for-valdef-shape-box-border-box③">border-box</a> or <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-content-box" id="ref-for-valdef-shape-box-content-box③">content-box</a>, if present), the keyword as
 specified, or the absolute length (with <span class="css">border-box</span> or <span class="css">content-box</span>, if present)
@@ -1547,9 +1526,6 @@ elements, table rows, and row groups
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to width, resp. height of
 containing block
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the percentage as specified (with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-border-box" id="ref-for-valdef-shape-box-border-box⑤">border-box</a> or <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-content-box" id="ref-for-valdef-shape-box-content-box⑤">content-box</a>, if present); the keyword as
@@ -2367,9 +2343,6 @@ are not. </p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -2691,9 +2664,6 @@ that the opposite margin does not become negative.)</span> </p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -2726,9 +2696,6 @@ vertical text, define <dfn data-dfn-type="dfn" data-noexport="" id="clearance">c
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -2928,9 +2895,6 @@ and non-replaced <a class="css" data-link-type="maybe" href="https://drafts.cssw
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -2964,9 +2928,6 @@ and non-replaced <a class="css" data-link-type="maybe" href="https://drafts.cssw
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3173,9 +3134,6 @@ clipped. </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3449,9 +3407,6 @@ can wrap around a float. </p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3542,9 +3497,6 @@ narrower as a whole. </p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -3595,9 +3547,6 @@ the content edge, so that list markers stay close to the content: </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3718,9 +3667,6 @@ rather than one that depends on the context: </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -4947,7 +4893,6 @@ elements</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Applies to
       <th scope="col">Canonical order
@@ -4961,7 +4906,6 @@ elements</a>
       <td>block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>N/A
@@ -4975,7 +4919,6 @@ elements</a>
       <td>block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>N/A
@@ -4989,7 +4932,6 @@ elements</a>
       <td>all, but see text
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>order of grammar
@@ -5002,7 +4944,6 @@ elements</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>all block-level elements
       <td>N/A
@@ -5015,7 +4956,6 @@ elements</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>all block-level elements
       <td>N/A
@@ -5028,7 +4968,6 @@ elements</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>all block-level elements
       <td>N/A
@@ -5043,7 +4982,6 @@ available | min-content | max-content | fit-content | complex | auto
 elements, table columns, and column groups
       <td>no
       <td>see prose
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the
@@ -5059,7 +4997,6 @@ length; auto if the property does not apply
       <td>all elements with a block-level inner formatting context.
       <td>no
       <td>n/a
-      <td>visual
       <td>yes
       <td>
       <td>N/A
@@ -5072,7 +5009,6 @@ length; auto if the property does not apply
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>see text
       <td>N/A
@@ -5085,7 +5021,6 @@ length; auto if the property does not apply
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>see text
       <td>N/A
@@ -5099,7 +5034,6 @@ absolute length or auto
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>see text
       <td>N/A
@@ -5113,7 +5047,6 @@ absolute length or auto
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>see text
       <td>N/A
@@ -5127,7 +5060,6 @@ absolute length or auto
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>see text
       <td>N/A
@@ -5145,7 +5077,6 @@ elements, table rows, and row groups
       <td>no
       <td>refer to width, resp. height of
 containing block
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the
@@ -5166,7 +5097,6 @@ elements, table rows, and row groups
       <td>no
       <td>refer to width, resp. height of
 containing block
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the
@@ -5187,7 +5117,6 @@ inline elements, table rows, and row groups
       <td>no
       <td>refer to width, resp. height of
 containing block
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the
@@ -5208,7 +5137,6 @@ inline elements, table rows, and row groups
       <td>no
       <td>refer to width, resp. height of
 containing block
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the
@@ -5227,7 +5155,6 @@ no-content ]{1,2}
 and non-replaced inline-block elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>N/A
@@ -5241,7 +5168,6 @@ and non-replaced inline-block elements
 and non-replaced inline-block elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>N/A
@@ -5255,7 +5181,6 @@ and non-replaced inline-block elements
 and non-replaced inline-block elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>N/A
@@ -5268,7 +5193,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>all elements
       <td>N/A
@@ -5281,7 +5205,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>all elements
       <td>N/A
@@ -5294,7 +5217,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>all elements
       <td>N/A
@@ -5307,7 +5229,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>all elements
       <td>N/A
@@ -5320,7 +5241,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>no
       <td>width* of containing block
-      <td>visual
       <td>yes
       <td>all elements
       <td>N/A
@@ -5333,7 +5253,6 @@ and non-replaced inline-block elements
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>all elements
       <td>N/A
@@ -5348,7 +5267,6 @@ available | min-content | max-content | fit-content | auto
 elements, table rows, and row groups
       <td>no
       <td>refer to width of containing block
-      <td>visual
       <td>yes
       <td>
       <td>the length or percentage before the

--- a/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
@@ -500,9 +500,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -598,9 +595,6 @@ or that are block containers, table row groups, or table rows
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -646,9 +640,6 @@ or that are block containers, table row groups, or table rows
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -987,9 +978,6 @@ or that are block containers, table row groups, or table rows
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1708,7 +1696,6 @@ Forced Breaks</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1720,7 +1707,6 @@ Forced Breaks</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1731,7 +1717,6 @@ Forced Breaks</a>
       <td>block-level elements, table row groups, table rows (but see prose)
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1742,7 +1727,6 @@ Forced Breaks</a>
       <td>block-level elements, table row groups, table rows (but see prose)
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1754,7 +1738,6 @@ Forced Breaks</a>
 or that are block containers, table row groups, or table rows
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1765,7 +1748,6 @@ or that are block containers, table row groups, or table rows
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1776,7 +1758,6 @@ or that are block containers, table row groups, or table rows
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-cascade-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-cascade-3/Overview.html
@@ -500,9 +500,6 @@ it only applies between constructs in the same stylesheet.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>see individual properties 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -1726,7 +1723,6 @@ Importing Style Sheets: the @import rule</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1734,7 +1730,6 @@ Importing Style Sheets: the @import rule</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-all" id="ref-for-propdef-all④">all</a>
       <td>initial | inherit | unset
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties

--- a/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.bs
@@ -307,9 +307,6 @@ Resetting All Properties: the 'all' property</h3>
 			<th>Percentages:
 			<td>See individual properties
 		<tr>
-			<th>Media:
-			<td>See individual properties
-		<tr>
 			<th>Computed value:
 			<td>See individual properties
 		<tr>

--- a/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.html
@@ -613,9 +613,6 @@ it only applies between constructs in the same stylesheet.</p>
       <th>Percentages: 
       <td>See individual properties 
      <tr>
-      <th>Media: 
-      <td>See individual properties 
-     <tr>
       <th>Computed value: 
       <td>See individual properties 
      <tr>
@@ -1843,14 +1840,12 @@ Conditional @import Rules</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Com­puted value
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-all" id="ref-for-propdef-all④">all</a>
       <td>initial | inherit | unset | revert
-      <td>See individual properties
       <td>See individual properties
       <td>See individual properties
       <td>See individual properties

--- a/tests/github/w3c/csswg-drafts/css-color-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-color-4/Overview.bs
@@ -62,7 +62,6 @@ Foreground Color: the 'color' property</h2>
 	Applies to: all elements
 	Inherited: yes
 	Percentages: N/A
-	Media: visual
 	Computed value: See <a>resolving color values</a>
 	</pre>
 
@@ -2794,7 +2793,6 @@ Transparency: the 'opacity' property</h2>
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: the specified value converted to a number, clamped to the range [0,1]
 	Animation type: as number
 	</pre>
@@ -2871,7 +2869,6 @@ Preserving Colors in Different-Capability Devices: the 'color-adjust' property</
 	Initial: economy
 	Applies to: all elements
 	Inherited: yes
-	Media: visual
 	Computed value: as specified
 	Percentages: N/A
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
@@ -483,9 +483,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See <a data-link-type="dfn" href="#resolve-color-values" id="ref-for-resolve-color-values">resolving color values</a> 
      <tr>
@@ -4165,9 +4162,6 @@ color: firebrick;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the specified value converted to a number, clamped to the range [0,1] 
      <tr>
@@ -4247,9 +4241,6 @@ color: firebrick;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -5326,7 +5317,6 @@ The currentcolor keyword</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -5338,7 +5328,6 @@ The currentcolor keyword</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>See resolving color values
@@ -5349,7 +5338,6 @@ The currentcolor keyword</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -5360,7 +5348,6 @@ The currentcolor keyword</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as number
       <td>per grammar
       <td>the specified value converted to a number, clamped to the range [0,1]

--- a/tests/github/w3c/csswg-drafts/css-contain-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-contain-1/Overview.bs
@@ -52,7 +52,6 @@ Strong Containment: the 'contain' property</h2>
 		Initial: none
 		Inherited: no
 		Applies to: all elements
-		Media: all
 		Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
@@ -399,9 +399,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1221,7 +1218,6 @@ Paint Containment</a> <a href="#ref-for-propdef-display⑥">(2)</a> <a href="#re
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1233,7 +1229,6 @@ Paint Containment</a> <a href="#ref-for-propdef-display⑥">(2)</a> <a href="#re
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-content-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-content-3/Overview.bs
@@ -92,7 +92,6 @@ Inserting and replacing content with the 'content' property</h2>
 		Inherited: no
 		Percentages: n/a
 		Computed Value: As specified below
-		Media: all
 	</pre>
 
 
@@ -384,7 +383,6 @@ Specifying quotes with the 'quotes' property</h4>
 		Inherited: yes
 		Percentages: n/a
 		Computed Value: specified value
-		Media: all
 	</pre>
 
 	Issue: The previous ED had an initial value of ''text'',
@@ -944,7 +942,6 @@ The string-set property</h4>
 	Applies to: all elements, but not pseudo-elements
 	Inherited: no
 	Percentages: N/A
-	Media: all
 	Computed value: specified value
 	</pre>
 
@@ -1193,7 +1190,6 @@ bookmark-level
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -1227,7 +1223,6 @@ bookmark-label</h3>
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -1272,7 +1267,6 @@ bookmark-state</h3>
 	Applies to: block-level elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-content-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-content-3/Overview.html
@@ -457,9 +457,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified below 
      <tr>
@@ -692,9 +689,6 @@ Only pseudo-elements that are actually generated are checked.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>all 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1104,9 +1098,6 @@ Chapter One...........1
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1298,9 +1289,6 @@ Chapter One...........1
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1346,9 +1334,6 @@ Chapter One...........1
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1397,9 +1382,6 @@ Chapter One...........1
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -2002,7 +1984,6 @@ Inserting and replacing content with the content property</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2014,7 +1995,6 @@ Inserting and replacing content with the content property</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2025,7 +2005,6 @@ Inserting and replacing content with the content property</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2036,7 +2015,6 @@ Inserting and replacing content with the content property</a>
       <td>block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2047,7 +2025,6 @@ Inserting and replacing content with the content property</a>
       <td>all elements, tree-abiding pseudo-elements, and page margin boxes
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>As specified below
@@ -2058,7 +2035,6 @@ Inserting and replacing content with the content property</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2069,7 +2045,6 @@ Inserting and replacing content with the content property</a>
       <td>all elements, but not pseudo-elements
       <td>no
       <td>N/A
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.bs
@@ -300,7 +300,6 @@ For: @viewport
 Value: <<viewport-length>>
 Initial: auto
 Percentages: Refer to the width of the ''initial viewport''
-Media: visual, continuous
 Computed value: auto, an absolute length, or a percentage as specified
 </pre>
 
@@ -310,7 +309,6 @@ For: @viewport
 Value: <<viewport-length>>
 Initial: auto
 Percentages: Refer to the width of the ''initial viewport''
-Media: visual, continuous
 Computed value: auto, an absolute length, or a percentage as specified
 </pre>
 
@@ -361,7 +359,6 @@ For: @viewport
 Value: <<viewport-length>>{1,2}
 Initial: See individual descriptors
 Percentages: See individual descriptors
-Media: visual, continuous
 Computed value: See individual descriptors
 </pre>
 
@@ -379,7 +376,6 @@ For: @viewport
 Value: <<viewport-length>>
 Initial: auto
 Percentages: Refer to the height of the ''initial viewport''
-Media: visual, continuous
 Computed value: auto, an absolute length, or a percentage as specified
 </pre>
 
@@ -389,7 +385,6 @@ For: @viewport
 Value: <<viewport-length>>
 Initial: auto
 Percentages: Refer to the height of the ''initial viewport''
-Media: visual, continuous
 Computed value: auto, an absolute length, or a percentage as specified
 </pre>
 
@@ -413,7 +408,6 @@ For: @viewport
 Value: <<viewport-length>>{1,2}
 Initial: See individual descriptors
 Percentages: See individual descriptors
-Media: visual, continuous
 Computed value: See individual descriptors
 </pre>
 
@@ -431,7 +425,6 @@ For: @viewport
 Value: auto | <<number>> | <<percentage>>
 Initial: auto
 Percentages: The zoom factor itself
-Media: visual, continuous
 Computed value: auto, or a non-negative number or percentage as specified
 </pre>
 
@@ -475,7 +468,6 @@ For: @viewport
 Value: auto | <<number>> | <<percentage>>
 Initial: auto
 Percentages: The zoom factor itself
-Media: visual, continuous
 Computed value: auto, or a non-negative number or percentage as specified
 </pre>
 
@@ -517,7 +509,6 @@ For: @viewport
 Value: auto | <<number>> | <<percentage>>
 Initial: auto
 Percentages: The zoom factor itself
-Media: visual, continuous
 Computed value: auto, or a non-negative number or percentage as specified
 </pre>
 
@@ -561,7 +552,6 @@ For: @viewport
 Value: zoom | fixed
 Initial: zoom
 Percentages: N/A
-Media: visual, continuous
 Computed value: as specified
 </pre>
 
@@ -605,7 +595,6 @@ For: @viewport
 Value: auto | portrait | landscape
 Initial: auto
 Percentages: N/A
-Media: visual, continuous
 Computed value: as specified
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.html
@@ -641,9 +641,6 @@ instance 'em’s are resolved against the initial value of the <a class="propert
       <th>Percentages:
       <td>Refer to the width of the <span class="css">initial viewport</span>
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>auto, an absolute length, or a percentage as specified
    </table>
@@ -664,9 +661,6 @@ instance 'em’s are resolved against the initial value of the <a class="propert
      <tr>
       <th>Percentages:
       <td>Refer to the width of the <span class="css">initial viewport</span>
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>auto, an absolute length, or a percentage as specified
@@ -709,9 +703,6 @@ viewport'' width within the min/max constraints.</p>
       <th>Percentages:
       <td>See individual descriptors
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>See individual descriptors
    </table>
@@ -736,9 +727,6 @@ set <span class="property">min-width</span> to the first and <span class="proper
       <th>Percentages:
       <td>Refer to the height of the <span class="css">initial viewport</span>
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>auto, an absolute length, or a percentage as specified
    </table>
@@ -759,9 +747,6 @@ set <span class="property">min-width</span> to the first and <span class="proper
      <tr>
       <th>Percentages:
       <td>Refer to the height of the <span class="css">initial viewport</span>
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>auto, an absolute length, or a percentage as specified
@@ -790,9 +775,6 @@ viewport'' height within the min/max constraints.</p>
       <th>Percentages:
       <td>See individual descriptors
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>See individual descriptors
    </table>
@@ -818,9 +800,6 @@ the first and max-height to the second.</p>
      <tr>
       <th>Percentages:
       <td>The zoom factor itself
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>auto, or a non-negative number or percentage as specified
@@ -864,9 +843,6 @@ initial or the actual viewport.</p>
       <th>Percentages:
       <td>The zoom factor itself
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>auto, or a non-negative number or percentage as specified
    </table>
@@ -905,9 +881,6 @@ used value of <span class="property">zoom</span> is <span class="css">auto</span
      <tr>
       <th>Percentages:
       <td>The zoom factor itself
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>auto, or a non-negative number or percentage as specified
@@ -949,9 +922,6 @@ used value of <span class="property">zoom</span> is <span class="css">auto</span
      <tr>
       <th>Percentages:
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>as specified
@@ -995,9 +965,6 @@ used value of <span class="property">zoom</span> is <span class="css">auto</span
      <tr>
       <th>Percentages:
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual, continuous
      <tr>
       <th>Computed value:
       <td>as specified
@@ -1966,7 +1933,6 @@ Interface CSSRule</a>
       <th scope="col">Value
       <th scope="col">Initial
       <th scope="col">Computed value
-      <th scope="col">Media
       <th scope="col">Percentages
     <tbody>
      <tr>
@@ -1974,77 +1940,66 @@ Interface CSSRule</a>
       <td>&lt;viewport-length>{1,2}
       <td>See individual descriptors
       <td>See individual descriptors
-      <td>visual, continuous
       <td>See individual descriptors
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-max-height" id="ref-for-descdef-viewport-max-height">max-height</a>
       <td>&lt;viewport-length>
       <td>auto
       <td>auto, an absolute length, or a percentage as specified
-      <td>visual, continuous
       <td>Refer to the height of the initial viewport
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-max-width" id="ref-for-descdef-viewport-max-width">max-width</a>
       <td>&lt;viewport-length>
       <td>auto
       <td>auto, an absolute length, or a percentage as specified
-      <td>visual, continuous
       <td>Refer to the width of the initial viewport
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-max-zoom" id="ref-for-descdef-viewport-max-zoom⑤">max-zoom</a>
       <td>auto | &lt;number> | &lt;percentage>
       <td>auto
       <td>auto, or a non-negative number or percentage as specified
-      <td>visual, continuous
       <td>The zoom factor itself
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-min-height" id="ref-for-descdef-viewport-min-height">min-height</a>
       <td>&lt;viewport-length>
       <td>auto
       <td>auto, an absolute length, or a percentage as specified
-      <td>visual, continuous
       <td>Refer to the height of the initial viewport
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-min-width" id="ref-for-descdef-viewport-min-width">min-width</a>
       <td>&lt;viewport-length>
       <td>auto
       <td>auto, an absolute length, or a percentage as specified
-      <td>visual, continuous
       <td>Refer to the width of the initial viewport
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-min-zoom" id="ref-for-descdef-viewport-min-zoom④">min-zoom</a>
       <td>auto | &lt;number> | &lt;percentage>
       <td>auto
       <td>auto, or a non-negative number or percentage as specified
-      <td>visual, continuous
       <td>The zoom factor itself
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-orientation" id="ref-for-descdef-viewport-orientation①">orientation</a>
       <td>auto | portrait | landscape
       <td>auto
       <td>as specified
-      <td>visual, continuous
       <td>N/A
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-user-zoom" id="ref-for-descdef-viewport-user-zoom③">user-zoom</a>
       <td>zoom | fixed
       <td>zoom
       <td>as specified
-      <td>visual, continuous
       <td>N/A
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-width" id="ref-for-descdef-viewport-width">width</a>
       <td>&lt;viewport-length>{1,2}
       <td>See individual descriptors
       <td>See individual descriptors
-      <td>visual, continuous
       <td>See individual descriptors
      <tr>
       <th scope="row"><a class="css" data-link-type="descriptor" href="#descdef-viewport-zoom" id="ref-for-descdef-viewport-zoom①③">zoom</a>
       <td>auto | &lt;number> | &lt;percentage>
       <td>auto
       <td>auto, or a non-negative number or percentage as specified
-      <td>visual, continuous
       <td>The zoom factor itself
    </table>
   </div>

--- a/tests/github/w3c/csswg-drafts/css-display-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-display-3/Overview.bs
@@ -166,7 +166,6 @@ Box Layout Modes: the 'display' property</h2>
 	Inherited: no
 	Computed value: see prose in a variety of specs
 	Animatable: no
-	Media: all
 	</pre>
 
 	The 'display' property defines an element's <dfn export>display type</dfn>,
@@ -705,7 +704,6 @@ Toggling Box Generation: the 'display-or-not' property</h2>
 	Inherited: no
 	Percentages: n/a
 	Computed value: as specified
-	Media: all
 	</pre>
 
 	The ''display: none'' value was historically used as a "toggle"

--- a/tests/github/w3c/csswg-drafts/css-display-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-display-3/Overview.html
@@ -492,9 +492,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see prose in a variety of specs 
      <tr>
@@ -2260,7 +2257,6 @@ Introduction</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2272,7 +2268,6 @@ Introduction</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>no
       <td>per grammar
       <td>see prose in a variety of specs

--- a/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.bs
@@ -130,7 +130,6 @@ The 'wrap-flow' property</h4>
   Applies to: block-level elements.
   Inherited: no
   Percentages: N/A
-  Media: visual
   Computed value: as specified except for element's whose 'float' computed value is not ''none'', in which case the computed value is ''auto''.
   </pre>
 
@@ -348,7 +347,6 @@ Initial: wrap
 Applies to: block-level elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: as specified
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.html
@@ -434,9 +434,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified except for element’s whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-float" id="ref-for-propdef-float">float</a> computed value is not <span class="css">none</span>, in which case the computed value is <a class="css" data-link-type="maybe" href="#valdef-wrap-flow-auto" id="ref-for-valdef-wrap-flow-auto②">auto</a>. 
      <tr>
@@ -610,9 +607,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1228,7 +1222,6 @@ Exclusions order</a> <a href="#ref-for-propdef-z-index②">(2)</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1240,7 +1233,6 @@ Exclusions order</a> <a href="#ref-for-propdef-z-index②">(2)</a>
       <td>block-level elements.
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified except for element’s whose float computed value is not none, in which case the computed value is auto.
@@ -1251,7 +1243,6 @@ Exclusions order</a> <a href="#ref-for-propdef-z-index②">(2)</a>
       <td>block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.bs
@@ -1020,7 +1020,6 @@ Flex Flow Direction: the 'flex-direction' property</h3>
 	Applies to: <a>flex containers</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	</pre>
 
 	The 'flex-direction' property specifies how <a>flex items</a> are placed in the flex container,
@@ -1085,7 +1084,6 @@ Flex Line Wrapping: the 'flex-wrap' property</h3>
 	Applies to: <a>flex containers</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	</pre>
 
 	The 'flex-wrap' property controls whether the flex container is <a>single-line</a> or <a>multi-line</a>,
@@ -1211,7 +1209,6 @@ Display Order: the 'order' property</h3>
 	Applies to: <a>flex items</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	Animation type: integer
 	</pre>
 
@@ -1502,7 +1499,6 @@ The 'flex' Shorthand</h3>
 	Initial: 0 1 auto
 	Applies to: <a>flex items</a>
 	Inherited: no
-	Media: visual
 	</pre>
 
 	The 'flex' property specifies the components of a <dfn>flexible length</dfn>:
@@ -1679,7 +1675,6 @@ The 'flex-grow' property</h4>
 	Applies to: <a>flex items</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	Animation type: number
 	</pre>
 
@@ -1702,7 +1697,6 @@ The 'flex-shrink' property</h4>
 	Applies to: <a>flex items</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	Animation type: number
 	</pre>
 
@@ -1726,7 +1720,6 @@ The 'flex-basis' property</h4>
 	Inherited: no
 	Computed value: as specified, with lengths made absolute
 	Percentages: relative to the <a>flex container's</a> inner <a>main size</a>
-	Media: visual
 	Animation type: discrete for keywords, otherwise as length, percentage, or calc
 	</pre>
 
@@ -1895,7 +1888,6 @@ Axis Alignment: the 'justify-content' property</h3>
 	Applies to: <a>flex containers</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	</pre>
 
 	The 'justify-content' property aligns <a>flex items</a> along the <a>main axis</a> of the current line of the flex container.
@@ -1982,7 +1974,6 @@ Cross-axis Alignment: the 'align-items' and 'align-self' properties</h3>
 	Applies to: <a>flex containers</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	</pre>
 
 	<pre class='propdef'>
@@ -1992,7 +1983,6 @@ Cross-axis Alignment: the 'align-items' and 'align-self' properties</h3>
 	Applies to: <a>flex items</a>
 	Inherited: no
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	<a>Flex items</a> can be aligned in the <a>cross axis</a> of the current line of the flex container,
@@ -2083,7 +2073,6 @@ Packing Flex Lines: the 'align-content' property</h3>
 	Applies to: <a>multi-line</a> <a>flex containers</a>
 	Inherited: no
 	Computed value: specified value
-	Media: visual
 	</pre>
 
 	The 'align-content' property aligns a flex container's lines within the flex container

--- a/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
@@ -1241,9 +1241,6 @@ nav > ul > li:not(:target):not(:hover) > ul {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1299,9 +1296,6 @@ nav > ul > li:not(:target):not(:hover) > ul {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1349,9 +1343,6 @@ nav > ul > li:not(:target):not(:hover) > ul {
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1436,9 +1427,6 @@ nav > ul > li:not(:target):not(:hover) > ul {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1673,9 +1661,6 @@ unless the flex container itself is completely empty.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -1821,9 +1806,6 @@ unless the flex container itself is completely empty.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1861,9 +1843,6 @@ unless the flex container itself is completely empty.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1900,9 +1879,6 @@ unless the flex container itself is completely empty.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the <a data-link-type="dfn" href="#flex-container" id="ref-for-flex-container②⑥">flex container’s</a> inner <a data-link-type="dfn" href="#main-size" id="ref-for-main-size⑤">main size</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
@@ -2046,9 +2022,6 @@ any positive free space is distributed to auto margins in that dimension.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -2131,9 +2104,6 @@ any positive free space is distributed to auto margins in that dimension.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -2163,9 +2133,6 @@ any positive free space is distributed to auto margins in that dimension.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2239,9 +2206,6 @@ any positive free space is distributed to auto margins in that dimension.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -5939,7 +5903,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -5951,7 +5914,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>multi-line flex containers
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -5962,7 +5924,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex containers
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -5973,7 +5934,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -5984,7 +5944,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -5995,7 +5954,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>relative to the flex container’s inner main size
-      <td>visual
       <td>discrete for keywords, otherwise as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -6006,14 +5964,12 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex containers
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-flex-flow" id="ref-for-propdef-flex-flow①①">flex-flow</a>
       <td>&lt;flex-direction> || &lt;flex-wrap>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -6028,7 +5984,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>number
       <td>per grammar
       <td>specified value
@@ -6039,7 +5994,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>number
       <td>per grammar
       <td>specified value
@@ -6050,7 +6004,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex containers
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -6061,7 +6014,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex containers
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -6072,7 +6024,6 @@ Flex Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>integer
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.bs
+++ b/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.bs
@@ -270,7 +270,6 @@ Initial: depends on user agent
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: as specified
 Animatable: no
 </pre>
@@ -480,7 +479,6 @@ Initial: normal
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: numeric weight value (see description)
 Animatable: as font weight
 </pre>
@@ -591,7 +589,6 @@ Initial: normal
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: as specified
 Animatable: as font stretch
 </pre>
@@ -639,7 +636,6 @@ Initial: normal
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: as specifed
 Animatable: no
 </pre>
@@ -693,7 +689,6 @@ Initial: medium
 Applies to: all elements
 Inherited: yes
 Percentages: refer to parent element's font size
-Media: visual
 Computed value: absolute length
 Animatable: as length
 </pre>
@@ -836,7 +831,6 @@ Initial: none
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: as specified
 Animatable: as number
 </pre>
@@ -1134,7 +1128,6 @@ Initial: weight style
 Applies to: all elements
 Inherited: yes
 Percentages: n/a
-Media: visual
 Computed value: as specified
 Animatable: no
 </pre>

--- a/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.html
+++ b/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.html
@@ -683,9 +683,6 @@ other.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -874,9 +871,6 @@ to render samples of computer code.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>numeric weight value (see description)
      <tr>
@@ -1026,9 +1020,6 @@ may use numerical values instead of relative weights.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1089,9 +1080,6 @@ values rounded towards the later value in the list above. </p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specifed
@@ -1157,9 +1145,6 @@ faces when implementing support for <em>system font fallback</em>.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to parent element’s font size
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length
@@ -1299,9 +1284,6 @@ em { font-size: 1.5em }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1427,9 +1409,6 @@ span {
       <td>see individual properties
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties
-     <tr>
-      <th>Media:
       <td>see individual properties
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1567,9 +1546,6 @@ button p em { font-weight: bolder }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -2635,9 +2611,6 @@ purpose.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -2695,9 +2668,6 @@ large impact on text rendering speed.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -2778,9 +2748,6 @@ not affected by the settings above, including <a class="css" data-link-type="may
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -2905,9 +2872,6 @@ remain constant, such as in multi-column layout.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3013,9 +2977,6 @@ blockquote:first-line { font-variant: small-caps; }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3132,9 +3093,6 @@ stylistic(<a class="production css" data-link-type="type" href="#typedef-feature
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3505,9 +3463,6 @@ span.alt-U {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3593,9 +3548,6 @@ span.alt-U {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
      <tr>
-      <th>Media:
-      <td>see individual properties
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
@@ -3632,9 +3584,6 @@ values.  It does not reset the values of either <a class="property" data-link-ty
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3732,9 +3681,6 @@ tags.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -4776,7 +4722,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -4787,7 +4732,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>[ [ &lt;‘font-style’> || &lt;font-variant-css21> || &lt;‘font-weight’> || &lt;‘font-stretch’> ]?
 &lt;‘font-size’> [ / &lt;‘line-height’> ]? &lt;‘font-family’> ]
 | caption | icon | menu | message-box | small-caption | status-bar
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -4803,7 +4747,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -4815,7 +4758,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4827,7 +4769,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4839,7 +4780,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4851,7 +4791,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>refer to parent element’s font size
-      <td>visual
       <td>as length
       <td>
       <td>per grammar
@@ -4863,7 +4802,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>as number
       <td>
       <td>per grammar
@@ -4875,7 +4813,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>as font stretch
       <td>
       <td>per grammar
@@ -4887,7 +4824,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -4899,7 +4835,6 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -4915,7 +4850,6 @@ annotation(&lt;feature-value-name>) || [ small-caps | all-small-caps | petite-ca
 &lt;numeric-figure-values> || &lt;numeric-spacing-values> || &lt;numeric-fraction-values> || ordinal || slashed-zero ||
 &lt;east-asian-variant-values> || &lt;east-asian-width-values> || ruby
 ]
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -4936,7 +4870,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4948,7 +4881,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4960,7 +4892,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4972,7 +4903,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4984,7 +4914,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4996,7 +4925,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5008,7 +4936,6 @@ annotation(&lt;feature-value-name>)
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>as font weight
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.bs
@@ -70,7 +70,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -337,7 +336,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: numeric weight value (see description)
-Media: visual
 Animatable: As <<number>>
 </pre>
 
@@ -469,7 +467,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: Not resolved.
 Computed value: As specified
-Media: visual
 Animatable: As <<number>>
 </pre>
 
@@ -532,7 +529,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: As specified
-Media: visual
 Animatable: If both "from" and "to" values are "oblique", then yes, as an <<angle>>. Otherwise, no.
 </pre>
 
@@ -616,7 +612,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: refer to parent element's font size
 Computed value: absolute length
-Media: visual
 Animatable: As <<length>>
 </pre>
 
@@ -760,7 +755,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: refer to parent element's font size
 Computed value: absolute length
-Media: visual
 Animatable: As <<length>>
 </pre>
 
@@ -772,7 +766,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: refer to parent element's font size
 Computed value: absolute length
-Media: visual
 Animatable: As <<length>>
 </pre>
 
@@ -800,7 +793,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: as <<number>>
 </pre>
 
@@ -947,7 +939,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: see individual properties
 Computed value: see individual properties
-Media: visual
 Animatable: see individual properties
 </pre>
 
@@ -1119,7 +1110,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -2798,7 +2788,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -2916,7 +2905,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -3217,7 +3205,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -3301,7 +3288,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: yes (see description)
 </pre>
 
@@ -3387,7 +3373,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: N/a
 Computed value: As specified
-Media: visual
 Animatable: No (see below)
 </pre>
 
@@ -3644,7 +3629,6 @@ Applies to: all elements
 Inherited: yes
 Percentages: N/a
 Computed value: As specified
-Media: visual
 Animatable: No (see below)
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.html
@@ -520,9 +520,6 @@ other.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -734,9 +731,6 @@ per <a href="https://lists.w3.org/Archives/Public/www-style/2015Aug/0051.html">d
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>numeric weight value (see description)
      <tr>
@@ -878,9 +872,6 @@ rounded values. In this specification, the font-matching algorithm is able to ac
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>Not resolved.
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
      <tr>
@@ -969,9 +960,6 @@ face exists and a different width is substituted:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
      <tr>
@@ -1053,9 +1041,6 @@ faces when implementing support for <em>installed font fallback</em>.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to parent element’s font size
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length
@@ -1198,9 +1183,6 @@ em { font-size: 1.5em }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to parent element’s font size
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length
      <tr>
@@ -1230,9 +1212,6 @@ em { font-size: 1.5em }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to parent element’s font size
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length
@@ -1271,9 +1250,6 @@ The interaction of those nonstandard algorithms with <a class="property" data-li
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1399,9 +1375,6 @@ span {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
@@ -1543,9 +1516,6 @@ button p em { font-weight: bolder }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3021,9 +2991,6 @@ purpose.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3117,9 +3084,6 @@ generic font families.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3361,9 +3325,6 @@ An instance of one such font as a "variable font."</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -3449,9 +3410,6 @@ This can be accomplished by clamping a chosen value to the range supported by th
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3539,9 +3497,6 @@ chosen by the font designer to provide pleasing visual results.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
@@ -3788,9 +3743,6 @@ might apply differently in the context of those two elements.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
@@ -4948,7 +4900,6 @@ The CSSFontPaletteValuesRule interface</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -4960,7 +4911,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -4971,7 +4921,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -4982,7 +4931,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -4993,7 +4941,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>refer to parent element’s font size
-      <td>visual
       <td>As &lt;length>
       <td>per grammar
       <td>absolute length
@@ -5004,7 +4951,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>refer to parent element’s font size
-      <td>visual
       <td>As &lt;length>
       <td>per grammar
       <td>absolute length
@@ -5015,7 +4961,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -5026,7 +4971,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>N/a
-      <td>visual
       <td>No (see below)
       <td>per grammar
       <td>As specified
@@ -5037,7 +4981,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>refer to parent element’s font size
-      <td>visual
       <td>As &lt;length>
       <td>per grammar
       <td>absolute length
@@ -5048,7 +4991,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>as &lt;number>
       <td>per grammar
       <td>as specified
@@ -5059,7 +5001,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>Not resolved.
-      <td>visual
       <td>As &lt;number>
       <td>per grammar
       <td>As specified
@@ -5070,7 +5011,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>If both "from" and "to" values are "oblique", then yes, as an &lt;angle>. Otherwise, no.
       <td>per grammar
       <td>As specified
@@ -5081,7 +5021,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -5092,7 +5031,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -5103,7 +5041,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>N/a
-      <td>visual
       <td>No (see below)
       <td>per grammar
       <td>As specified
@@ -5114,7 +5051,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes (see description)
       <td>per grammar
       <td>as specified
@@ -5125,7 +5061,6 @@ The CSSFontPaletteValuesRule interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>As &lt;number>
       <td>per grammar
       <td>numeric weight value (see description)

--- a/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.bs
@@ -51,7 +51,6 @@ Initial: none
 Applies to: all elements, but not pseudo-elements
 Inherited: no
 Percentages: N/A
-Media: all
 Computed value: specified value
 </pre>
 
@@ -240,7 +239,6 @@ The ''running()'' value
 <pre class="propdef partial">
 	Name: position
 	New Values: running()
-	Media: paged
 </pre>
 
 
@@ -336,7 +334,6 @@ Initial: none
 Applies to: elements
 Inherited: no
 Percentages: N/A
-Media: all
 Computed value: specified value
 </pre>
 
@@ -353,7 +350,6 @@ Just as with ''string()'', ''element()'' takes an optional keyword to describe w
 <pre class="propdef partial">
 	Name: content
 	New Values: element()
-	Media: paged
 </pre>
 
 <pre class="prod">
@@ -440,7 +436,6 @@ The following new value of the 'float' property creates a footnote element:
 <pre class="propdef partial">
 	Name: float
 	New Values: footnote
-	Media: paged
 	</pre>
 <dl dfn-type="value" dfn-for="float">
 	<dt><dfn>footnote</dfn></dt>
@@ -454,7 +449,6 @@ The 'footnote-display' property determines whether a footnote is displayed as a 
 	Value: block | inline | compact
 	Initial: block
 	Applies to: elements
-	Media: paged
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
@@ -581,7 +575,6 @@ Rendering footnotes can be complex. If a footnote falls near the bottom of the p
 	Value: auto | line | block
 	Initial: auto
 	Applies to: elements
-	Media: paged
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value

--- a/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.html
@@ -390,9 +390,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>all
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -525,9 +522,6 @@ h1 { position: running(header); }
      <tr class="value">
       <th><a href="https://drafts.csswg.org/css-values/#value-defs">New values:</a>
       <td class="prod">running()
-     <tr>
-      <th>Media:
-      <td>paged
    </table>
 <pre class="prod"><dfn class="dfn-paneled" data-dfn-type="function" data-export="" id="funcdef-running">running()</dfn> = string( <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value③">&lt;custom-ident></a> )
 </pre>
@@ -556,8 +550,8 @@ p.rh::before {
     </figure>
    </div>
    <p class="note" role="note">The element <span class="css">value()</span> can only be used in page margin boxes. And it cannot be combined with other possible values for the content property.</p>
-   <div class="issue" id="issue-e7c4af6b">
-    <a class="self-link" href="#issue-e7c4af6b"></a> 
+   <div class="issue" id="issue-b96b424b">
+    <a class="self-link" href="#issue-b96b424b"></a> 
     <p>This idea would be much more useful if we could also copy (rather than just move) elements. That would avoid the duplication of HTML in the example above. </p>
     <p>Bert Bos has proposed an alternative syntax, which allows both moving and copying elements into running heads. In the example below, h2 elements appear in their normal place in the document, but are also copied into running heads.</p>
     <div class="example" id="example-ffc3e328">
@@ -605,9 +599,6 @@ letter-spacing: 1pt;
        <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
        <td>N/A
       <tr>
-       <th>Media:
-       <td>all
-      <tr>
        <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
        <td>specified value
       <tr>
@@ -629,9 +620,6 @@ letter-spacing: 1pt;
      <tr class="value">
       <th><a href="https://drafts.csswg.org/css-values/#value-defs">New values:</a>
       <td class="prod">element()
-     <tr>
-      <th>Media:
-      <td>paged
    </table>
 <pre class="prod"><dfn class="dfn-paneled" data-dfn-type="function" data-export="" id="funcdef-element">element()</dfn> = string( <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value⑤">&lt;custom-ident></a> [ <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-comma" id="ref-for-comb-comma②">,</a> [ first <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①①">|</a> start <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①②">|</a> last <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①③">|</a> first-except] ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a> )
 </pre>
@@ -690,9 +678,6 @@ span.footnote { float: footnote; }
      <tr class="value">
       <th><a href="https://drafts.csswg.org/css-values/#value-defs">New values:</a>
       <td class="prod">footnote
-     <tr>
-      <th>Media:
-      <td>paged
    </table>
    <dl>
     <dt><dfn class="css" data-dfn-for="float" data-dfn-type="value" data-export="" id="valdef-float-footnote">footnote<a class="self-link" href="#valdef-float-footnote"></a></dfn>
@@ -719,9 +704,6 @@ span.footnote { float: footnote; }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>paged
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
@@ -820,9 +802,6 @@ content: '. ';
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>paged
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
@@ -1341,7 +1320,6 @@ Page groups </a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1353,7 +1331,6 @@ Page groups </a>
       <td>elements
       <td>no
       <td>N/A
-      <td>paged
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -1364,7 +1341,6 @@ Page groups </a>
       <td>elements
       <td>no
       <td>N/A
-      <td>paged
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -1375,7 +1351,6 @@ Page groups </a>
       <td>elements
       <td>no
       <td>N/A
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -1386,7 +1361,6 @@ Page groups </a>
       <td>all elements, but not pseudo-elements
       <td>no
       <td>N/A
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -1442,9 +1416,6 @@ letter-spacing: 1pt;
        <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
        <td>N/A
       <tr>
-       <th>Media:
-       <td>all
-      <tr>
        <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
        <td>specified value
       <tr>
@@ -1454,7 +1425,7 @@ letter-spacing: 1pt;
        <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
        <td>discrete
     </table>
-     <a href="#issue-e7c4af6b"> ↵ </a>
+     <a href="#issue-b96b424b"> ↵ </a>
    </div>
    <div class="issue">Why is float:bottom used with the footnote area? Floating footnotes to the footnote area, and then floating the footnote area itself, seems overly complex, given that implementations don’t allow the footnote area to float anywhere else. Note that some implementations do allow the footnote area to be absolutely positioned.<a href="#issue-4af1f674"> ↵ </a></div>
    <div class="issue">How would one describe this in the grammar of CSS3-Page?<a href="#issue-829ce977"> ↵ </a></div>

--- a/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.bs
@@ -47,7 +47,6 @@ Value: none |  [ [ &lt;custom-ident>  &lt;content-level>] [,  &lt;custom-ident> 
 Initial: none
 Applies To: all elements and pseudo-elements, but not ::first-line or ::first-letter.
 Inherited: no
-Media: visual
 Computed value: as specified
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.html
@@ -342,9 +342,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -740,7 +737,6 @@ span.reference::before {
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -752,7 +748,6 @@ span.reference::before {
       <td>all elements and pseudo-elements, but not ::first-line or ::first-letter.
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-grid-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-grid-1/Overview.bs
@@ -1367,7 +1367,6 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 	Applies to: <a>grid containers</a>
 	Inherited: no
 	Percentages: refer to corresponding dimension of the content area
-	Media: visual
 	Computed value: As specified, with lengths made absolute
 	Animatable: as a <a href="https://www.w3.org/TR/css3-transitions/#animtype-simple-list">simple list</a> of <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>, provided the only differences are the values of the <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a> components in the list
 	</pre>
@@ -1836,7 +1835,6 @@ Named Areas: the 'grid-template-areas' property</h3>
 	Applies to: <a>grid containers</a>
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -1985,7 +1983,6 @@ Explicit Grid Shorthand: the 'grid-template' property</h3>
 	Applies to: <a>grid containers</a>
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: visual
 	Computed value: see individual properties
 	Animatable: see individual properties
 	</pre>
@@ -2128,7 +2125,6 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 	Applies to: <a>grid containers</a>
 	Inherited: no
 	Percentages: see <a href="#track-sizing">Track Sizing</a>
-	Media: visual
 	Computed value: see <a href="#track-sizing">Track Sizing</a>
 	</pre>
 
@@ -2199,7 +2195,6 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 	Applies to: <a>grid containers</a>
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -2357,7 +2352,6 @@ Grid Definition Shorthand: the 'grid' property</h3>
 	Applies to: <a>grid containers</a>
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: visual
 	Computed value: see individual properties
 	Animatable: see individual properties
 	</pre>
@@ -2710,7 +2704,6 @@ Line-based Placement: the 'grid-row-start', 'grid-column-start', 'grid-row-end',
 	Applies to: <a>grid items</a> and absolutely-positioned boxes whose containing block is a <a>grid container</a>
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -2897,7 +2890,6 @@ Placement Shorthands: the 'grid-column', 'grid-row', and 'grid-area' properties<
 	Applies to: <a>grid items</a> and absolutely-positioned boxes whose containing block is a <a>grid container</a>
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: visual
 	Computed value: see individual properties
 	</pre>
 
@@ -2919,7 +2911,6 @@ Placement Shorthands: the 'grid-column', 'grid-row', and 'grid-area' properties<
 	Applies to: <a>grid items</a> and absolutely-positioned boxes whose containing block is a <a>grid container</a>
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: visual
 	Computed value: see individual properties
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
@@ -1454,9 +1454,6 @@ the grid item is sized as for <a class="css" data-link-type="propdesc" href="htt
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to corresponding dimension of the content area 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified, with lengths made absolute 
      <tr>
@@ -1770,9 +1767,6 @@ but the same <span>track list</span> can also contain <a class="production css" 
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1893,9 +1887,6 @@ but the same <span>track list</span> can also contain <a class="production css" 
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -2008,9 +1999,6 @@ grid-template-columns: auto 1fr auto;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see <a href="#track-sizing">Track Sizing</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see <a href="#track-sizing">Track Sizing</a> 
      <tr>
@@ -2081,9 +2069,6 @@ grid-template-columns: auto 1fr auto;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -2229,9 +2214,6 @@ form > input, form > select {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -2507,9 +2489,6 @@ grid-auto-columns: 1fr;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -2666,9 +2645,6 @@ grid-column-start: B 2; grid-column-end: span 1;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -2706,9 +2682,6 @@ grid-column-start: B 2; grid-column-end: span 1;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -5896,7 +5869,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -5911,7 +5883,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>
       <td>per grammar
@@ -5923,7 +5894,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5935,7 +5905,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>see Track Sizing
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5947,7 +5916,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5959,7 +5927,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>see Track Sizing
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5971,7 +5938,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5983,7 +5949,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -5995,7 +5960,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -6007,7 +5971,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -6019,7 +5982,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -6031,7 +5993,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid items and absolutely-positioned boxes whose containing block is a grid container
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -6045,7 +6006,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>
       <td>per grammar
@@ -6057,7 +6017,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -6069,7 +6028,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>refer to corresponding dimension of the content area
-      <td>visual
       <td>as a simple list of length, percentage, or calc, provided the only differences are the values of the length, percentage, or calc components in the list
       <td>
       <td>per grammar
@@ -6081,7 +6039,6 @@ Grid Container Baselines</a> <a href="#ref-for-TermAlignmentBaseline①">(2)</a>
       <td>grid containers
       <td>no
       <td>refer to corresponding dimension of the content area
-      <td>visual
       <td>as a simple list of length, percentage, or calc, provided the only differences are the values of the length, percentage, or calc components in the list
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-images-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-images-3/Overview.bs
@@ -1275,7 +1275,6 @@ Sizing Objects: the 'object-fit' property {#the-object-fit}
 	Applies to: replaced elements
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1373,7 +1372,6 @@ Positioning Objects: the 'object-position' property {#the-object-position}
 	Applies to: replaced elements
 	Inherited: no
 	Percentages: refer to width and height of element itself
-	Media: visual
 	Computed value: specified value
 	Animatable: yes
 	Canonical Order: the horizontal component of the <<position>>, followed by the vertical component
@@ -1426,7 +1424,6 @@ Image Processing {#image-processing}
 	Initial: 0deg
 	Applies to: all elements
 	Inherited: yes
-	Media: visual
 	Computed value: an <<angle>>, rounded and normalized (see text), plus optionally a ''flip'' keyword
 	Animatable: no
 	</pre>
@@ -1512,7 +1509,6 @@ Determining How To Scale an Image: the 'image-rendering' property {#the-image-re
 	Initial: auto
 	Applies to: all elements
 	Inherited: yes
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
@@ -1262,9 +1262,6 @@ by setting the <a data-link-type="dfn" href="#concrete-object-size" id="ref-for-
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1346,9 +1343,6 @@ by setting the <a data-link-type="dfn" href="#concrete-object-size" id="ref-for-
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to width and height of element itself 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1399,9 +1393,6 @@ by setting the <a data-link-type="dfn" href="#concrete-object-size" id="ref-for-
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#angle-value" id="ref-for-angle-value⑤" title="Expands to: turn | rad | grad | deg">&lt;angle></a>, rounded and normalized (see text), plus optionally a <span class="css">flip</span> keyword 
@@ -1483,9 +1474,6 @@ by setting the <a data-link-type="dfn" href="#concrete-object-size" id="ref-for-
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -2375,7 +2363,6 @@ A future edition of the <a href="http://www.w3.org/TR/css-print/">CSS Print Prof
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2387,7 +2374,6 @@ A future edition of the <a href="http://www.w3.org/TR/css-print/">CSS Print Prof
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>an &lt;angle>, rounded and normalized (see text), plus optionally a flip keyword
@@ -2398,7 +2384,6 @@ A future edition of the <a href="http://www.w3.org/TR/css-print/">CSS Print Prof
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -2409,7 +2394,6 @@ A future edition of the <a href="http://www.w3.org/TR/css-print/">CSS Print Prof
       <td>replaced elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
@@ -2420,7 +2404,6 @@ A future edition of the <a href="http://www.w3.org/TR/css-print/">CSS Print Prof
       <td>replaced elements
       <td>no
       <td>refer to width and height of element itself
-      <td>visual
       <td>yes
       <td>the horizontal component of the &lt;position>, followed by the vertical component
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-images-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-images-4/Overview.bs
@@ -1445,7 +1445,6 @@ Sizing Objects: the 'object-fit' property {#the-object-fit}
 	Applies to: replaced elements
 	Inherited: no
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -1563,7 +1562,6 @@ Overriding Image Resolutions: the 'image-resolution' property {#the-image-resolu
 	Initial: 1dppx
 	Applies to: all elements
 	Inherited: yes
-	Media: visual
 	Computed value: as specified, except with <<resolution>> possibly altered by computed for ''snap'' (see below)
 	Animatable: no
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
@@ -1461,9 +1461,6 @@ background-size: 60px 60px;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1560,9 +1557,6 @@ background-size: 60px 60px;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, except with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#resolution-value" id="ref-for-resolution-value③" title="Expands to: dppx | x | dpcm | dpi">&lt;resolution></a> possibly altered by computed for <a class="css" data-link-type="maybe" href="#valdef-image-resolution-snap" id="ref-for-valdef-image-resolution-snap">snap</a> (see below) 
@@ -2338,7 +2332,6 @@ Using Out-Of-Document Sources: the ElementSources interface</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2350,7 +2343,6 @@ Using Out-Of-Document Sources: the ElementSources interface</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified, except with &lt;resolution> possibly altered by computed for snap (see below)
@@ -2361,7 +2353,6 @@ Using Out-Of-Document Sources: the ElementSources interface</a>
       <td>replaced elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-inline-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-inline-3/Overview.bs
@@ -58,7 +58,6 @@ Dominant Baselines: the 'dominant-baseline' property</h3>
 	Applies to: block containers, inline boxes, table rows, table columns, grid containers, and flex containers
 	Inherited: yes
 	Percentages: N/A
-	Media: visual
 	Computed value: as specified
 	</pre>
 
@@ -139,7 +138,6 @@ Transverse Box Alignment: the 'vertical-align' property</h3>
 	Applies to: inline-level boxes
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: as specified
 	</pre>
 
@@ -159,7 +157,6 @@ Alignment Point: 'alignment-baseline' longhand</h4>
 	Applies to: inline-level boxes, flex items, grid items, table cells
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: as specified
 	</pre>
 
@@ -247,7 +244,6 @@ Alignment Shift: 'baseline-shift' longhand</h4>
 	<!-- table cells left out b/c CSS2.1 vertical-align values must have no effect... -->
 	Inherited: no
 	Percentages: refer to the used value of 'line-height'
-	Media: visual
 	Computed value: absolute length, percentage, or keyword specified
 	</pre>
 
@@ -434,7 +430,6 @@ Creating Initial Letters: the 'initial-letter' property</h3>
 	Applies to: <code>::first-letter</code> pseudo-elements and inline-level first child of a block container
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: as specified
 	</pre>
 
@@ -599,7 +594,6 @@ Alignment of Initial Letters: the 'initial-letter-align' property</h3>
 	Applies to: <code>::first-letter</code> pseudo elements and inline level first child of a block container
 	Inherited: yes
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -841,7 +835,6 @@ Initial Letter Wrapping: the 'initial-letter-wrap' property</h3>
 	Applies to: <code>::first-letter</code> pseudo-elements and inline-level first child of a block container
 	Inherited: yes
 	Percentages: relative to <a>logical width</a> of (last fragment of) initial letter
-	Media: visual
 	Computed value: as specified
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-inline-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-inline-3/Overview.html
@@ -401,9 +401,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -474,9 +471,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -510,9 +504,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -587,9 +578,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the used value of <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height" id="ref-for-propdef-line-height">line-height</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length, percentage, or keyword specified 
@@ -734,9 +722,6 @@ span /* style phrase inside span */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -868,9 +853,6 @@ span /* style phrase inside span */
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1046,9 +1028,6 @@ initial-letter-align: hebrew;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to <a data-link-type="dfn" href="https://drafts.csswg.org/css-writing-modes-4/#logical-width" id="ref-for-logical-width">logical width</a> of (last fragment of) initial letter 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2076,7 +2055,6 @@ Alignment Point: alignment-baseline longhand</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2088,7 +2066,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>inline-level boxes, flex items, grid items, table cells
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2099,7 +2076,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>inline-level boxes, flex items, grid items
       <td>no
       <td>refer to the used value of line-height
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length, percentage, or keyword specified
@@ -2110,7 +2086,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>block containers, inline boxes, table rows, table columns, grid containers, and flex containers
       <td>yes
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2121,7 +2096,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>::first-letter pseudo-elements and inline-level first child of a block container
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2132,7 +2106,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>::first-letter pseudo elements and inline level first child of a block container
       <td>yes
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2143,7 +2116,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>::first-letter pseudo-elements and inline-level first child of a block container
       <td>yes
       <td>relative to logical width of (last fragment of) initial letter
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2154,7 +2126,6 @@ Alignment Point: alignment-baseline longhand</a>
       <td>inline-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.bs
@@ -194,7 +194,6 @@ Defining a <dfn>Line Grid</dfn>: the 'line-grid' property</h2>
 		Inherited: no
 		Animatable: no
 		Percentages: N/A
-		Media: visual
 		Computed Value: as specified
 	</pre>
 
@@ -330,7 +329,6 @@ Snapping Line Boxes: the 'line-snap' property</h3>
 		Inherited: yes
 		Animatable: no
 		Percentages: N/A
-		Media: visual
 		Computed Value: as specified
 	</pre>
 
@@ -448,7 +446,6 @@ Snapping Block Boxes: the 'box-snap' property</h3>
 		Inherited: yes
 		Animatable: no
 		Percentages: N/A
-		Media: visual
 		Computed Value: as specified
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.html
@@ -458,9 +458,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -589,9 +586,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -698,9 +692,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1203,7 +1194,6 @@ Defining a Line Grid: the line-grid property</a> <a href="#ref-for-writing-modeâ
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">AniÂ­matÂ­able
       <th scope="col">Canonical order
       <th scope="col">ComÂ­puted value
@@ -1215,7 +1205,6 @@ Defining a Line Grid: the line-grid property</a> <a href="#ref-for-writing-modeâ
       <td>block-level boxes and internal table elements except table cells
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1226,7 +1215,6 @@ Defining a Line Grid: the line-grid property</a> <a href="#ref-for-writing-modeâ
       <td>block, flex and grid containers
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1237,7 +1225,6 @@ Defining a Line Grid: the line-grid property</a> <a href="#ref-for-writing-modeâ
       <td>block container elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-lists-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-lists-3/Overview.bs
@@ -234,7 +234,6 @@ Image Markers: the 'list-style-image' property</h3>
 	Applies to: <a>list items</a>
 	Inherited: yes
 	Percentages: n/a
-	Media: visual
 	Computed value: computed value of the <<image>>, or ''list-style-image/none''
 	</pre>
 
@@ -276,7 +275,6 @@ Text-based Markers: the 'list-style-type' property</h3>
 	Applies to: <a>list items</a>
 	Inherited: yes
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -339,7 +337,6 @@ Positioning Markers: The 'list-style-position' property</h3>
 	Applies to: <a>list items</a>
 	Inherited: yes
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value (but see prose)
 	</pre>
 
@@ -410,7 +407,6 @@ Styling Markers: the 'list-style' shorthand property</h3>
 	Applies to: <a>list items</a>
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: visual
 	Computed value: see individual properties
 	</pre>
 
@@ -630,7 +626,6 @@ The 'marker-side' property</h3>
 	Applies to: <a>list items</a>
 	Inherited: yes
 	Percentages: n/a
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -709,7 +704,6 @@ Manipulating Counters: the 'counter-increment', 'counter-set' and 'counter-reset
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: all
 	Computed value: specified value
 	</pre>
 
@@ -744,7 +738,6 @@ Manipulating Counters: the 'counter-increment', 'counter-set' and 'counter-reset
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: all
 	Computed value: specified value
 	</pre>
 
@@ -755,7 +748,6 @@ Manipulating Counters: the 'counter-increment', 'counter-set' and 'counter-reset
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: all
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
@@ -562,9 +562,6 @@ Note 1:   This is a very short
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>computed value of the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-image" id="ref-for-typedef-image②">&lt;image></a>, or <a class="css" data-link-type="maybe" href="#valdef-list-style-image-none" id="ref-for-valdef-list-style-image-none">none</a> 
      <tr>
@@ -615,9 +612,6 @@ Note 1:   This is a very short
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -686,9 +680,6 @@ Note 1:   This is a very short
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value (but see prose) 
@@ -765,9 +756,6 @@ Note 1:   This is a very short
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -954,9 +942,6 @@ list-style: none disc url(bullet.png);
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1036,9 +1021,6 @@ list-style: none disc url(bullet.png);
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1087,9 +1069,6 @@ list-style: none disc url(bullet.png);
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1119,9 +1098,6 @@ list-style: none disc url(bullet.png);
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>all 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -2239,7 +2215,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2251,7 +2226,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2262,7 +2236,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2273,7 +2246,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2284,7 +2256,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>list items
       <td>see individual properties
       <td>see individual properties
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>see individual properties
@@ -2295,7 +2266,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>list items
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>computed value of the &lt;image>, or none
@@ -2306,7 +2276,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>list items
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value (but see prose)
@@ -2317,7 +2286,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>list items
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2328,7 +2296,6 @@ Generating The ::marker Boxes</a> <a href="#ref-for-originating-element①">(2)<
       <td>list items
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-logical-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-logical-1/Overview.bs
@@ -276,7 +276,6 @@ Logical Height and Logical Width: the 'block-size' and 'inline-size' properties<
   Applies to: Same as 'width' and 'height'
   Inherited: No
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: Same as 'width' and 'height'
   </pre>
 
@@ -291,7 +290,6 @@ Logical Height and Logical Width: the 'block-size' and 'inline-size' properties<
   Applies to: same as 'width' and 'height'
   Inherited: No
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: Same as 'min-width' and 'min-height'
   </pre>
 
@@ -306,7 +304,6 @@ Logical Height and Logical Width: the 'block-size' and 'inline-size' properties<
   Applies to: same as 'width' and 'height'
   Inherited: no
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: Same as 'max-width' and 'max-height'
   </pre>
 
@@ -325,7 +322,6 @@ the 'margin-block-start', 'margin-block-end', 'margin-inline-start', 'margin-inl
   Applies to: Same as 'margin'
   Inherited: no
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: the percentage as specified or the absolute length or auto (see text)
   </pre>
 
@@ -357,7 +353,6 @@ the 'inset-block-start', 'inset-block-end', 'inset-inline-start', 'inset-inline-
   Applies to: positioned elements
   Inherited: no
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: Same as box offsets: 'top', 'right', 'bottom', 'left' properties except that directions are flow-relative
   </pre>
 
@@ -399,7 +394,6 @@ the 'padding-block-start', 'padding-block-end', 'padding-inline-start', 'padding
   Applies to: all elements
   Inherited: no
   Percentages: As for the corresponding physical property
-  Media: visual
   Computed value: length (see text)
   </pre>
 
@@ -435,7 +429,6 @@ the 'border-block-start-width', 'border-block-end-width', 'border-inline-start-w
   Applies to: all elements
   Inherited: no
   Percentages: n/a
-  Media: visual
   Computed value: absolute length; 0 if the border style is none or hidden (see text)
   </pre>
 
@@ -469,7 +462,6 @@ the 'border-block-start-style', 'border-block-end-style', 'border-inline-start-s
   Applies to: all elements
   Inherited: no
   Percentages: n/a
-  Media: visual
   Computed value: specified value (see text)
   </pre>
 
@@ -502,7 +494,6 @@ the 'border-block-start-color', 'border-block-end-color', 'border-inline-start-c
   Applies to: all elements
   Inherited: no
   Percentages: n/a
-  Media: visual
   Computed value: computed color (see text)
   </pre>
 
@@ -626,7 +617,6 @@ Background Image Transform: The ''background-image-transform'' property</h3>
   Applies to: all elements
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: as specified
   </pre>
 
@@ -678,7 +668,6 @@ Border Image Transform: The 'border-image-transform' property</h3>
   Applies to: All elements, except internal table elements when 'border-collapse' is ''collapse''
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: as specified
   </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-logical-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-logical-1/Overview.html
@@ -607,9 +607,6 @@ the <span class="property">border-block-start</span>, <span class="property">bor
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visudet.html#propdef-width" id="ref-for-propdef-width②">width</a> and <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visudet.html#propdef-height" id="ref-for-propdef-height①">height</a> 
      <tr>
@@ -642,9 +639,6 @@ the <span class="property">border-block-start</span>, <span class="property">bor
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-min-width" id="ref-for-propdef-min-width①">min-width</a> and <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-min-height" id="ref-for-propdef-min-height">min-height</a> 
      <tr>
@@ -676,9 +670,6 @@ the <span class="property">border-block-start</span>, <span class="property">bor
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-max-width" id="ref-for-propdef-max-width①">max-width</a> and <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS21/visudet.html#propdef-max-height" id="ref-for-propdef-max-height">max-height</a> 
@@ -714,9 +705,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-margin-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the percentage as specified or the absolute length or auto (see text) 
      <tr>
@@ -747,9 +735,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-margin-block-st
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -789,9 +774,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-inset-block-sta
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as box offsets: <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visuren.html#propdef-top" id="ref-for-propdef-top②">top</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visuren.html#propdef-right" id="ref-for-propdef-right③">right</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visuren.html#propdef-bottom" id="ref-for-propdef-bottom①">bottom</a>, <a class="property" data-link-type="propdesc" href="https://www.w3.org/TR/CSS22/visuren.html#propdef-left" id="ref-for-propdef-left③">left</a> properties except that directions are flow-relative 
      <tr>
@@ -822,9 +804,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-inset-block-sta
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -862,9 +841,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-inset-block-sta
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>see individual properties 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -899,9 +875,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-padding-block-s
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>As for the corresponding physical property 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>length (see text) 
      <tr>
@@ -932,9 +905,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-padding-block-s
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -975,9 +945,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length; 0 if the border style is none or hidden (see text) 
      <tr>
@@ -1008,9 +975,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1050,9 +1014,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value (see text) 
      <tr>
@@ -1083,9 +1044,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1125,9 +1083,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>computed color (see text) 
      <tr>
@@ -1158,9 +1113,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1200,9 +1152,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties 
      <tr>
-      <th>Media:
-      <td>see individual properties 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
      <tr>
@@ -1233,9 +1182,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1322,9 +1268,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1379,9 +1322,6 @@ the <a class="property" data-link-type="propdesc" href="#propdef-border-block-st
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2581,7 +2521,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2593,7 +2532,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2604,14 +2542,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as width and height
       <td>No
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as width and height
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-block" id="ref-for-propdef-border-block①">border-block</a>
       <td>&lt;‘border-block-start’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2627,13 +2563,11 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
-      <td>see individual properties
       <td>per grammar
       <td>see individual properties
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-block-end" id="ref-for-propdef-border-block-end②">border-block-end</a>
       <td>&lt;‘border-top-width’> || &lt;‘border-top-style’> || &lt;color>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2648,7 +2582,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>computed color (see text)
@@ -2659,7 +2592,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value (see text)
@@ -2670,14 +2602,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length; 0 if the border style is none or hidden (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-block-start" id="ref-for-propdef-border-block-start③">border-block-start</a>
       <td>&lt;‘border-top-width’> || &lt;‘border-top-style’> || &lt;color>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2692,7 +2622,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>computed color (see text)
@@ -2703,7 +2632,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value (see text)
@@ -2714,14 +2642,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length; 0 if the border style is none or hidden (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-block-style" id="ref-for-propdef-border-block-style①">border-block-style</a>
       <td>&lt;‘border-top-style’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2737,7 +2663,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
-      <td>see individual properties
       <td>per grammar
       <td>see individual properties
      <tr>
@@ -2747,14 +2672,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>All elements, except internal table elements when border-collapse is collapse
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-inline" id="ref-for-propdef-border-inline①">border-inline</a>
       <td>&lt;‘border-block-start’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2770,13 +2693,11 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
-      <td>see individual properties
       <td>per grammar
       <td>see individual properties
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-inline-end" id="ref-for-propdef-border-inline-end②">border-inline-end</a>
       <td>&lt;‘border-top-width’> || &lt;‘border-top-style’> || &lt;color>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2791,7 +2712,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>computed color (see text)
@@ -2802,7 +2722,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value (see text)
@@ -2813,14 +2732,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length; 0 if the border style is none or hidden (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-inline-start" id="ref-for-propdef-border-inline-start②">border-inline-start</a>
       <td>&lt;‘border-top-width’> || &lt;‘border-top-style’> || &lt;color>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2835,7 +2752,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>computed color (see text)
@@ -2846,7 +2762,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value (see text)
@@ -2857,14 +2772,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length; 0 if the border style is none or hidden (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-border-inline-style" id="ref-for-propdef-border-inline-style①">border-inline-style</a>
       <td>&lt;‘border-top-style’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2880,7 +2793,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
-      <td>see individual properties
       <td>per grammar
       <td>see individual properties
      <tr>
@@ -2890,14 +2802,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as width and height
       <td>No
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as width and height
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-inset" id="ref-for-propdef-inset②">inset</a>
       <td>&lt;‘top’>{1,4}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2913,7 +2823,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
-      <td>see individual properties
       <td>per grammar
       <td>see individual properties
      <tr>
@@ -2923,7 +2832,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>positioned elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as box offsets: top, right, bottom, left properties except that directions are flow-relative
@@ -2934,14 +2842,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>positioned elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as box offsets: top, right, bottom, left properties except that directions are flow-relative
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-inset-inline" id="ref-for-propdef-inset-inline①">inset-inline</a>
       <td>&lt;‘top’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2956,7 +2862,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>positioned elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as box offsets: top, right, bottom, left properties except that directions are flow-relative
@@ -2967,14 +2872,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>positioned elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as box offsets: top, right, bottom, left properties except that directions are flow-relative
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-margin-block" id="ref-for-propdef-margin-block①">margin-block</a>
       <td>&lt;‘margin-left’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2989,7 +2892,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as margin
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>the percentage as specified or the absolute length or auto (see text)
@@ -3000,14 +2902,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as margin
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>the percentage as specified or the absolute length or auto (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-margin-inline" id="ref-for-propdef-margin-inline①">margin-inline</a>
       <td>&lt;‘margin-left’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -3022,7 +2922,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as margin
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>the percentage as specified or the absolute length or auto (see text)
@@ -3033,7 +2932,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>Same as margin
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>the percentage as specified or the absolute length or auto (see text)
@@ -3044,7 +2942,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>same as width and height
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as max-width and max-height
@@ -3055,7 +2952,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>same as width and height
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as max-width and max-height
@@ -3066,7 +2962,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>same as width and height
       <td>No
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as min-width and min-height
@@ -3077,14 +2972,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>same as width and height
       <td>No
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as min-width and min-height
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-padding-block" id="ref-for-propdef-padding-block①">padding-block</a>
       <td>&lt;‘padding-left’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -3099,7 +2992,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>length (see text)
@@ -3110,14 +3002,12 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>length (see text)
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-padding-inline" id="ref-for-propdef-padding-inline①">padding-inline</a>
       <td>&lt;‘padding-left’>{1,2}
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -3132,7 +3022,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>length (see text)
@@ -3143,7 +3032,6 @@ Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-t
       <td>all elements
       <td>no
       <td>As for the corresponding physical property
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>length (see text)

--- a/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.bs
@@ -111,7 +111,6 @@ Internal display model: the 'foo' property {#the-foo-property}
 		Applies to: all elements
 		Inherited: no
 		Percentages: n/a
-		Media: visual
 		Computed value: specified value
 		Animatable: no
 		Canonical order: per grammar

--- a/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.html
@@ -436,9 +436,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -514,9 +511,6 @@ on screen, on paper, in speech, etc.
       <td>see individual properties
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties
-     <tr>
-      <th>Media:
       <td>see individual properties
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -768,7 +762,6 @@ on screen, on paper, in speech, etc.
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -781,7 +774,6 @@ on screen, on paper, in speech, etc.
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -789,7 +781,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-shorthand-foo" id="ref-for-propdef-shorthand-foo">shorthand-foo</a>
       <td>foo | bar | baz
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.bs
@@ -330,7 +330,6 @@ these two properties determine the outcome:-->
 	Applies to: <a>block containers</a> except <a>table wrapper boxes</a>
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: the absolute length
 	Animatable: as <<length>>
 	</pre>
@@ -402,7 +401,6 @@ these two properties determine the outcome:-->
 	Applies to: <a>block containers</a> except <a>table wrapper boxes</a>
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	Animatable: as <<integer>>
 	</pre>
@@ -441,7 +439,6 @@ these two properties determine the outcome:-->
 	Applies to: see individual properties
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: see individual properties
 	Computed value: see individual properties
 	Animatable: see individual properties
 	</pre>
@@ -598,7 +595,6 @@ Column gaps and rules</h2>
 	Applies to: <a>multicol containers</a>
 	Inherited: no
 	Percentages: refer to the content width of the multi-column container
-	Media: visual
 	Computed value: as specified, with <<length>>s made absolute
 	Animation type: length, percentage, or calc
 	</pre>
@@ -632,7 +628,6 @@ Column gaps and rules</h2>
 	Applies to: multicol containers
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: same as the computed value of 'color' is computed
 	Animatable: as <<color>>
 	</pre>
@@ -654,7 +649,6 @@ Column gaps and rules</h2>
 	Applies to: multicol containers
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	Animatable: no
 	</pre>
@@ -675,7 +669,6 @@ Column gaps and rules</h2>
 	Applies to: multicol containers
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: absolute length; ''0'' if the column rule style is ''border-style/none'' or ''hidden''
 	Animatable: as <<length>>
 	</pre>
@@ -694,7 +687,6 @@ Column gaps and rules</h2>
 	Applies to: see individual properties
 	Inherited: see individual properties
 	Percentages: see individual properties
-	Media: see individual properties
 	Computed value: see individual properties
 	Animatable: see individual properties
 	</pre>
@@ -761,7 +753,6 @@ Spanning columns</h2>
 	Applies to: in-flow block-level elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 
@@ -941,7 +932,6 @@ Filling columns</h2>
 	Applies to: multicol containers
 	Inherited: no
 	Percentages: N/A
-	Media: see below
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
@@ -647,9 +647,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the absolute length 
      <tr>
@@ -722,9 +719,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -768,9 +762,6 @@ on screen, on paper, in speech, etc.
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -901,9 +892,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the content width of the multi-column container 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value④" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>s made absolute 
      <tr>
@@ -948,9 +936,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>same as the computed value of <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color" id="ref-for-propdef-color">color</a> is computed 
      <tr>
@@ -986,9 +971,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1023,9 +1005,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length; <span class="css">0</span> if the column rule style is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none" id="ref-for-valdef-line-style-none①">none</a> or <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden" id="ref-for-valdef-line-style-hidden">hidden</a> 
      <tr>
@@ -1057,9 +1036,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1121,9 +1097,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1278,9 +1251,6 @@ columns: auto auto; <span class="c">/* column-width: auto; column-count: auto */
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>see below 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1990,7 +1960,6 @@ Filling columns</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -2003,7 +1972,6 @@ Filling columns</a>
       <td>block containers except table wrapper boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>as &lt;integer>
       <td>
       <td>per grammar
@@ -2015,7 +1983,6 @@ Filling columns</a>
       <td>multicol containers
       <td>no
       <td>N/A
-      <td>see below
       <td>
       <td>discrete
       <td>per grammar
@@ -2027,7 +1994,6 @@ Filling columns</a>
       <td>multicol containers
       <td>no
       <td>refer to the content width of the multi-column container
-      <td>visual
       <td>
       <td>length, percentage, or calc
       <td>per grammar
@@ -2035,7 +2001,6 @@ Filling columns</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-column-rule" id="ref-for-propdef-column-rule⑤">column-rule</a>
       <td>&lt;‘column-rule-width’> || &lt;‘column-rule-style’> || &lt;‘column-rule-color’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2051,7 +2016,6 @@ Filling columns</a>
       <td>multicol containers
       <td>no
       <td>N/A
-      <td>visual
       <td>as &lt;color>
       <td>
       <td>per grammar
@@ -2063,7 +2027,6 @@ Filling columns</a>
       <td>multicol containers
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -2075,7 +2038,6 @@ Filling columns</a>
       <td>multicol containers
       <td>no
       <td>N/A
-      <td>visual
       <td>as &lt;length>
       <td>
       <td>per grammar
@@ -2087,7 +2049,6 @@ Filling columns</a>
       <td>in-flow block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -2099,7 +2060,6 @@ Filling columns</a>
       <td>block containers except table wrapper boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>as &lt;length>
       <td>
       <td>per grammar
@@ -2107,7 +2067,6 @@ Filling columns</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-columns" id="ref-for-propdef-columns⑤">columns</a>
       <td>&lt;‘column-width’> || &lt;‘column-count’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties

--- a/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.bs
@@ -146,7 +146,6 @@ Spanning columns</h2>
 	Applies to: in-flow block-level elements
 	Inherited: no
 	Percentages: N/A
-	Media: visual
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.html
@@ -413,9 +413,6 @@ In addition, once final, it will replace and supersede the following:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -774,7 +771,6 @@ columns</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -786,7 +782,6 @@ columns</a>
       <td>in-flow block-level elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.bs
@@ -287,7 +287,6 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 		Applies to: block containers [[!CSS21]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
 		Inherited: no
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified, except with ''visible''/''clip'' computing to ''auto''/''hidden'' (respectively) if one of 'overflow-x' or 'overflow-y' is neither ''visible'' nor ''clip''
 		Animatable: no
 	</pre>
@@ -306,7 +305,6 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 		Applies to: block containers [[!CSS21]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
 		Inherited: no
 		Percentages: N/A
-		Media: visual
 		Computed value: see individual properties
 		Animatable: no
 		Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
@@ -480,7 +478,6 @@ as the Flow-Relative box model properties defined in [[css-logical-1#box]].
   Applies to: Same as 'overflow-x' and 'overflow-y'
   Inherited: No
   Percentages: N/A
-  Media: visual
   Computed value: Same as 'overflow-x' and 'overflow-y'
   </pre>
 
@@ -499,7 +496,6 @@ Limiting Visible Lines: the 'max-lines' property</h2>
 		Inherited: no
 		Animatable: as integer
 		Percentages: N/A
-		Media: visual
 		Computed value: specified value
 	</pre>
 
@@ -587,7 +583,6 @@ Indicating Block-Axis Overflow: the 'block-overflow' property</h2>
 		Inherited: yes
 		Animatable: no
 		Percentages: N/A
-		Media: visual
 		Computed value: specified value
 	</pre>
 
@@ -734,7 +729,6 @@ Setting 'max-lines' and 'block-overflow' together: the 'line-clamp' property</h2
 		Inherited: see individual properties
 		Animatable: see individual properties
 		Percentages: N/A
-		Media: visual
 		Computed value: see individual properties
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.html
@@ -548,9 +548,6 @@ work will resume on fragmented overflow and other fun things once this is comple
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, except with <a class="css" data-link-type="maybe" href="#valdef-overflow-visible" id="ref-for-valdef-overflow-visible②">visible</a>/<a class="css" data-link-type="maybe" href="#valdef-overflow-clip" id="ref-for-valdef-overflow-clip②">clip</a> computing to <a class="css" data-link-type="maybe" href="#valdef-overflow-auto" id="ref-for-valdef-overflow-auto①">auto</a>/<span class="css">hidden</span> (respectively) if one of <a class="property" data-link-type="propdesc" href="#propdef-overflow-x" id="ref-for-propdef-overflow-x②">overflow-x</a> or <a class="property" data-link-type="propdesc" href="#propdef-overflow-y" id="ref-for-propdef-overflow-y②">overflow-y</a> is neither <span class="css">visible</span> nor <span class="css">clip</span> 
      <tr>
@@ -586,9 +583,6 @@ work will resume on fragmented overflow and other fun things once this is comple
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -733,9 +727,6 @@ as the Flow-Relative box model properties defined in <a href="https://www.w3.org
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as <a class="property" data-link-type="propdesc" href="#propdef-overflow-x" id="ref-for-propdef-overflow-x⑥">overflow-x</a> and <a class="property" data-link-type="propdesc" href="#propdef-overflow-y" id="ref-for-propdef-overflow-y⑥">overflow-y</a> 
      <tr>
@@ -768,9 +759,6 @@ as the Flow-Relative box model properties defined in <a href="https://www.w3.org
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -847,9 +835,6 @@ as the Flow-Relative box model properties defined in <a href="https://www.w3.org
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -971,9 +956,6 @@ as the Flow-Relative box model properties defined in <a href="https://www.w3.org
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -1787,7 +1769,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1800,7 +1781,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>block containers
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1812,7 +1792,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>see individual properties
       <td>see individual properties
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>
       <td>per grammar
@@ -1824,7 +1803,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>block containers (excluding multi-column containers)
       <td>no
       <td>N/A
-      <td>visual
       <td>as integer
       <td>
       <td>per grammar
@@ -1836,7 +1814,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>block containers [CSS21], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1848,7 +1825,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>Same as overflow-x and overflow-y
       <td>No
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1860,7 +1836,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>Same as overflow-x and overflow-y
       <td>No
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1872,7 +1847,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>block containers [CSS21], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1884,7 +1858,6 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
       <td>block containers [CSS21], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.bs
@@ -393,7 +393,6 @@ and extends it further.
 		Applies to: block containers [[!CSS21]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
 		Inherited: no
 		Percentages: N/A
-		Media: visual
 		Computed value: see below
 		Animatable: no
 		Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
@@ -955,7 +954,6 @@ the ''continue/fragments'' value of the 'continue' property.
 		Inherited: no
 		Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animatable-types">integer</a>
 		Percentages: N/A
-		Media: visual
 		Computed value: specified value
 		Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
 	</pre>

--- a/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.html
@@ -545,9 +545,6 @@ provided by the <a class="property" data-link-type="propdesc" href="https://draf
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -715,9 +712,6 @@ and extends it further.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see below 
@@ -1179,9 +1173,6 @@ the <a class="css" data-link-type="maybe" href="#valdef-continue-fragments" id="
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1769,7 +1760,6 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1782,7 +1772,6 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
       <td>block containers [CSS21], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1794,7 +1783,6 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
       <td>fragment boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>as integer
       <td>
       <td>per grammar
@@ -1806,7 +1794,6 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-page-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-page-3/Overview.bs
@@ -1983,7 +1983,6 @@ Using named pages: 'page'</h3>
 	Applies to: boxes that create <a href="https://www.w3.org/TR/css3-break/#btw-blocks">class A</a> break points
 	Inherited: no (but see prose)
 	Percentages: n/a
-	Media: paged
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-page-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-page-3/Overview.html
@@ -1838,9 +1838,6 @@ size: 8.5in 11in;/* width height */
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>paged 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -3283,7 +3280,6 @@ Bleed Area: the bleed property</a> <a href="#ref-for-length-value④">(2)</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3295,7 +3291,6 @@ Bleed Area: the bleed property</a> <a href="#ref-for-length-value④">(2)</a>
       <td>boxes that create class A break points
       <td>no (but see prose)
       <td>n/a
-      <td>paged
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.bs
@@ -107,7 +107,6 @@ Floating to the inline-start/inline-end and block-start/block-end</h2>
     Applies to: all elements.
     Inherited: no
     Percentages: N/A
-    Media: visual
     Computed value: as specified.
     Animatable: no
   </pre>
@@ -205,7 +204,6 @@ And some more text&lt;/p>
   Applies to: all elements.
   Inherited: no
   Percentages: N/A
-  Media: visual
   Computed value: as specified.
   Animatable: no
 </pre>
@@ -460,7 +458,6 @@ The 'clear' property</h2>
     Applies to: block-level elements, floats, regions, pages
     Inherited: no
     Percentages: N/A
-    Media: visual
     Computed value: as specified.
     Animatable: no
   </pre>
@@ -663,7 +660,6 @@ The 'clear' property</h2>
       Applies to: floats
       Inherited: no
       Percentages: N/A
-      Media: visual
       Computed value: as specified.
       Animatable: no
     </pre>
@@ -804,7 +800,6 @@ The 'clear' property</h2>
     Applies to: floats
     Inherited: no
     Percentages: see prose
-    Media: visual
     Computed value: one absolute length
     Animatable: no
   </pre>

--- a/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.html
@@ -394,9 +394,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified. 
      <tr>
@@ -486,9 +483,6 @@ And some more text&lt;/p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified.
@@ -675,9 +669,6 @@ table { float: snap-block(3em 2em, bottom) }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified. 
      <tr>
@@ -829,9 +820,6 @@ table { float: snap-block(3em 2em, bottom) }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified. 
      <tr>
@@ -944,9 +932,6 @@ table { float: snap-block(3em 2em, bottom) }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see prose 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>one absolute length 
@@ -1568,7 +1553,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1580,7 +1564,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <td>block-level elements, floats, regions, pages
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified.
@@ -1591,7 +1574,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <td>all elements.
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified.
@@ -1602,7 +1584,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <td>floats
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified.
@@ -1613,7 +1594,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <td>floats
       <td>no
       <td>see prose
-      <td>visual
       <td>no
       <td>per grammar
       <td>one absolute length
@@ -1624,7 +1604,6 @@ The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a hre
       <td>all elements.
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified.

--- a/tests/github/w3c/csswg-drafts/css-position-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-position-3/Overview.bs
@@ -733,7 +733,6 @@ Choosing a positioning scheme: 'position' property</h3>
   Inherited: no
   Animatable: no
   Percentages: N/A
-  Media: visual
   Computed value: specified value
   </pre>
 
@@ -844,7 +843,6 @@ Box offsets: 'top', 'right', 'bottom', 'left'</h3>
   Inherited: no
   Animation type: length or percentage
   Percentages: refer to height of <a>containing block</a>
-  Media: visual
   Computed value: For 'position': ''relative'', see Relative positioning.<br/> For 'position': ''sticky'', see Sticky positioning.<br/> For 'position': ''static'', ''top/auto''.<br/> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, ''top/auto''.
   </pre>
 
@@ -870,7 +868,6 @@ Box offsets: 'top', 'right', 'bottom', 'left'</h3>
   Inherited: no
   Animation type: length or percentage
   Percentages: refer to height of <a>containing block</a>
-  Media: visual
   Computed value: For 'position': ''relative'', see Relative positioning.<br/> For 'position': ''sticky'', see Sticky positioning.<br/> For 'position': ''static'', ''right/auto''.<br/> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, ''right/auto''.
   </pre>
 
@@ -896,7 +893,6 @@ Box offsets: 'top', 'right', 'bottom', 'left'</h3>
   Inherited: no
   Animation type: length or percentage
   Percentages: refer to height of <a>containing block</a>
-  Media: visual
   Computed value: For 'position': ''relative'', see Relative positioning.<br/> For 'position': ''sticky'', see Sticky positioning.<br/> For 'position': ''static'', ''bottom/auto''.<br/> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, ''bottom/auto''.
   </pre>
 
@@ -922,7 +918,6 @@ Box offsets: 'top', 'right', 'bottom', 'left'</h3>
   Inherited: no
   Animation type: length or percentage
   Percentages: refer to height of <a>containing block</a>
-  Media: visual
   Computed value: For 'position': ''relative'', see Relative positioning.<br/> For 'position': ''sticky'', see Sticky positioning.<br/> For 'position': ''static'', ''left/auto''. Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, ''left/auto''.
   </pre>
 
@@ -998,7 +993,6 @@ Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-s
     Inherited: no
     Animation type: length or percentage
     Percentages: refer to height of <a>containing block</a>
-    Media: visual
     Computed value: For ''position: relative'', see Relative positioning.<br/> For ''position: sticky'', see Sticky positioning.<br/> For ''position: static'', ''top/auto''.<br/> Otherwise: if specified as a <<length>>, the corresponding absolute length; if specified as a <<percentage>>, the specified value; otherwise, ''top/auto''.
   </pre>
 
@@ -1116,7 +1110,6 @@ Applies to: positioned elements
 Inherited: no
 Animatable: no
 Percentages: n/a
-Media: visual
 Computed value: specified value, but see prose
 </pre>
 
@@ -1948,7 +1941,6 @@ Layered presentation</h2>
   Inherited: no
   Animatable: &lt;integer>
   Percentages: N/A
-  Media: visual
   Computed value: as specified
   </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-position-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-position-3/Overview.html
@@ -958,9 +958,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1059,9 +1056,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block①②">containing block</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="property" data-link-type="propdesc" href="#propdef-position" id="ref-for-propdef-position①①">position</a>: <a class="css" data-link-type="maybe" href="#valdef-position-relative" id="ref-for-valdef-position-relative④">relative</a>, see Relative positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-sticky" id="ref-for-valdef-position-sticky②">sticky</a>, see Sticky positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-static" id="ref-for-valdef-position-static④">static</a>, <a class="css" data-link-type="maybe" href="#valdef-top-auto" id="ref-for-valdef-top-auto">auto</a>.<br> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, <span class="css">auto</span>. 
      <tr>
@@ -1101,9 +1095,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block①⑤">containing block</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="property" data-link-type="propdesc" href="#propdef-position" id="ref-for-propdef-position①④">position</a>: <a class="css" data-link-type="maybe" href="#valdef-position-relative" id="ref-for-valdef-position-relative⑤">relative</a>, see Relative positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-sticky" id="ref-for-valdef-position-sticky③">sticky</a>, see Sticky positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-static" id="ref-for-valdef-position-static⑤">static</a>, <a class="css" data-link-type="maybe" href="#valdef-top-auto" id="ref-for-valdef-top-auto②">auto</a>.<br> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, <span class="css">auto</span>. 
@@ -1145,9 +1136,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block①⑧">containing block</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="property" data-link-type="propdesc" href="#propdef-position" id="ref-for-propdef-position①⑦">position</a>: <a class="css" data-link-type="maybe" href="#valdef-position-relative" id="ref-for-valdef-position-relative⑥">relative</a>, see Relative positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-sticky" id="ref-for-valdef-position-sticky④">sticky</a>, see Sticky positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-static" id="ref-for-valdef-position-static⑥">static</a>, <a class="css" data-link-type="maybe" href="#valdef-top-auto" id="ref-for-valdef-top-auto④">auto</a>.<br> Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, <span class="css">auto</span>. 
      <tr>
@@ -1187,9 +1175,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block②①">containing block</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="property" data-link-type="propdesc" href="#propdef-position" id="ref-for-propdef-position②⓪">position</a>: <a class="css" data-link-type="maybe" href="#valdef-position-relative" id="ref-for-valdef-position-relative⑦">relative</a>, see Relative positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-sticky" id="ref-for-valdef-position-sticky⑤">sticky</a>, see Sticky positioning.<br> For <span class="property">position</span>: <a class="css" data-link-type="maybe" href="#valdef-position-static" id="ref-for-valdef-position-static⑦">static</a>, <a class="css" data-link-type="maybe" href="#valdef-top-auto" id="ref-for-valdef-top-auto⑥">auto</a>. Otherwise: if specified as a '&lt;length>', the corresponding absolute length; if specified as a '&lt;percentage>', the specified value; otherwise, <span class="css">auto</span>. 
@@ -1260,9 +1245,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to height of <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block②⑥">containing block</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="css" data-link-type="propdesc" href="#propdef-position" id="ref-for-propdef-position②③">position: relative</a>, see Relative positioning.<br> For <span class="css">position: sticky</span>, see Sticky positioning.<br> For <span class="css">position: static</span>, <a class="css" data-link-type="maybe" href="#valdef-top-auto" id="ref-for-valdef-top-auto⑨">auto</a>.<br> Otherwise: if specified as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>, the corresponding absolute length; if specified as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#percentage-value" id="ref-for-percentage-value">&lt;percentage></a>, the specified value; otherwise, <span class="css">auto</span>. 
@@ -1890,9 +1872,6 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2781,7 +2760,6 @@ Box offsets: top, right, bottom, left</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -2794,7 +2772,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2806,7 +2783,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2818,7 +2794,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2830,7 +2805,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2842,7 +2816,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2854,7 +2827,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2866,7 +2838,6 @@ Box offsets: top, right, bottom, left</a>
       <td>all elements except table-column-group and table-column
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -2878,7 +2849,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2890,7 +2860,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>refer to height of containing block
-      <td>visual
       <td>
       <td>length or percentage
       <td>per grammar
@@ -2902,7 +2871,6 @@ Box offsets: top, right, bottom, left</a>
       <td>positioned elements
       <td>no
       <td>N/A
-      <td>visual
       <td>&lt;integer>
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-regions-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-regions-1/Overview.bs
@@ -373,7 +373,6 @@ The 'flow-into' property</h3>
 		Applies To: All elements, but not <a href="https://www.w3.org/TR/selectors/#pseudo-elements">pseudo-elements</a> such as <code>::first-line</code>, <code>::first-letter</code>, <code>::before</code> or <code>::after</code>.
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	<dl>
@@ -561,7 +560,6 @@ The 'flow-from' property</h3>
 		Applies To: Non-replaced <a href="https://www.w3.org/TR/CSS21/visuren.html#block-boxes">block containers</a>. <br/> This might be expanded in future versions of the specification to allow other types of containers to receive flow content.
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	<dl>
@@ -861,7 +859,6 @@ Region flow break properties: 'break-before', 'break-after', 'break-inside'</h3>
 		Applies To: block-level elements
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	<pre class='propdef'>
@@ -871,7 +868,6 @@ Region flow break properties: 'break-before', 'break-after', 'break-inside'</h3>
 		Applies To: block-level elements
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	<pre class='propdef'>
@@ -881,7 +877,6 @@ Region flow break properties: 'break-before', 'break-after', 'break-inside'</h3>
 		Applies To: block-level elements
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	These properties describe page, column and region break behavior
@@ -914,7 +909,6 @@ The region-fragment property</h3>
 		Applies To: <a>CSS Regions</a>
 		Inherited: no
 		Computed Value: as specified
-		Media: visual
 	</pre>
 
 	The 'region-fragment' property controls the behavior

--- a/tests/github/w3c/csswg-drafts/css-regions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-regions-1/Overview.html
@@ -689,9 +689,6 @@ nav {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -850,9 +847,6 @@ nav {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1079,9 +1073,6 @@ nav {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1112,9 +1103,6 @@ nav {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1144,9 +1132,6 @@ nav {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1191,9 +1176,6 @@ nav {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2653,7 +2635,6 @@ The NamedFlow interface</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2665,7 +2646,6 @@ The NamedFlow interface</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2676,7 +2656,6 @@ The NamedFlow interface</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2687,7 +2666,6 @@ The NamedFlow interface</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2698,7 +2676,6 @@ The NamedFlow interface</a>
       <td>Non-replaced block containers.  This might be expanded in future versions of the specification to allow other types of containers to receive flow content.
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2709,7 +2686,6 @@ The NamedFlow interface</a>
       <td>All elements, but not pseudo-elements such as ::first-line, ::first-letter, ::before or ::after.
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2720,7 +2696,6 @@ The NamedFlow interface</a>
       <td>CSS Regions
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.bs
@@ -169,7 +169,6 @@ Specifying the Step Size: the 'block-step-size' property {#block-step-size}
 	Inherited: no
 	Animatable: ???
 	Percentages: N/A
-	Media: visual
 	Computed Value: keyword or absolute length
 	</pre>
 
@@ -201,7 +200,6 @@ Specifying the Spacing Type: the 'block-step-insert' property {#block-step-inser
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: visual
 	Computed Value: as specified
 	</pre>
 
@@ -235,7 +233,6 @@ Specifying Alignment: the 'block-step-align' property {#block-step-align}
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: visual
 	Computed Value: as specified
 	</pre>
 
@@ -286,7 +283,6 @@ Rounding Method: the 'block-step-round' property {#block-step-round}
 	Inherited: no
 	Animatable: no
 	Percentages: N/A
-	Media: visual
 	Computed Value: as specified
 	</pre>
 
@@ -329,7 +325,6 @@ Block Step Adjustment Shorthand: the 'block-step' shorthand {#block-step}
 	Inherited: no
 	Animatable: See individual properties
 	Percentages: N/A
-	Media: visual
 	Computed Value: See individual properties
 	</pre>
 
@@ -356,7 +351,6 @@ Adjusting Line Box Heights: the 'line-height-step' property {#line-height-step}
 	Inherited: yes
 	Animatable: no
 	Percentages: N/A
-	Media: visual
 	Computed Value: the absolute length
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.html
@@ -496,9 +496,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>keyword or absolute length 
      <tr>
@@ -542,9 +539,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -587,9 +581,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -647,9 +638,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -695,9 +683,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties 
      <tr>
@@ -733,9 +718,6 @@ or that the <a class="property" data-link-type="propdesc" href="#propdef-line-he
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the absolute length 
@@ -1162,7 +1144,6 @@ h1 {
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1174,7 +1155,6 @@ h1 {
       <td>block-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>See individual properties
       <td>per grammar
       <td>See individual properties
@@ -1185,7 +1165,6 @@ h1 {
       <td>block-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1196,7 +1175,6 @@ h1 {
       <td>block-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1207,7 +1185,6 @@ h1 {
       <td>block-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1218,7 +1195,6 @@ h1 {
       <td>block-level boxes
       <td>no
       <td>N/A
-      <td>visual
       <td>???
       <td>per grammar
       <td>keyword or absolute length
@@ -1229,7 +1205,6 @@ h1 {
       <td>block containers
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>the absolute length

--- a/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.bs
@@ -217,7 +217,6 @@ Extending the @viewport rule {#extending-viewport-rule}
     Value: auto | contain | cover
     Initial: auto
     Percentages: N/A
-    Media: visual, continuous
     Computed value: as specified
 </pre>
 
@@ -333,7 +332,6 @@ spec:css21; type:type; text:<uri>
     Value: auto | outside-shape | [ <<basic-shape>> || shape-box ] | <<image>> | <code>display</code>
     Initial: auto
     Inherited: no
-    Media: visual
     Computed value: computed lengths for <<basic-shape>>, the absolute URI for <<uri>>, otherwise as specified
     Animatable: as specified for <<basic-shape>>, otherwise no
 </pre>
@@ -408,7 +406,6 @@ We add the 'border-boundary' property to set a boundary constraint that affects 
     Value: none | parent | display
     Initial: none
     Inherited: yes
-    Media: visual
 </pre>
 
 When the 'border-boundary' property on an element is set to '<code>parent</code>', additional borders of the element could be drawn where the element's area and the borders of its parent are met. When it is set to '<code>display</code>', additional borders could be drawn where the element's area and the borders of screen are met. The default value is '<code>none</code>', imposing no boundary constraint on the borders.

--- a/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.html
@@ -546,9 +546,6 @@ For example, when rendering to PDF, the shape is known to be a rectangle, so 'sh
       <th>Percentages:
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>as specified
    </table>
@@ -641,9 +638,6 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>computed lengths for <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape" id="ref-for-typedef-basic-shape①">&lt;basic-shape></a>, the absolute URI for <a class="production css" data-link-type="type" href="https://www.w3.org/TR/CSS21/syndata.html#value-def-uri" id="ref-for-value-def-uri">&lt;uri></a>, otherwise as specified
      <tr>
@@ -720,9 +714,6 @@ Without using Media Queries, contents can be aligned within the display edge aut
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1063,7 +1054,6 @@ Changes from March 1th 2016 version</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1076,7 +1066,6 @@ Changes from March 1th 2016 version</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1088,7 +1077,6 @@ Changes from March 1th 2016 version</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as specified for &lt;basic-shape>, otherwise no
       <td>
       <td>per grammar
@@ -1121,7 +1109,6 @@ Changes from March 1th 2016 version</a>
       <th scope="col">Value
       <th scope="col">Initial
       <th scope="col">Computed value
-      <th scope="col">Media
       <th scope="col">Percentages
     <tbody>
      <tr>
@@ -1129,7 +1116,6 @@ Changes from March 1th 2016 version</a>
       <td>auto | contain | cover
       <td>auto
       <td>as specified
-      <td>visual, continuous
       <td>N/A
    </table>
   </div>

--- a/tests/github/w3c/csswg-drafts/css-round-display-1/Overview_before_merge_motionpath.bs
+++ b/tests/github/w3c/csswg-drafts/css-round-display-1/Overview_before_merge_motionpath.bs
@@ -175,7 +175,6 @@ The 'shape' media feature describes the general shape of the targeted display ar
     Value: auto | contain | cover
     Initial: auto
     Percentages: N/A
-    Media: visual, continuous
     Computed value: as specified
 </pre>
 
@@ -268,7 +267,6 @@ spec:css21; type:type; text:<uri>
     Value: auto | outside-shape | [ <<basic-shape>> || shape-box ] | <<image>> | <code>display</code>
     Initial: auto
     Inherited: no
-    Media: visual
     Computed value: computed lengths for <<basic-shape>>, the absolute URI for <<uri>>, otherwise as specified
     Animatable: as specified for <<basic-shape>>, otherwise no
 </pre>
@@ -340,7 +338,6 @@ We add the 'border-boundary' property to set a boundary constraint that affects 
     Value: none | parent | display
     Initial: none
     Inherited: yes
-    Media: visual
 </pre>
 
 When the 'border-boundary' property on an element is set to '<code>parent</code>', additional borders of the element could be drawn where the element's area and the borders of its parent are met. When it is set to '<code>display</code>', additional borders could be drawn where the element's area and the borders of screen are met. The default value is '<code>none</code>', imposing no boundary constraint on the borders.
@@ -430,7 +427,6 @@ The 'polar-angle' property specifies the angle from the Y-axis.
     Applies to: all elements
     Value: <<angle>>
     Initial: 0
-    Media: visual
     Inherited: no
     Percentages: N/A
 	Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animatable-types">angle</a>
@@ -448,7 +444,6 @@ The 'polar-distance' property determines how far elements are positioned from th
     Applies to: all elements
     Value: [ <<length>> | <<percentage>> <<size>>? ] && contain?
     Initial: 0
-    Media: visual
     Inherited: no
     Percentages: relative to distance from the origin of polar coordinates to edge of containing block
     Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>
@@ -622,7 +617,6 @@ The 'polar-origin' property establishes the point of origin for coordinate syste
     Applies to: all elements
     Value: auto | <<position>>
     Initial: auto
-    Media: visual
     Inherited: no
     Percentages: Refer to the size of containing block
 	Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>
@@ -744,7 +738,6 @@ The value of 'polar-distance' is the distance between an anchor point and the or
     Applies to: all elements
     Value: <<position>>
     Initial: 50% 50%
-    Media: visual
     Inherited: no
     Percentages: relative to width and height of an element
 	Animatable: as <<position>>

--- a/tests/github/w3c/csswg-drafts/css-round-display-1/Overview_before_merge_motionpath.html
+++ b/tests/github/w3c/csswg-drafts/css-round-display-1/Overview_before_merge_motionpath.html
@@ -526,9 +526,6 @@ In conventional positioning method, the Cartesian coordinates, elements are posi
       <th>Percentages:
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual, continuous
-     <tr>
       <th>Computed value:
       <td>as specified
    </table>
@@ -599,9 +596,6 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>computed lengths for <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape" id="ref-for-typedef-basic-shape①">&lt;basic-shape></a>, the absolute URI for <a class="production css" data-link-type="type" href="https://www.w3.org/TR/CSS21/syndata.html#value-def-uri" id="ref-for-value-def-uri">&lt;uri></a>, otherwise as specified
@@ -678,9 +672,6 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -774,9 +765,6 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -809,9 +797,6 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to distance from the origin of polar coordinates to edge of containing block
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -950,9 +935,6 @@ The first example shows positioning elements with polar-distance not using exten
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>Refer to the size of containing block
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1051,9 +1033,6 @@ The first example shows positioning elements with polar-distance not using exten
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to width and height of an element
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1602,7 +1581,6 @@ Changes from September 22th 2015 version</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1615,7 +1593,6 @@ Changes from September 22th 2015 version</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1627,7 +1604,6 @@ Changes from September 22th 2015 version</a>
       <td>all elements
       <td>no
       <td>relative to width and height of an element
-      <td>visual
       <td>as &lt;position>
       <td>
       <td>per grammar
@@ -1639,7 +1615,6 @@ Changes from September 22th 2015 version</a>
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as angle
       <td>
       <td>per grammar
@@ -1651,7 +1626,6 @@ Changes from September 22th 2015 version</a>
       <td>all elements
       <td>no
       <td>relative to distance from the origin of polar coordinates to edge of containing block
-      <td>visual
       <td>as length, percentage, or calc
       <td>
       <td>per grammar
@@ -1663,7 +1637,6 @@ Changes from September 22th 2015 version</a>
       <td>all elements
       <td>no
       <td>Refer to the size of containing block
-      <td>visual
       <td>as length, percentage, or calc
       <td>
       <td>per grammar
@@ -1675,7 +1648,6 @@ Changes from September 22th 2015 version</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as specified for &lt;basic-shape>, otherwise no
       <td>
       <td>per grammar
@@ -1708,7 +1680,6 @@ Changes from September 22th 2015 version</a>
       <th scope="col">Value
       <th scope="col">Initial
       <th scope="col">Computed value
-      <th scope="col">Media
       <th scope="col">Percentages
     <tbody>
      <tr>
@@ -1716,7 +1687,6 @@ Changes from September 22th 2015 version</a>
       <td>auto | contain | cover
       <td>auto
       <td>as specified
-      <td>visual, continuous
       <td>N/A
    </table>
   </div>

--- a/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.bs
@@ -1276,9 +1276,6 @@ Ruby overhanging: the 'ruby-overhang' property</h3>
       <th>Percentages:
       <td>N/A
     <tr>
-      <th>Media:
-      <td>visual
-    <tr>
       <th>Computed value:
       <td>specified value (except for initial and inherit)
   </table>
@@ -1362,9 +1359,6 @@ Ruby annotation spanning: the 'ruby-span' property</h3>
     <tr>
       <th>Percentages:
       <td>N/A
-    <tr>
-      <th>Media:
-      <td>visual
     <tr>
       <th>Computed value:
       <td>&lt;number&gt;

--- a/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.html
@@ -999,9 +999,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1078,9 +1075,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1162,9 +1156,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1858,7 +1849,6 @@ Breaking Between Bases</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1870,7 +1860,6 @@ Breaking Between Bases</a>
       <td>ruby bases, ruby annotations, ruby base containers, ruby annotation containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1881,7 +1870,6 @@ Breaking Between Bases</a>
       <td>ruby annotation containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -1892,7 +1880,6 @@ Breaking Between Bases</a>
       <td>ruby annotation containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
@@ -497,9 +497,6 @@ or exclude portions of the DOM from the anchor node selection algorithm.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -995,7 +992,6 @@ Anchor Node Selection</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1007,7 +1003,6 @@ Anchor Node Selection</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.bs
@@ -261,7 +261,6 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#scroll-snap-type}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: as specified
     Animatable: no
     </pre>
@@ -407,7 +406,6 @@ Scroll Snapport: the 'scroll-padding' property {#scroll-padding}
     Applies to: <a>scroll containers</a>
     Inherited: no
     Percentages: relative to the corresponding dimension of the scroll container’s scrollport
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length, percentage, or calc
     </pre>
@@ -494,7 +492,6 @@ Scroll Snapping Area: the 'scroll-margin' property {#scroll-margin}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length
     </pre>
@@ -543,7 +540,6 @@ Scroll Snapping Alignment: the 'scroll-snap-align' property {#scroll-snap-align}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: two keywords
     Animatable: no
     </pre>
@@ -756,7 +752,6 @@ Scroll Snap Limits: the 'scroll-snap-stop' property {#scroll-snap-stop}
     Percentages: n/a
     Computed value: as specified
     Animatable: no
-    Media: interactive
     </pre>
 
     When scrolling with an intended direction,
@@ -961,7 +956,6 @@ Physical Longhands for 'scroll-padding' {#padding-longhands-physical}
     Applies to: <a>scroll containers</a>
     Inherited: no
     Percentages: relative to the scroll container’s scrollport
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length, percentage, or calc
     </pre>
@@ -980,7 +974,6 @@ Flow-relative Longhands for 'scroll-padding'  {#padding-longhands-logical}
     Applies to: <a>scroll containers</a>
     Inherited: no
     Percentages: relative to the scroll container’s scrollport
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length, percentage, or calc
     </pre>
@@ -996,7 +989,6 @@ Flow-relative Longhands for 'scroll-padding'  {#padding-longhands-logical}
     Applies to: all elements
     Inherited: no
     Percentages: relative to the scroll container’s scrollport
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length, percentage, or calc
     </pre>
@@ -1019,7 +1011,6 @@ Physical Longhands for 'scroll-margin'  {#margin-longhands-physical}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length
     </pre>
@@ -1038,7 +1029,6 @@ Flow-relative Longhands for 'scroll-margin'  {#margin-longhands-logical}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length
     </pre>
@@ -1054,7 +1044,6 @@ Flow-relative Longhands for 'scroll-margin'  {#margin-longhands-logical}
     Applies to: all elements
     Inherited: no
     Percentages: n/a
-    Media: interactive
     Computed value: as specified, with lengths made absolute
     Animatable: as length
     </pre>

--- a/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.html
@@ -573,9 +573,6 @@ CR period.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -684,9 +681,6 @@ h1, h2, h3, h4, h5, h6 {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the corresponding dimension of the scroll container’s scrollport 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -766,9 +760,6 @@ h1, h2, h3, h4, h5, h6 {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -815,9 +806,6 @@ h1, h2, h3, h4, h5, h6 {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>two keywords 
@@ -985,9 +973,6 @@ h1, h2, h3, h4, h5, h6 {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1162,9 +1147,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the scroll container’s scrollport 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -1199,9 +1181,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the scroll container’s scrollport 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -1234,9 +1213,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the scroll container’s scrollport 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
@@ -1273,9 +1249,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -1310,9 +1283,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -1345,9 +1315,6 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1">[
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
@@ -1962,7 +1929,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1974,7 +1940,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -1985,7 +1950,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -1996,7 +1960,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2007,7 +1970,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2018,7 +1980,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2029,7 +1990,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2040,7 +2000,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2051,7 +2010,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2062,7 +2020,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2073,7 +2030,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2084,7 +2040,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>as length
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2095,7 +2050,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the corresponding dimension of the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2106,7 +2060,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2117,7 +2070,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2128,7 +2080,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2139,7 +2090,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2150,7 +2100,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2161,7 +2110,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2172,7 +2120,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2183,7 +2130,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2194,7 +2140,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2205,7 +2150,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>scroll containers
       <td>no
       <td>relative to the scroll container’s scrollport
-      <td>interactive
       <td>as length, percentage, or calc
       <td>per grammar
       <td>as specified, with lengths made absolute
@@ -2216,7 +2160,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>no
       <td>per grammar
       <td>two keywords
@@ -2227,7 +2170,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>no
       <td>per grammar
       <td>as specified
@@ -2238,7 +2180,6 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>no
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.bs
@@ -65,7 +65,6 @@ Computed value: the computed color or the keyword normal
 Animation type: <a href="https://www.w3.org/TR/css3-transitions/#animtype-color">color</a>
 Applies to: block containers and boxes that establish a formatting context [same as elements that <a href=https://www.w3.org/TR/CSS22/visufx.html#propdef-overflow">'overflow' applies to</a>]
 Percentages: n/a
-Media: visual
 </pre>
 
 These properties allow the author to set colors for various aspects of a scrollbar.

--- a/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.html
@@ -330,9 +330,6 @@ on the web since Windows IE 5.5 introduced it in 2000.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the computed color or the keyword normal
      <tr>
@@ -569,7 +566,6 @@ Scrollbar Color Properties</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -581,7 +577,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -592,7 +587,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -603,7 +597,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -614,7 +607,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -625,7 +617,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -636,7 +627,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -647,7 +637,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal
@@ -658,7 +647,6 @@ Scrollbar Color Properties</a>
       <td>block containers and boxes that establish a formatting context [same as elements that overflow applies to]
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color or the keyword normal

--- a/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.bs
@@ -848,7 +848,6 @@ Float Area Shape: the 'shape-outside' property</h3>
 		Applies to: floats
 		Inherited: no
 		Computed value: as <a href="#basic-shape-computed-values">defined</a> for <<basic-shape>> (with <<shape-box>> following, if supplied), the <<image>> with its URI made absolute, otherwise as specified.
-		Media: visual
 		Animatable: as <a href="#basic-shape-interpolation">specified</a> for <<basic-shape>>, otherwise no
 	</pre>
 
@@ -925,7 +924,6 @@ Choosing Image Pixels: the 'shape-image-threshold' property</h3>
 		Applies to: floats
 		Inherited: no
 		Computed value: The same as the specified value after clipping the <<number>> to the range [0.0,1.0]
-		Media: visual
 		Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-number">number</a>
 	</pre>
 
@@ -984,7 +982,6 @@ Expanding a Shape: the 'shape-margin' property</h3>
 		Applies to: floats
 		Inherited: no
 		Computed value: as specified, but with lengths made absolute
-		Media: visual
 		Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>.
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.html
@@ -935,9 +935,6 @@ serializes as "circle(at 95% 0%)"
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as <a href="#basic-shape-computed-values">defined</a> for <a class="production css" data-link-type="type" href="#typedef-basic-shape" id="ref-for-typedef-basic-shape⑤">&lt;basic-shape></a> (with <a class="production css" data-link-type="type" href="#typedef-shape-box" id="ref-for-typedef-shape-box③" title="Expands to: border-box | content-box | margin-box | padding-box">&lt;shape-box></a> following, if supplied), the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-images-3/#typedef-image" id="ref-for-typedef-image②">&lt;image></a> with its URI made absolute, otherwise as specified. 
      <tr>
@@ -1007,9 +1004,6 @@ serializes as "circle(at 95% 0%)"
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>The same as the specified value after clipping the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#number-value" id="ref-for-number-value①">&lt;number></a> to the range [0.0,1.0] 
      <tr>
@@ -1078,9 +1072,6 @@ serializes as "circle(at 95% 0%)"
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with lengths made absolute 
@@ -1558,7 +1549,6 @@ Interpolation of Basic Shapes</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1570,7 +1560,6 @@ Interpolation of Basic Shapes</a>
       <td>floats
       <td>no
       <td>n/a
-      <td>visual
       <td>as number
       <td>per grammar
       <td>The same as the specified value after clipping the &lt;number> to the range [0.0,1.0]
@@ -1581,7 +1570,6 @@ Interpolation of Basic Shapes</a>
       <td>floats
       <td>no
       <td>n/a
-      <td>visual
       <td>as length, percentage, or calc.
       <td>per grammar
       <td>as specified, but with lengths made absolute
@@ -1592,7 +1580,6 @@ Interpolation of Basic Shapes</a>
       <td>floats
       <td>no
       <td>n/a
-      <td>visual
       <td>as specified for &lt;basic-shape>, otherwise no
       <td>per grammar
       <td>as defined for &lt;basic-shape> (with &lt;shape-box> following, if supplied), the &lt;image> with its URI made absolute, otherwise as specified.

--- a/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.bs
@@ -318,7 +318,6 @@ The 'shape-inside' Property</h4>
 		Applies To: block-level elements
 		Inherited: no
 		Computed Value: computed lengths for <<basic-shape>>, the absolute URI for <<uri>>, otherwise as specified</td>
-		Media: visual
 		Animatable: as specified for <<basic-shape>>, otherwise no
 	</pre>
 
@@ -453,7 +452,6 @@ The 'shape-padding' Property</h4>
 		Applies To: block-level elements
 		Inherited: no
 		Computed Value: the absolute length
-		Media: visual
 		Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.html
@@ -533,9 +533,6 @@ Lorem ipsum dolor sit amet...
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>computed lengths for <a class="production css" data-link-type="type" href="#typedef-basic-shape" id="ref-for-typedef-basic-shape①">&lt;basic-shape></a>, the absolute URI for <a class="production css" data-link-type="type" href="#typedef-uri" id="ref-for-typedef-uri">&lt;uri></a>, otherwise as specified
      <tr>
@@ -643,9 +640,6 @@ Lorem ipsum dolor sit amet...
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the absolute length 
@@ -974,7 +968,6 @@ The shape-padding Property</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -986,7 +979,6 @@ The shape-padding Property</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as specified for &lt;basic-shape>, otherwise no
       <td>per grammar
       <td>computed lengths for &lt;basic-shape>, the absolute URI for &lt;uri>, otherwise as specified
@@ -997,7 +989,6 @@ The shape-padding Property</a>
       <td>block-level elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as length, percentage, or calc
       <td>per grammar
       <td>the absolute length

--- a/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.bs
@@ -156,7 +156,6 @@ Size adjustment control: the 'text-size-adjust' property {#adjustment-control}
       Applies to: all elements
       Inherited: yes
       Percentages: see below
-      Media: visual
       Computed value: as specified
       Animatable: as percentage
       Canonical order: N/A

--- a/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.html
@@ -410,9 +410,6 @@ this with more detail/precision.</span></p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see below 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -676,7 +673,6 @@ this with more detail/precision.</span></p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -688,7 +684,6 @@ this with more detail/precision.</span></p>
       <td>all elements
       <td>yes
       <td>see below
-      <td>visual
       <td>as percentage
       <td>N/A
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-sizing-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-sizing-3/Overview.html
@@ -567,9 +567,6 @@ Otherwise, equal to the <a data-link-type="dfn" href="#max-content" id="ref-for-
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to width/height of <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#containing-block" id="ref-for-containing-block⑥">containing block</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
      <tr>
@@ -602,9 +599,6 @@ Otherwise, equal to the <a data-link-type="dfn" href="#max-content" id="ref-for-
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to width/height of <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#containing-block" id="ref-for-containing-block⑦">containing block</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
@@ -642,9 +636,6 @@ Otherwise, equal to the <a data-link-type="dfn" href="#max-content" id="ref-for-
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to width/height of <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#containing-block" id="ref-for-containing-block⑧">containing block</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute 
@@ -758,9 +749,6 @@ Otherwise, equal to the <a data-link-type="dfn" href="#max-content" id="ref-for-
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1922,7 +1910,6 @@ Intrinsic Sizes</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1935,7 +1922,6 @@ Intrinsic Sizes</a>
       <td>all elements that accept width or height
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1947,7 +1933,6 @@ Intrinsic Sizes</a>
       <td>all elements except non-replaced inlines
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar
@@ -1959,7 +1944,6 @@ Intrinsic Sizes</a>
       <td>all elements that accept width or height
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar
@@ -1971,7 +1955,6 @@ Intrinsic Sizes</a>
       <td>all elements that accept width or height
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar
@@ -1983,7 +1966,6 @@ Intrinsic Sizes</a>
       <td>all elements that accept width or height
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar
@@ -1995,7 +1977,6 @@ Intrinsic Sizes</a>
       <td>all elements that accept width or height
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar
@@ -2007,7 +1988,6 @@ Intrinsic Sizes</a>
       <td>all elements except non-replaced inlines
       <td>no
       <td>relative to width/height of containing block
-      <td>visual
       <td>As &lt;length-percentage>, or keyword, or as fit-content() with the &lt;length-percentage> argument interpolable
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-tables-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-tables-3/Overview.bs
@@ -805,7 +805,6 @@ spec:css-sizing-3; type:property; text:box-sizing
 				Applies To: <a>table-root</a> boxes when 'border-collapse' is <code>separate</code>
 				Inherited: yes
 				Computed Value: two absolute lengths
-				Media: visual
 				Animatable: yes
 			</pre>
 
@@ -827,7 +826,6 @@ spec:css-sizing-3; type:property; text:box-sizing
 				Initial: top
 				Applies to: <a>table-caption</a> boxes
 				Inherited: yes
-				Media: visual
 			</pre>
 
 			This property specifies the position of the caption box with respect to the table box.
@@ -2517,7 +2515,6 @@ With a table-internal box as non-containing block parent</h3>
 			Initial: show
 			Applies to: <a>table-cell</a> boxes
 			Inherited: yes
-			Media: visual
 		</pre>
 
 		<a>In collapsed-borders mode</a>,

--- a/tests/github/w3c/csswg-drafts/css-tables-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-tables-3/Overview.html
@@ -1066,9 +1066,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1113,9 +1110,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1153,9 +1147,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>two absolute lengths 
      <tr>
@@ -1191,9 +1182,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2364,9 +2352,6 @@ img[title] { float: none; }
       <tr>
        <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
        <td>n/a 
-      <tr>
-       <th>Media:
-       <td>visual 
       <tr>
        <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
        <td>as specified 
@@ -3557,7 +3542,6 @@ With a table-internal as containing block</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -3570,7 +3554,6 @@ With a table-internal as containing block</a>
       <td>table-root boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3582,7 +3565,6 @@ With a table-internal as containing block</a>
       <td>table-root boxes when border-collapse is separate
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>
       <td>per grammar
@@ -3594,7 +3576,6 @@ With a table-internal as containing block</a>
       <td>table-caption boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3606,7 +3587,6 @@ With a table-internal as containing block</a>
       <td>table-cell boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3618,7 +3598,6 @@ With a table-internal as containing block</a>
       <td>table-root boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
@@ -647,9 +647,6 @@ that is indivisible with respect to a particular typographic operation
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -750,9 +747,6 @@ that is indivisible with respect to a particular typographic operation
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1033,9 +1027,6 @@ that is indivisible with respect to a particular typographic operation
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
        <tr>
-        <th>Media:
-        <td>visual 
-       <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>the specified integer or length made absolute 
        <tr>
@@ -1139,9 +1130,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -1255,9 +1243,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -1404,9 +1389,6 @@ that is indivisible with respect to a particular typographic operation
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
        <tr>
-        <th>Media:
-        <td>visual 
-       <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
        <tr>
@@ -1482,9 +1464,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -1565,9 +1544,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified, except for <a class="css" data-link-type="maybe" href="#valdef-text-align-match-parent" id="ref-for-valdef-text-align-match-parent">match-parent</a> which computes as defined below 
@@ -1652,9 +1628,6 @@ that is indivisible with respect to a particular typographic operation
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
        <tr>
-        <th>Media:
-        <td>visual 
-       <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
        <tr>
@@ -1689,9 +1662,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -1729,9 +1699,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -1970,9 +1937,6 @@ that is indivisible with respect to a particular typographic operation
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>refers to width of the affected glyph 
        <tr>
-        <th>Media:
-        <td>visual 
-       <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified, with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>s made absolute 
        <tr>
@@ -2041,9 +2005,6 @@ that is indivisible with respect to a particular typographic operation
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>an absolute length 
@@ -2232,9 +2193,6 @@ is non-zero.</p>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>refers to width of containing block 
        <tr>
-        <th>Media:
-        <td>visual 
-       <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>the percentage as specified or the absolute length, plus any keywords as specified 
        <tr>
@@ -2335,9 +2293,6 @@ Can help us stay on the page.
        <tr>
         <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
         <td>n/a 
-       <tr>
-        <th>Media:
-        <td>visual 
        <tr>
         <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
         <td>as specified 
@@ -3464,7 +3419,6 @@ Bidirectionality and Line Boxes</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3476,7 +3430,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -3487,7 +3440,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3498,7 +3450,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>length
       <td>n/a
       <td>an absolute length
@@ -3509,7 +3460,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3520,7 +3470,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3531,7 +3480,6 @@ Bidirectionality and Line Boxes</a>
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>length, number, or calc
       <td>n/a
       <td>the specified integer or length made absolute
@@ -3542,7 +3490,6 @@ Bidirectionality and Line Boxes</a>
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified, except for match-parent which computes as defined below
@@ -3553,7 +3500,6 @@ Bidirectionality and Line Boxes</a>
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3564,7 +3510,6 @@ Bidirectionality and Line Boxes</a>
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3575,7 +3520,6 @@ Bidirectionality and Line Boxes</a>
       <td>block containers
       <td>yes
       <td>refers to width of containing block
-      <td>visual
       <td>length, percentage, or calc, but only if keywords match
       <td>per grammar
       <td>the percentage as specified or the absolute length, plus any keywords as specified
@@ -3586,7 +3530,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3597,7 +3540,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3608,7 +3550,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3619,7 +3560,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified
@@ -3630,7 +3570,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>refers to width of the affected glyph
-      <td>visual
       <td>length, percentage, or calc
       <td>n/a
       <td>as specified, with &lt;length>s made absolute
@@ -3641,7 +3580,6 @@ Bidirectionality and Line Boxes</a>
       <td>inline boxes
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>n/a
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-text-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-text-4/Overview.bs
@@ -47,7 +47,6 @@ White Space Collapsing: the 'text-space-collapse' property</h3>
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property declares whether and how
@@ -115,7 +114,6 @@ White Space Trimming: the 'text-space-trim' property</h3>
 	Inherited: no
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property allows authors to specify trimming behavior
@@ -180,7 +178,6 @@ Text Wrap Settings: the 'text-wrap' property</h3>
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property specifies the mode for text wrapping.
@@ -294,7 +291,6 @@ Inline breaks between boxes: the 'wrap-before'/'wrap-after' properties</h3>
 	Inherited: no
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	These properties specify modifications to break opportunities
@@ -358,7 +354,6 @@ Line breaks within boxes: the 'wrap-inside' property</h3>
 	Inherited: no
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	<dl dfn-for=wrap-inside dfn-type=value>
@@ -471,7 +466,6 @@ Shorthand for White Space and Wrapping: the 'white-space' property</h2>
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property is a shorthand for 'text-space-collapse', 'text-wrap', and 'text-space-trim'.
@@ -538,7 +532,6 @@ Hyphens: the 'hyphenate-character' property</h3>
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property specifies strings that are shown between parts of
@@ -571,7 +564,6 @@ Hyphenation Size Limit: the 'hyphenate-limit-zone' property</h3>
 	Inherited: yes
 	Percentages: refers to width of the line box
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	<p class="issue">Is 'hyphenate-limit-zone' a good name? Comments/suggestions?
@@ -592,7 +584,6 @@ Hyphenation Character Limits: the 'hyphenate-limit-chars' property</h3>
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property specifies the minimum number of characters in a
@@ -638,7 +629,6 @@ Hyphenation Line Limits: the 'hyphenate-limit-lines' and 'hyphenate-limit-last' 
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 	This property indicates the maximum number of successive hyphenated
@@ -656,7 +646,6 @@ Hyphenation Line Limits: the 'hyphenate-limit-lines' and 'hyphenate-limit-last' 
 	Inherited: yes
 	Percentages: n/a
 	Computed value: as specified
-	Media: visual
 	</pre>
 
 
@@ -956,9 +945,6 @@ Character Class Spacing: the 'text-spacing' property</h3>
 		<tr>
 			<th>Percentages:
 			<td>N/A
-		<tr>
-			<th>Media:
-			<td>visual
 		<tr>
 			<th>Computed&#160;value:
 			<td>specified value

--- a/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
@@ -362,9 +362,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -433,9 +430,6 @@ m|mi, m|mn, m|mo, m|ms, m|mtext {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -498,9 +492,6 @@ dt + dt:before { content: ", "; text-space-trim: discard-before; }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -615,9 +606,6 @@ dt + dt:before { content: ", "; text-space-trim: discard-before; }
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -679,9 +667,6 @@ dt + dt:before { content: ", "; text-space-trim: discard-before; }
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -782,9 +767,6 @@ Berlin, Germany
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -859,9 +841,6 @@ Berlin, Germany
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -907,9 +886,6 @@ Berlin, Germany
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refers to width of the line box 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -945,9 +921,6 @@ Berlin, Germany
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1006,9 +979,6 @@ Berlin, Germany
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1043,9 +1013,6 @@ Berlin, Germany
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1291,9 +1258,6 @@ Antarctica.
      <tr>
       <th>Percentages: 
       <td>N/A 
-     <tr>
-      <th>Media: 
-      <td>visual 
      <tr>
       <th>Computed value: 
       <td>specified value 
@@ -2125,7 +2089,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2138,7 +2101,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2150,7 +2112,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2162,7 +2123,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2174,7 +2134,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>block containers
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2186,7 +2145,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>block containers
       <td>yes
       <td>refers to width of the line box
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2198,7 +2156,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2210,7 +2167,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2229,7 +2185,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>block containers
       <td>yes
       <td>N/A
-      <td>visual
       <td>
       <td>
       <td>
@@ -2241,7 +2196,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2253,7 +2207,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2265,7 +2218,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>inline-level boxes and flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2277,7 +2229,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>inline-level boxes and flex items
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2289,7 +2240,6 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef
       <td>inline boxes
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-text-decor-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-decor-3/Overview.html
@@ -504,9 +504,6 @@ cite { color: fuchsia; }</pre>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -573,9 +570,6 @@ cite { color: fuchsia; }</pre>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -613,9 +607,6 @@ cite { color: fuchsia; }</pre>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the computed color 
      <tr>
@@ -649,9 +640,6 @@ cite { color: fuchsia; }</pre>
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -701,9 +689,6 @@ cite { color: fuchsia; }</pre>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -885,9 +870,6 @@ cite { color: fuchsia; }</pre>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td><span class="css">none</span>, a pair of keywords representing the shape and fill, or a string 
      <tr>
@@ -1042,9 +1024,6 @@ cite { color: fuchsia; }</pre>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1078,9 +1057,6 @@ cite { color: fuchsia; }</pre>
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>see individual properties 
-     <tr>
-      <th>Media:
       <td>see individual properties 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -1119,9 +1095,6 @@ cite { color: fuchsia; }</pre>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1226,9 +1199,6 @@ cite { color: fuchsia; }</pre>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>any <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> made absolute; any specified color computed; otherwise as specified 
@@ -2040,7 +2010,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2048,7 +2017,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-text-decoration" id="ref-for-propdef-text-decoration⑨">text-decoration</a>
       <td>&lt;‘text-decoration-line’> || &lt;‘text-decoration-style’> || &lt;‘text-decoration-color’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2063,7 +2031,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>the computed color
@@ -2074,7 +2041,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>no (but see prose, above)
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2085,14 +2051,12 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-text-emphasis" id="ref-for-propdef-text-emphasis③">text-emphasis</a>
       <td>&lt;‘text-emphasis-style’> || &lt;‘text-emphasis-color’>
-      <td>see individual properties
       <td>see individual properties
       <td>see individual properties
       <td>see individual properties
@@ -2107,7 +2071,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>color
       <td>per grammar
       <td>as specified
@@ -2118,7 +2081,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2129,7 +2091,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>none, a pair of keywords representing the shape and fill, or a string
@@ -2140,7 +2101,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>shadow list
       <td>per grammar
       <td>any &lt;length> made absolute; any specified color computed; otherwise as specified
@@ -2151,7 +2111,6 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.bs
@@ -40,7 +40,6 @@ Text Decoration Line Thickness: the 'text-decoration-width' property</h3>
 			Applies to: all elements
 			Inherited: no
 			Percentages: N/A
-			Media: visual
 			Computed value: as specified
 			Animatable: no
 	</pre>
@@ -180,7 +179,6 @@ Text Underline Offset: the 'text-underline-offset' property</h3>
 			Applies to: all elements
 			Inherited: yes
 			Percentages: N/A
-			Media: visual
 			Computed value: as specified
 			Animatable: no
 	</pre>
@@ -263,7 +261,6 @@ Text Decoration Line Continuity: the 'text-decoration-skip' property</h4>
 			Applies to: all elements
 			Inherited: yes
 			Percentages: N/A
-			Media: visual
 			Computed value: as specified
 			Animatable: no
 	</pre>
@@ -363,7 +360,6 @@ Text Decoration Line Continuity: the 'text-decoration-skip-ink' property</h4>
 			Applies to: all elements
 			Inherited: yes
 			Percentages: N/A
-			Media: visual
 			Computed value: as specified
 			Animatable: no
 	</pre>
@@ -436,7 +432,6 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 			Applies to: all elements
 			Inherited: yes
 			Percentages: N/A
-			Media: visual
 			Computed value: as specified
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.html
@@ -397,9 +397,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -523,9 +520,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -607,9 +601,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -697,9 +688,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -763,9 +751,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1286,7 +1271,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -1299,7 +1283,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1311,7 +1294,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1323,7 +1305,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar
@@ -1335,7 +1316,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -1347,7 +1327,6 @@ Text Decoration Line Continuity: the text-decoration-skip property</a> <a href="
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.bs
@@ -264,7 +264,6 @@ Applies to: [=transformable elements=]
 Inherited: no
 Percentages: refer to the size of [=reference box=]
 Computed value: As specified, but with relative lengths converted into absolute lengths.
-Media: visual
 Animatable: as <a href="#interpolation-of-transforms">transform</a>
 </pre>
 
@@ -300,7 +299,6 @@ Applies to: [=transformable elements=]
 Inherited: no
 Percentages: refer to the size of [=reference box=]
 Computed value: For <<length>> the absolute value, otherwise a percentage
-Media: visual
 Animatable: as <a href="https://drafts.csswg.org/css3-transitions/#animtype-simple-list">simple list</a> of <a href="https://drafts.csswg.org/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>
 </pre>
 
@@ -348,7 +346,6 @@ Applies to: [=transformable elements=]
 Inherited: no
 Percentages: N/A
 Computed value: Same as specified value.
-Media: visual
 Animatable: no
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.html
@@ -594,9 +594,6 @@ The current user coordinate system has its origin at the top-left of a <a data-l
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the size of <a data-link-type="dfn" href="#reference-box" id="ref-for-reference-box①">reference box</a>
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified, but with relative lengths converted into absolute lengths.
      <tr>
@@ -641,9 +638,6 @@ The current user coordinate system has its origin at the top-left of a <a data-l
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the size of <a data-link-type="dfn" href="#reference-box" id="ref-for-reference-box②">reference box</a>
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value②" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage
@@ -707,9 +701,6 @@ The current user coordinate system has its origin at the top-left of a <a data-l
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value.
@@ -1881,7 +1872,6 @@ matrix[1][1] *= scale[1]
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1893,7 +1883,6 @@ matrix[1][1] *= scale[1]
       <td>transformable elements
       <td>no
       <td>refer to the size of reference box
-      <td>visual
       <td>as transform
       <td>per grammar
       <td>As specified, but with relative lengths converted into absolute lengths.
@@ -1904,7 +1893,6 @@ matrix[1][1] *= scale[1]
       <td>transformable elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -1915,7 +1903,6 @@ matrix[1][1] *= scale[1]
       <td>transformable elements
       <td>no
       <td>refer to the size of reference box
-      <td>visual
       <td>as simple list of length, percentage, or calc
       <td>per grammar
       <td>For &lt;length> the absolute value, otherwise a percentage

--- a/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.bs
@@ -548,7 +548,6 @@ Initial: none
 Applies to: <a>transformable elements</a>
 Inherited: no
 Percentages: relative to the width of the containing block (for the first value) or the height (for the second value)
-Media: visual
 Computed Value: as specified, with lengths made absolute
 Animatable: as <<length>> or <<percentage>> list
 </pre>
@@ -571,7 +570,6 @@ Value: none | [ x | y | z | <<number>>{3} ]? && <<angle>>
 Initial: none
 Applies to: <a>transformable elements</a>
 Inherited: no
-Media: visual
 Animatable: as SLERP
 </pre>
 
@@ -603,7 +601,6 @@ Value: none | <<number>>{1,3}
 Initial: none
 Applies to: <a>transformable elements</a>
 Inherited: no
-Media: visual
 Animatable: as <<number>> list
 </pre>
 
@@ -666,7 +663,6 @@ Applies to: <a>transformable elements</a>
 Inherited: no
 Percentages: N/A
 Computed value: Same as specified value.
-Media: visual
 Animatable: no
 </pre>
 
@@ -709,7 +705,6 @@ Applies to: <a>transformable elements</a>
 Inherited: no
 Percentages: N/A
 Computed value: Absolute length or "none".
-Media: visual
 Animatable: as <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
 
@@ -745,7 +740,6 @@ Applies to: <a>transformable elements</a>
 Inherited: no
 Percentages: refer to the size of the <a>reference box</a>
 Computed value: For <<length>> the absolute value, otherwise a percentage.
-Media: visual
 Animatable: as <a href="https://drafts.csswg.org/css3-transitions/#animtype-simple-list">simple list</a> of <a href="https://drafts.csswg.org/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a>
 </pre>
 
@@ -790,7 +784,6 @@ Applies to: <a>transformable elements</a>
 Inherited: no
 Percentages: N/A
 Computed value: Same as specified value.
-Media: visual
 Animatable: no
 </pre>
 

--- a/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
@@ -745,9 +745,6 @@ rather than having to remember the order in <a class="property" data-link-type="
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the width of the containing block (for the first value) or the height (for the second value)
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute
      <tr>
@@ -787,9 +784,6 @@ equivalent to the <a class="css" data-link-type="maybe" href="#funcdef-translate
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -837,9 +831,6 @@ which can have additional side-effects in UAs.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -918,9 +909,6 @@ value (<span class="css">0px</span> for translate, <span class="css">0deg</span>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value.
      <tr>
@@ -985,9 +973,6 @@ a stacking context, which is unwanted. See <a href="https://www.w3.org/Bugs/Publ
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Absolute length or "none".
      <tr>
@@ -1031,9 +1016,6 @@ a stacking context, which is unwanted. See <a href="https://www.w3.org/Bugs/Publ
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the size of the <a data-link-type="dfn" href="https://drafts.csswg.org/css-transforms-1/#reference-box" id="ref-for-reference-box">reference box</a>
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value⑥" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
@@ -1091,9 +1073,6 @@ a stacking context, which is unwanted. See <a href="https://www.w3.org/Bugs/Publ
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value.
@@ -2124,7 +2103,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2136,7 +2114,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -2147,7 +2124,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>N/A
-      <td>visual
       <td>as length
       <td>per grammar
       <td>Absolute length or "none".
@@ -2158,7 +2134,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>refer to the size of the reference box
-      <td>visual
       <td>as simple list of length, percentage, or calc
       <td>per grammar
       <td>For &lt;length> the absolute value, otherwise a percentage.
@@ -2169,7 +2144,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as SLERP
       <td>per grammar
       <td>as specified
@@ -2180,7 +2154,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as &lt;number> list
       <td>per grammar
       <td>as specified
@@ -2191,7 +2164,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -2202,7 +2174,6 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
       <td>transformable elements
       <td>no
       <td>relative to the width of the containing block (for the first value) or the height (for the second value)
-      <td>visual
       <td>as &lt;length> or &lt;percentage> list
       <td>per grammar
       <td>as specified, with lengths made absolute

--- a/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.bs
@@ -268,7 +268,6 @@ Introduction {#introduction}
         Inherited: no
         Animatable: no
         Percentages: N/A
-        Media: visual
         Computed value: Same as specified value.
         Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
       </pre>
@@ -345,7 +344,6 @@ Introduction {#introduction}
         Inherited: no
         Animatable: no
         Percentages: N/A
-        Media: interactive
         Computed value: Same as specified value.
         Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
       </pre>
@@ -378,7 +376,6 @@ Introduction {#introduction}
         Inherited: no
         Animatable: no
         Percentages: N/A
-        Media: interactive
         Computed value: Same as specified value.
         Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
       </pre>
@@ -401,7 +398,6 @@ Introduction {#introduction}
         Inherited: no
         Animatable: no
         Percentages: N/A
-        Media: interactive
         Computed value: Same as specified value.
         Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
       </pre>
@@ -420,7 +416,6 @@ Introduction {#introduction}
         Inherited: no
         Animatable: no
         Percentages: N/A
-        Media: interactive
         Computed value: see individual properties
         Canonical order: <abbr title="follows order of property value definition">per grammar</abbr>
       </pre>

--- a/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.html
@@ -523,9 +523,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value. 
      <tr>
@@ -587,9 +584,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value. 
      <tr>
@@ -630,9 +624,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value. 
      <tr>
@@ -666,9 +657,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>interactive 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value. 
      <tr>
@@ -700,9 +688,6 @@ on screen, on paper, in speech, etc.
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>interactive 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties 
@@ -2512,7 +2497,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2524,7 +2508,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <td>all elements, ::before and ::after pseudo elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>see individual properties
@@ -2535,7 +2518,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <td>all elements, ::before and ::after pseudo elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -2546,7 +2528,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <td>all elements, ::before and ::after pseudo elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -2557,7 +2538,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <td>all elements, ::before and ::after pseudo elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>Same as specified value.
@@ -2568,7 +2548,6 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
       <td>all elements, ::before and ::after pseudo elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>no
       <td>per grammar
       <td>Same as specified value.

--- a/tests/github/w3c/csswg-drafts/css-ui-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-ui-3/Overview.bs
@@ -139,7 +139,6 @@ Initial: content-box
 Applies to: all elements that accept width or height 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: specified value 
 </pre>
 
@@ -290,7 +289,6 @@ Initial: see individual properties
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: see individual properties 
 Animation type: see individual properties 
 </pre>
@@ -304,7 +302,6 @@ Initial: medium
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: absolute length; ''0'' if the outline style is ''border-style/none''.
 Animation type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
@@ -318,7 +315,6 @@ Initial: none
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: as specified
 </pre>
 
@@ -331,7 +327,6 @@ Initial: invert
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: The computed value for ''outline-color/invert'' is ''outline-color/invert'';
 	the computed value of ''outline-color/currentColor'' is ''outline-color/currentColor'' (See [[CSS-COLOR-3/#currentColor]]);
 	see the 'color' property for other <<color>> values.
@@ -462,7 +457,6 @@ Initial: 0
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: <<length>> value in absolute units (px or physical). 
 Animation Type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a> 
 </pre>
@@ -517,7 +511,6 @@ Applies to: elements with 'overflow' other than visible,
  and optionally replaced elements such as images, videos, and iframes 
 Inherited: no 
 Percentages: N/A 
-Media: visual 
 Computed value: as specified
 </pre>
 
@@ -640,7 +633,6 @@ Initial: clip
 Applies to: block containers
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: as specified
 </pre>
 
@@ -933,7 +925,6 @@ Initial: auto
 Applies to: all elements 
 Inherited: yes 
 Percentages: N/A 
-Media: visual, interactive 
 Computed value: as specified, except with any relative URLs converted to absolute 
 </pre>
 
@@ -1244,7 +1235,6 @@ Initial: auto
 Applies to: all elements
 Inherited: yes 
 Percentages: N/A 
-Media: interactive 
 Computed value: The computed value for ''caret-color/auto'' is ''caret-color/auto'';
 	the computed value of ''caret-color/currentColor'' is ''cart-color/currentColor'' (See [[CSS-COLOR-3/#currentColor]]);
 	see the 'color' property for other <<color>> values.

--- a/tests/github/w3c/csswg-drafts/css-ui-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ui-3/Overview.html
@@ -498,9 +498,6 @@ and Information on the stacking of outlines defined in <a href="https://www.w3.o
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -662,9 +659,6 @@ without making sure an alternative highlighting mechanism is provided. </strong>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
@@ -695,9 +689,6 @@ without making sure an alternative highlighting mechanism is provided. </strong>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length; <span class="css">0</span> if the outline style is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none" id="ref-for-valdef-line-style-none">none</a>.
@@ -730,9 +721,6 @@ without making sure an alternative highlighting mechanism is provided. </strong>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -763,9 +751,6 @@ without making sure an alternative highlighting mechanism is provided. </strong>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>The computed value for <a class="css" data-link-type="maybe" href="#valdef-outline-color-invert" id="ref-for-valdef-outline-color-invert">invert</a> is <span class="css">invert</span>;
@@ -881,9 +866,6 @@ However, it is possible to offset the outline and draw it beyond the <span>borde
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> value in absolute units (px or physical).
      <tr>
@@ -947,9 +929,6 @@ and optionally replaced elements such as images, videos, and iframes
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1060,9 +1039,6 @@ the following rule can be used:</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1302,9 +1278,6 @@ having it overlap other text by default. </div>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual, interactive
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, except with any relative URLs converted to absolute
@@ -1558,9 +1531,6 @@ boxes are generated for it and its cursor is used for the canvas.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>interactive
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>The computed value for <a class="css" data-link-type="maybe" href="#valdef-caret-color-auto" id="ref-for-valdef-caret-color-auto">auto</a> is <span class="css">auto</span>;
@@ -2558,7 +2528,6 @@ frame[noresize] { resize:none }
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2570,7 +2539,6 @@ frame[noresize] { resize:none }
       <td>all elements that accept width or height
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>specified value
@@ -2581,7 +2549,6 @@ frame[noresize] { resize:none }
       <td>all elements
       <td>yes
       <td>N/A
-      <td>interactive
       <td>color
       <td>per grammar
       <td>The computed value for auto is auto;
@@ -2604,7 +2571,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual, interactive
       <td>discrete
       <td>per grammar
       <td>as specified, except with any relative URLs converted to absolute
@@ -2615,7 +2581,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -2626,7 +2591,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>color
       <td>per grammar
       <td>The computed value for invert is invert;
@@ -2639,7 +2603,6 @@ see the color property for other &lt;color> values.
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>length
       <td>per grammar
       <td>&lt;length> value in absolute units (px or physical).
@@ -2650,7 +2613,6 @@ see the color property for other &lt;color> values.
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2661,7 +2623,6 @@ see the color property for other &lt;color> values.
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>length
       <td>per grammar
       <td>absolute length; 0 if the outline style is none.
@@ -2673,7 +2634,6 @@ see the color property for other &lt;color> values.
 and optionally replaced elements such as images, videos, and iframes
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified
@@ -2684,7 +2644,6 @@ and optionally replaced elements such as images, videos, and iframes
       <td>block containers
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/csswg-drafts/css-ui-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-ui-4/Overview.bs
@@ -152,7 +152,6 @@ Initial: content-box
 Applies to: all elements that accept width or height
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: specified value
 </pre>
 
@@ -374,7 +373,6 @@ Initial: see individual properties
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: see individual properties
 Animation type: see individual properties
 </pre>
@@ -389,7 +387,6 @@ Initial: medium
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: absolute length; ''0'' if the outline style is ''border-style/none''.
 Animation type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
@@ -404,7 +401,6 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: as specified
 </pre>
 
@@ -418,7 +414,6 @@ Initial: invert
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: The computed value for ''outline-color/invert'' is ''outline-color/invert''.
  For <<color>> values, see <a>resolving color values</a> in [[!CSS-COLOR-4]].
 Animation Type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-color">color</a>
@@ -546,7 +541,6 @@ Initial: 0
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: <<length>> value in absolute units (px or physical).
 Animation Type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
@@ -601,7 +595,6 @@ Applies to: elements with 'overflow' other than visible,
  and optionally replaced elements such as images, videos, and iframes
 Inherited: no
 Percentages: N/A
-Media: visual
 Computed value: as specified
 </pre>
 
@@ -717,7 +710,6 @@ Initial: clip
 Applies to: block containers
 Inherited: no
 Percentages: refer to the width of the line box
-Media: visual
 Computed value: As specified, with <<length>> converted to absolute units
 </pre>
 
@@ -1127,7 +1119,6 @@ Initial: auto
 Applies to: all elements
 Inherited: yes
 Percentages: N/A
-Media: visual, interactive
 Computed value: as specified, except with any relative URLs converted to absolute
 </pre>
 
@@ -1461,7 +1452,6 @@ Initial: auto
 Applies to: all elements
 Inherited: yes
 Percentages: N/A
-Media: interactive
 Computed value: The computed value for ''caret-color/auto'' is ''caret-color/auto''.
  For <<color>> values, see <a>resolving color values</a> in [[!CSS-COLOR-4]].
 Animation Type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-color">color</a>
@@ -1515,7 +1505,6 @@ Initial: auto
 Applies to: elements that accept input
 Inherited: yes
 Percentages: N/A
-Media: interactive
 Computed value: Same as specified value.
 Animatable: no
 </pre>
@@ -1648,7 +1637,6 @@ Initial: auto
 Applies to: elements that accept input
 Inherited: yes
 Percentages: N/A
-Media: interactive
 Computed value: Same as specified value
 Animatable: no
 </pre>
@@ -1806,7 +1794,6 @@ Initial: auto
 Applies to: elements that accept input
 Inherited: yes
 Percentages: N/A
-Media: interactive
 Computed value: See individual properties
 Animatable: See individual properties
 </pre>
@@ -1875,7 +1862,6 @@ Initial: auto
 Applies to: all enabled elements
 Inherited: no
 Percentages: N/A
-Media: interactive
 Computed value: as specified
 </pre>
 
@@ -2042,7 +2028,6 @@ avoiding accidental selections of neighbouring content.
 	Initial: auto
 	Inherited: no
 	Applies to: all elements, and optionally to the ''::before'' and ''::after'' pseudo elements
-	Media: interactive
 	Computed value: See below
 </pre>
 
@@ -2382,7 +2367,6 @@ Initial: auto
 Applies To: all elements
 Inherited: no
 Computed value: As specified
-Media: all
 </pre>
 
 Issue: Should ''appearance/auto'' compute to ''appearance/none'' on regular elements?

--- a/tests/github/w3c/csswg-drafts/css-ui-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ui-4/Overview.html
@@ -553,9 +553,6 @@ which itself replaced and superseded the following:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -729,9 +726,6 @@ This supersedes the stacking of outlines as defined in <a href="https://www.w3.o
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
@@ -762,9 +756,6 @@ This supersedes the stacking of outlines as defined in <a href="https://www.w3.o
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length; <span class="css">0</span> if the outline style is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none" id="ref-for-valdef-line-style-none">none</a>.
@@ -797,9 +788,6 @@ This supersedes the stacking of outlines as defined in <a href="https://www.w3.o
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -830,9 +818,6 @@ This supersedes the stacking of outlines as defined in <a href="https://www.w3.o
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>The computed value for <a class="css" data-link-type="maybe" href="#valdef-outline-color-invert" id="ref-for-valdef-outline-color-invert">invert</a> is <span class="css">invert</span>.
@@ -946,9 +931,6 @@ However, it is possible to offset the outline and draw it beyond the <span>borde
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td><a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> value in absolute units (px or physical).
      <tr>
@@ -1010,9 +992,6 @@ and optionally replaced elements such as images, videos, and iframes
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1123,9 +1102,6 @@ user resizing of that element.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the width of the line box
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified, with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value②" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> converted to absolute units
@@ -1446,9 +1422,6 @@ then only the end ellipsis/string should be rendered.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual, interactive
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, except with any relative URLs converted to absolute
      <tr>
@@ -1715,9 +1688,6 @@ boxes are generated for it and its cursor is used for the canvas.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>The computed value for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ui-3/#valdef-caret-color-auto" id="ref-for-valdef-caret-color-auto">auto</a> is <span class="css">auto</span>.
 For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-color-3/#valuea-def-color" id="ref-for-valuea-def-color③" title="Expands to: indigo | gold | firebrick | indianred | yellow | darkolivegreen | darkseagreen | slategrey | darkslategrey | mediumvioletred | mediumorchid | transparent | chartreuse | mediumslateblue | black | springgreen | crimson | lightsalmon | brown | turquoise | olivedrab | cyan | silver | skyblue | gray | darkturquoise | goldenrod | darkgreen | darkviolet | darkgray | lightpink | teal | darkmagenta | lightgoldenrodyellow | lavender | yellowgreen | thistle | violet | navy | dimgrey | orchid | blue | ghostwhite | honeydew | cornflowerblue | darkblue | darkkhaki | mediumpurple | cornsilk | red | bisque | slategray | darkcyan | khaki | wheat | deepskyblue | rebeccapurple | darkred | steelblue | aliceblue | lightslategrey | gainsboro | mediumturquoise | floralwhite | coral | purple | lightgrey | lightcyan | darksalmon | beige | azure | lightsteelblue | oldlace | greenyellow | royalblue | lightseagreen | mistyrose | sienna | lightcoral | orangered | navajowhite | lime | palegreen | burlywood | seashell | mediumspringgreen | fuchsia | papayawhip | blanchedalmond | peru | aquamarine | white | darkslategray | tomato | ivory | dodgerblue | currentcolor | lemonchiffon | chocolate | orange | forestgreen | darkgrey | olive | mintcream | antiquewhite | darkorange | cadetblue | moccasin | limegreen | saddlebrown | grey | darkslateblue | lightskyblue | deeppink | plum | aqua | darkgoldenrod | maroon | sandybrown | magenta | tan | rosybrown | pink | lightblue | palevioletred | mediumseagreen | slateblue | dimgray | powderblue | seagreen | snow | mediumblue | midnightblue | paleturquoise | palegoldenrod | whitesmoke | darkorchid | salmon | lightslategray | lawngreen | lightgreen | lightgray | hotpink | lightyellow | lavenderblush | linen | mediumaquamarine | green | blueviolet | peachpuff">&lt;color></a> values, see <a data-link-type="dfn" href="https://drafts.csswg.org/css-color-4/#resolve-color-values" id="ref-for-resolve-color-values①">resolving color values</a> in <a data-link-type="biblio" href="#biblio-css-color-4">[CSS-COLOR-4]</a>.
@@ -1776,9 +1746,6 @@ though it sometimes resembles a caret, is not a caret (it’s a cursor).</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>interactive
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value
@@ -1905,9 +1872,6 @@ user@host:css-ui-4 $
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>interactive
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties
      <tr>
@@ -1941,9 +1905,6 @@ Omitted values are set to their initial values.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>interactive
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -2096,9 +2057,6 @@ avoiding accidental selections of neighbouring content.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>interactive
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See below
@@ -2379,9 +2337,6 @@ so that CSS can be used to fully restyle them.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>all
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>As specified
@@ -3828,7 +3783,6 @@ Single-Line Text Input Controls</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -3841,7 +3795,6 @@ Single-Line Text Input Controls</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>
       <td>discrete
       <td>per grammar
@@ -3853,7 +3806,6 @@ Single-Line Text Input Controls</a>
       <td>all elements that accept width or height
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3865,7 +3817,6 @@ Single-Line Text Input Controls</a>
       <td>elements that accept input
       <td>yes
       <td>N/A
-      <td>interactive
       <td>See individual properties
       <td>
       <td>per grammar
@@ -3877,7 +3828,6 @@ Single-Line Text Input Controls</a>
       <td>all elements
       <td>yes
       <td>N/A
-      <td>interactive
       <td>
       <td>color
       <td>per grammar
@@ -3890,7 +3840,6 @@ For &lt;color> values, see resolving color values in [CSS-COLOR-4].
       <td>elements that accept input
       <td>yes
       <td>N/A
-      <td>interactive
       <td>no
       <td>
       <td>per grammar
@@ -3912,7 +3861,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual, interactive
       <td>
       <td>discrete
       <td>per grammar
@@ -3924,7 +3872,6 @@ zoom-in | zoom-out
       <td>all enabled elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>
       <td>discrete
       <td>per grammar
@@ -3936,7 +3883,6 @@ zoom-in | zoom-out
       <td>all enabled elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>
       <td>discrete
       <td>per grammar
@@ -3948,7 +3894,6 @@ zoom-in | zoom-out
       <td>all enabled elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>
       <td>discrete
       <td>per grammar
@@ -3960,7 +3905,6 @@ zoom-in | zoom-out
       <td>all enabled elements
       <td>no
       <td>N/A
-      <td>interactive
       <td>
       <td>discrete
       <td>per grammar
@@ -3972,7 +3916,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>see individual properties
       <td>per grammar
@@ -3984,7 +3927,6 @@ zoom-in | zoom-out
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>color
       <td>per grammar
@@ -3997,7 +3939,6 @@ For &lt;color> values, see resolving color values in [CSS-COLOR-4].
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>length
       <td>per grammar
@@ -4009,7 +3950,6 @@ For &lt;color> values, see resolving color values in [CSS-COLOR-4].
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4021,7 +3961,6 @@ For &lt;color> values, see resolving color values in [CSS-COLOR-4].
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>length
       <td>per grammar
@@ -4034,7 +3973,6 @@ For &lt;color> values, see resolving color values in [CSS-COLOR-4].
 and optionally replaced elements such as images, videos, and iframes
       <td>no
       <td>N/A
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4046,7 +3984,6 @@ and optionally replaced elements such as images, videos, and iframes
       <td>block containers
       <td>no
       <td>refer to the width of the line box
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -4058,7 +3995,6 @@ and optionally replaced elements such as images, videos, and iframes
       <td>all elements, and optionally to the ::before and ::after pseudo elements
       <td>no
       <td>n/a
-      <td>interactive
       <td>
       <td>discrete
       <td>per grammar

--- a/tests/github/w3c/csswg-drafts/css-variables-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-variables-1/Overview.bs
@@ -63,7 +63,6 @@ Defining Custom Properties: the '--*' family of properties</h2>
 	Applies to: all elements
 	Inherited: yes
 	Computed value: specified value with variables substituted (but see prose for "invalid variables")
-	Media: all
 	Animatable: no
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-variables-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-variables-1/Overview.html
@@ -418,9 +418,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value with variables substituted (but see prose for "invalid variables") 
      <tr>
@@ -1354,7 +1351,6 @@ Changes since the May 6 2014 Last Call Working Draft</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1366,7 +1362,6 @@ Changes since the May 6 2014 Last Call Working Draft</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>all
       <td>no
       <td>per grammar
       <td>specified value with variables substituted (but see prose for "invalid variables")

--- a/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.bs
@@ -173,7 +173,6 @@ Hinting at Future Behavior: the 'will-change' property</h2>
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a
-	Media: all
 	Computed value: specified value
 	</pre>
 

--- a/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.html
@@ -426,9 +426,6 @@ on screen, on paper, in speech, etc.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>all 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -731,7 +728,6 @@ Hinting at Future Behavior: the will-change property</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -743,7 +739,6 @@ Hinting at Future Behavior: the will-change property</a>
       <td>all elements
       <td>no
       <td>n/a
-      <td>all
       <td>discrete
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.bs
@@ -223,7 +223,6 @@ Specifying Directionality: the 'direction' property</h3>
   Applies to: all elements
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -275,7 +274,6 @@ Embeddings and Overrides: the 'unicode-bidi' property</h3>
   Applies to: all elements, but see prose
   Inherited: no
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   </pre>
 
@@ -787,7 +785,6 @@ Block Flow Direction: the 'writing-mode' property</h3>
   Applies to: All elements except table row groups, table column groups, table rows, table columns, ruby base container, ruby annotation container
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -1204,7 +1201,6 @@ Orienting Text: the 'text-orientation' property</h3>
   Applies to: all elements except table row groups, rows, column groups, and columns
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -1402,7 +1398,6 @@ Obsolete: the SVG1.1 'glyph-orientation-vertical' property</h4>
   Applies to: n/a
   Inherited: na/
   Percentages: n/a
-  Media: n/a
   Computed value: n/a
   Animatable: n/a
   Canonical order: n/a
@@ -2315,7 +2310,6 @@ Horizontal-in-Vertical Composition: the 'text-combine-upright' property</h3>
   Applies to: non-replaced inline elements
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified keyword
   Animatable: no
   Canonical order: n/a

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.html
@@ -614,9 +614,6 @@ Vertical Scripts in Unicode</span></a>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -672,9 +669,6 @@ Vertical Scripts in Unicode</span></a>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1099,9 +1093,6 @@ english17 <i data-lt="">18WERBEH
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1448,9 +1439,6 @@ english17 <i data-lt="">18WERBEH
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1597,9 +1585,6 @@ english17 <i data-lt="">18WERBEH
       <td>na/ 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>n/a 
-     <tr>
-      <th>Media:
       <td>n/a 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -2250,9 +2235,6 @@ block-end side  |                           |  | block-start side |
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified keyword 
@@ -3543,7 +3525,6 @@ The Principal Writing Mode</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -3556,7 +3537,6 @@ The Principal Writing Mode</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3569,7 +3549,6 @@ The Principal Writing Mode</a>
       <td>na/
       <td>n/a
       <td>n/a
-      <td>n/a
       <td>
       <td>n/a
       <td>n/a
@@ -3580,7 +3559,6 @@ The Principal Writing Mode</a>
       <td>non-replaced inline elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3592,7 +3570,6 @@ The Principal Writing Mode</a>
       <td>all elements except table row groups, rows, column groups, and columns
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3604,7 +3581,6 @@ The Principal Writing Mode</a>
       <td>all elements, but see prose
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3616,7 +3592,6 @@ The Principal Writing Mode</a>
       <td>All elements except table row groups, table column groups, table rows, table columns, ruby base container, ruby annotation container
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.bs
@@ -224,7 +224,6 @@ Specifying Directionality: the 'direction' property</h3>
   Applies to: all elements
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -276,7 +275,6 @@ Embeddings and Overrides: the 'unicode-bidi' property</h3>
   Applies to: all elements, but see prose
   Inherited: no
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   </pre>
 
@@ -857,7 +855,6 @@ Block Flow Direction: the 'writing-mode' property</h3>
   Applies to: All elements except table row groups, table column groups, table rows, table columns, ruby base container, ruby annotation container
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -1280,7 +1277,6 @@ Orienting Text: the 'text-orientation' property</h3>
   Applies to: all elements except table row groups, rows, column groups, and columns
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified value
   Animatable: no
   Canonical order: n/a
@@ -1477,7 +1473,6 @@ Obsolete: the SVG1.1 'glyph-orientation-vertical' property</h4>
   Applies to: n/a
   Inherited: na/
   Percentages: n/a
-  Media: n/a
   Computed value: n/a
   Animatable: n/a
   Canonical order: n/a
@@ -2542,7 +2537,6 @@ Horizontal-in-Vertical Composition: the 'text-combine-upright' property</h3>
   Applies to: non-replaced inline elements
   Inherited: yes
   Percentages: n/a
-  Media: visual
   Computed value: specified keyword, plus integer if ''digits''
   Animatable: no
   Canonical order: n/a

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.html
@@ -621,9 +621,6 @@ Vertical Scripts in Unicode</span></a>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -679,9 +676,6 @@ Vertical Scripts in Unicode</span></a>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
@@ -1148,9 +1142,6 @@ TXET.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1503,9 +1494,6 @@ TXET.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value 
      <tr>
@@ -1651,9 +1639,6 @@ TXET.
       <td>na/ 
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
-      <td>n/a 
-     <tr>
-      <th>Media:
       <td>n/a 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
@@ -2420,9 +2405,6 @@ block-end side  |                           |  | block-start side |
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified keyword, plus integer if <span class="css">digits</span> 
@@ -3870,7 +3852,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
@@ -3883,7 +3864,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>all elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3896,7 +3876,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>na/
       <td>n/a
       <td>n/a
-      <td>n/a
       <td>
       <td>n/a
       <td>n/a
@@ -3907,7 +3886,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>non-replaced inline elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3919,7 +3897,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>all elements except table row groups, rows, column groups, and columns
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a
@@ -3931,7 +3908,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>all elements, but see prose
       <td>no
       <td>n/a
-      <td>visual
       <td>
       <td>discrete
       <td>per grammar
@@ -3943,7 +3919,6 @@ Conditions of Reordering-induced Box Fragmentation</a>
       <td>All elements except table row groups, table column groups, table rows, table columns, ruby base container, ruby annotation container
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>
       <td>n/a

--- a/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.bs
+++ b/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.bs
@@ -1732,7 +1732,6 @@ Initial: auto
 Applies to: <a>scrolling boxes</a>
 Inherited: no
 Computed value:    specified value
-Media: visual
 Animatable: no
 Canonical Order: per grammar
 </pre>

--- a/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.html
@@ -2138,9 +2138,6 @@ in the order they were added to the list, run these substeps:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
@@ -3344,7 +3341,6 @@ the Windows Internet Explorer browser.</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3356,7 +3352,6 @@ the Windows Internet Explorer browser.</p>
       <td>scrolling boxes
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value

--- a/tests/github/w3c/fxtf-drafts/compositing-1/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/compositing-1/Overview.bs
@@ -111,7 +111,6 @@ Applies to: All elements. In SVG, it applies to <a href="https://www.w3.org/TR/S
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -254,7 +253,6 @@ Applies to: All elements. In SVG, it applies to <a href="https://www.w3.org/TR/S
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -283,7 +281,6 @@ Applies to: All HTML elements
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 

--- a/tests/github/w3c/fxtf-drafts/compositing-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/compositing-1/Overview.html
@@ -452,9 +452,6 @@ This behavior is described in more detail in <a href="#blending">Blending</a>.</
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -580,9 +577,6 @@ p {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -620,9 +614,6 @@ p {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1675,7 +1666,6 @@ Draft of 2013-06-25</a>:</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1687,7 +1677,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All HTML elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1698,7 +1687,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All elements. In SVG, it applies to container elements, graphics elements and graphics referencing elements. [SVG11]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1709,7 +1697,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All elements. In SVG, it applies to container elements, graphics elements and graphics referencing elements. [SVG11]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/fxtf-drafts/compositing-2/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/compositing-2/Overview.bs
@@ -110,7 +110,6 @@ Applies to: All elements. In SVG, it applies to <a href="https://www.w3.org/TR/S
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -253,7 +252,6 @@ Applies to: All elements. In SVG, it applies to <a href="https://www.w3.org/TR/S
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -282,7 +280,6 @@ Applies to: All HTML elements
 Inherited: no
 Percentages: N/A
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 

--- a/tests/github/w3c/fxtf-drafts/compositing-2/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/compositing-2/Overview.html
@@ -450,9 +450,6 @@ This behavior is described in more detail in <a href="#blending">Blending</a>.</
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -578,9 +575,6 @@ p {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -618,9 +612,6 @@ p {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1683,7 +1674,6 @@ Draft of 2013-06-25</a>:</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -1695,7 +1685,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All HTML elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1706,7 +1695,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All elements. In SVG, it applies to container elements, graphics elements and graphics referencing elements. [SVG11]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1717,7 +1705,6 @@ Draft of 2013-06-25</a>:</p>
       <td>All elements. In SVG, it applies to container elements, graphics elements and graphics referencing elements. [SVG11]
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.bs
@@ -212,7 +212,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified, but with <<url>> values made absolute
-Media: visual
 Animatable: as specified for <<basic-shape>> [[!CSS-SHAPES]], otherwise no
 </pre>
 
@@ -353,7 +352,6 @@ Applies to: Applies to SVG <a>graphics elements</a>
 Inherited: yes
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -424,7 +422,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified, but with URIs made absolute
-Media: visual
 Animatable: no
 </pre>
 
@@ -476,7 +473,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -537,7 +533,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: Consists of: two keywords, one per dimension
-Media: visual
 Animatable: no
 </pre>
 
@@ -574,7 +569,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: refer to size of <a>mask painting area</a> <em>minus</em> size of <a>mask layer image</a>; see text 'background-position' [[!CSS3BG]]
 Computed value: Consisting of: two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a <<length>>), otherwise as a percentage.
-Media: visual
 Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-repeatable-list">repeatable list</a> of <a href="https://www.w3.org/TR/css3-transitions/#animtype-simple-list">simple list</a> of <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc
 </pre>
 
@@ -611,7 +605,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -661,7 +654,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -708,7 +700,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified, but with lengths made absolute
-Media: visual
 Animatable: as <a href="https://www.w3.org/TR/css3-transitions/#animtype-repeatable-list">repeatable list</a> of <a href="https://www.w3.org/TR/css3-transitions/#animtype-simple-list">simple list</a> of <a href="https://www.w3.org/TR/css3-transitions/#animtype-lpcalc">length, percentage, or calc</a> (<span class="note">This means keyword values are not animatable.</span>)
 </pre>
 
@@ -729,7 +720,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> withou
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -844,7 +834,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: see individual properties
 Computed value: see individual properties
-Media: visual
 Animatable: see individual properties
 </pre>
 
@@ -954,7 +943,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: ''mask-border-source/none'' or the image with its URI made absolute
-Media: visual
 Animatable: no
 </pre>
 
@@ -981,7 +969,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1009,7 +996,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: refer to size of the <a>mask border image</a>
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1028,7 +1014,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: relative to width/height of the <a>mask border image area</a>
 Computed value: all <<length>>s made absolute, otherwise as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1049,7 +1034,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: all <<length>>s made absolute, otherwise as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1070,7 +1054,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> exclud
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1091,7 +1074,6 @@ Applies to: See individual properties
 Inherited: no
 Percentages: n/a
 Computed value: See individual properties
-Media: visual
 Animatable: See individual properties
 </pre>
 
@@ -1205,7 +1187,6 @@ Applies to: <a element>mask</a> elements
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -1276,7 +1257,6 @@ Applies to: Absolutely positioned elements. In SVG, it applies to <a href="https
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: as <a href="http://dev.w3.org/csswg/css3-transitions/#animtype-rect">rectangle</a>
 </pre>
 

--- a/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.html
@@ -520,9 +520,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value" id="ref-for-url-value">&lt;url></a> values made absolute
      <tr>
@@ -692,9 +689,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -770,9 +764,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with URIs made absolute
      <tr>
@@ -828,9 +819,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -900,9 +888,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Consists of: two keywords, one per dimension
      <tr>
@@ -950,9 +935,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to size of <a data-link-type="dfn" href="#mask-painting-area" id="ref-for-mask-painting-area②">mask painting area</a> <em>minus</em> size of <a data-link-type="dfn" href="#mask-layer-image" id="ref-for-mask-layer-image⑧">mask layer image</a>; see text <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background-position" id="ref-for-propdef-background-position">background-position</a> <a data-link-type="biblio" href="#biblio-css3bg">[CSS3BG]</a>
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Consisting of: two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>), otherwise as a percentage.
      <tr>
@@ -999,9 +981,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1071,9 +1050,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1140,9 +1116,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with lengths made absolute
      <tr>
@@ -1176,9 +1149,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1283,9 +1253,6 @@ mask-composite: subtract, add;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
@@ -1378,9 +1345,6 @@ mask-composite: subtract, add;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td><span class="css">none</span> or the image with its URI made absolute
      <tr>
@@ -1417,9 +1381,6 @@ mask-composite: subtract, add;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -1465,9 +1426,6 @@ mask-composite: subtract, add;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to size of the <a data-link-type="dfn" href="#mask-border-image" id="ref-for-mask-border-image⑨">mask border image</a>
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1500,9 +1458,6 @@ mask-composite: subtract, add;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to width/height of the <a data-link-type="dfn" href="#mask-border-image-area" id="ref-for-mask-border-image-area③">mask border image area</a>
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>all <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>s made absolute, otherwise as specified
@@ -1538,9 +1493,6 @@ mask-composite: subtract, add;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>all <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value③" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a>s made absolute, otherwise as specified
      <tr>
@@ -1575,9 +1527,6 @@ mask-composite: subtract, add;
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1611,9 +1560,6 @@ mask-composite: subtract, add;
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties
@@ -1764,9 +1710,6 @@ If the attribute is not specified but at least one of the attributes <a data-lin
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1839,9 +1782,6 @@ lt;/p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -3820,7 +3760,6 @@ lt;/p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3832,7 +3771,6 @@ lt;/p>
       <td>Absolutely positioned elements. In SVG, it applies to elements which establish a new viewport, pattern elements and mask elements.
       <td>no
       <td>n/a
-      <td>visual
       <td>as rectangle
       <td>per grammar
       <td>as specified
@@ -3843,7 +3781,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>as specified for &lt;basic-shape> [CSS-SHAPES], otherwise no
       <td>per grammar
       <td>as specified, but with &lt;url> values made absolute
@@ -3854,7 +3791,6 @@ lt;/p>
       <td>Applies to SVG graphics elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3865,7 +3801,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -3876,7 +3811,6 @@ lt;/p>
       <td>See individual properties
       <td>no
       <td>n/a
-      <td>visual
       <td>See individual properties
       <td>per grammar
       <td>See individual properties
@@ -3887,7 +3821,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3898,7 +3831,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>all &lt;length>s made absolute, otherwise as specified
@@ -3909,7 +3841,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3920,7 +3851,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>refer to size of the mask border image
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3931,7 +3861,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>none or the image with its URI made absolute
@@ -3942,7 +3871,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>relative to width/height of the mask border image area
-      <td>visual
       <td>no
       <td>per grammar
       <td>all &lt;length>s made absolute, otherwise as specified
@@ -3953,7 +3881,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3964,7 +3891,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements without the defs element and all graphics elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3975,7 +3901,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified, but with URIs made absolute
@@ -3986,7 +3911,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3997,7 +3921,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -4008,7 +3931,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>refer to size of mask painting area minus size of mask layer image; see text background-position [CSS3BG]
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>per grammar
       <td>Consisting of: two keywords representing the origin and two offsets from that origin, each given as an absolute length (if given a &lt;length>), otherwise as a percentage.
@@ -4019,7 +3941,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>Consists of: two keywords, one per dimension
@@ -4030,7 +3951,6 @@ lt;/p>
       <td>All elements. In SVG, it applies to container elements excluding the defs element, all graphics elements and the use element
       <td>no
       <td>n/a
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc (This means keyword values are not animatable.)
       <td>per grammar
       <td>as specified, but with lengths made absolute
@@ -4041,7 +3961,6 @@ lt;/p>
       <td>mask elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.bs
@@ -168,7 +168,6 @@ Fill Geometry {#fill-geometry}
 		Applies to: SVG shapes
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed Value: as specified
 		Animatable: no
 	</pre>
@@ -242,7 +241,6 @@ Fill Geometry {#fill-geometry}
 		Applies to: all elements
 		Inherited: yes?
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: No
 	</pre>
@@ -263,7 +261,6 @@ Fill Paint {#fill-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: the computed color
 		Animatable: as color
 	</pre>
@@ -308,7 +305,6 @@ Fill Paint {#fill-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified, with URLs made absolute
 		Animatable: as repeatable list of images
 	</pre>
@@ -328,7 +324,6 @@ Fill Paint {#fill-paint}
 		Applies to: all elements
 		Inherited: no
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: no
 	</pre>
@@ -398,7 +393,6 @@ Fill Paint {#fill-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
 		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
 	</pre>
@@ -419,7 +413,6 @@ Fill Paint {#fill-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: as specified, but with lengths made absolute and omitted ''background-size/auto'' keywords filled in
 		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
 	</pre>
@@ -437,7 +430,6 @@ Fill Paint {#fill-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: A list, each item consisting of: two keywords, one per dimension
 		Animatable: no
 	</pre>
@@ -455,7 +447,6 @@ Fill Paint {#fill-paint}
 		Applies to: See individual properties
 		Inherited: See individual properties
 		Percentages: N/A
-		Media: visual
 		Computed value: See individual properties
 		Animatable: See individual properties
 	</pre>
@@ -499,7 +490,6 @@ Fill Transparency {#fill-filter}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: the specified value converted to a <<number>>, clamped to the range [0,1]
 		Animatable: as number
 	</pre>
@@ -579,7 +569,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
-		Media: visual
 		Computed value: the absolute length, or percentage
 		Animatable: as <<length-percentage>>
 	</pre>
@@ -599,7 +588,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: no
 	</pre>
@@ -689,7 +677,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: no
 	</pre>
@@ -750,7 +737,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: no
 	</pre>
@@ -861,7 +847,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: a number
 		Animatable: no
 	</pre>
@@ -912,7 +897,6 @@ Stroke Geometry {#stroke-geometry}
 		Applies to: all elements
 		Inherited: ?
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: No
 	</pre>
@@ -933,7 +917,6 @@ Stroke Dashing {#stroke-dashes}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
-		Media: visual
 		Computed value: as specified
 		Animatable: as repeated list of length, percentage or calc
 	</pre>
@@ -986,7 +969,6 @@ Stroke Dashing {#stroke-dashes}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: relative to the <a>scaled viewport size</a>
-		Media: visual
 		Computed value: as specified
 		Animatable: as repeated list of integers
 	</pre>
@@ -1014,7 +996,6 @@ Stroke Dashing {#stroke-dashes}
 	Applies to: inline boxes and <a>SVG shapes</a>
 	Inherited: yes
 	Percentages: N/A
-	Media: visual
 	Computed Value: specified value, with lengths made absolute
 	Animatable: yes, if <<length>>
 	</pre>
@@ -1082,7 +1063,6 @@ Stroke Dashing {#stroke-dashes}
 	Applies to: inline boxes and <a>SVG shapes</a>
 	Inherited: yes
 	Percentages: N/A
-	Media: visual
 	Computed Value: specified value, with lengths made absolute
 	Animatable: no
 	</pre>
@@ -1190,7 +1170,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: the computed color
 		Animatable: as color
 	</pre>
@@ -1221,7 +1200,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified, with URLs made absolute
 		Animatable: as repeatable list of images
 	</pre>
@@ -1241,7 +1219,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: all elements
 		Inherited: no
 		Percentages: N/A
-		Media: visual
 		Computed value: as specified
 		Animatable: no
 	</pre>
@@ -1311,7 +1288,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
 		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
 	</pre>
@@ -1332,7 +1308,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: as specified, but with lengths made absolute and omitted ''background-size/auto'' keywords filled in
 		Animatable: as <a>repeatable list</a> of <a>simple list</a> of length, percentage, or calc
 	</pre>
@@ -1350,7 +1325,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: n/a
-		Media: visual
 		Computed value: A list, each item consisting of: two keywords, one per dimension
 		Animatable: no
 	</pre>
@@ -1368,7 +1342,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: See individual properties
 		Inherited: See individual properties
 		Percentages: N/A
-		Media: visual
 		Computed value: See individual properties
 		Animatable: See individual properties
 	</pre>
@@ -1396,7 +1369,6 @@ Stroke Paint {#stroke-paint}
 		Applies to: inline boxes and <a>SVG shapes</a>
 		Inherited: yes
 		Percentages: N/A
-		Media: visual
 		Computed value: the specified value converted to a <<number>>, clamped to the range [0,1]
 		Animatable: as number
 	</pre>

--- a/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
@@ -654,9 +654,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -735,9 +732,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -771,9 +765,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the computed color 
@@ -828,9 +819,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with URLs made absolute 
      <tr>
@@ -866,9 +854,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -942,9 +927,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage 
      <tr>
@@ -982,9 +964,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with lengths made absolute and omitted <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css3-background/#valdef-background-size-auto" id="ref-for-valdef-background-size-auto">auto</a> keywords filled in 
      <tr>
@@ -1019,9 +998,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: two keywords, one per dimension 
      <tr>
@@ -1055,9 +1031,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties 
@@ -1107,9 +1080,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the specified value converted to a <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#number-value" id="ref-for-number-value">&lt;number></a>, clamped to the range [0,1] 
@@ -1182,9 +1152,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the <a data-link-type="dfn" href="#scaled-viewport-size" id="ref-for-scaled-viewport-size">scaled viewport size</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the absolute length, or percentage 
      <tr>
@@ -1219,9 +1186,6 @@ behaves as <a class="css" data-link-type="maybe" href="#valdef-paint-none" id="r
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1334,9 +1298,6 @@ Light gray represents dash pattern based on center of inset path.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1403,9 +1364,6 @@ Light gray represents dash pattern based on center of inset path.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1509,9 +1467,6 @@ Light gray represents dash pattern based on center of inset path.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>a number 
      <tr>
@@ -1571,9 +1526,6 @@ Light gray represents dash pattern based on center of inset path.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1607,9 +1559,6 @@ Light gray represents dash pattern based on center of inset path.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the <a data-link-type="dfn" href="#scaled-viewport-size" id="ref-for-scaled-viewport-size①">scaled viewport size</a> 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -1670,9 +1619,6 @@ Light gray represents dash pattern based on center of inset path.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>relative to the <a data-link-type="dfn" href="#scaled-viewport-size" id="ref-for-scaled-viewport-size②">scaled viewport size</a> 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
      <tr>
@@ -1712,9 +1658,6 @@ Light gray represents dash pattern based on center of inset path.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value, with lengths made absolute 
@@ -1787,9 +1730,6 @@ are positioned so that they are centered on their vertex.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value, with lengths made absolute 
@@ -1897,9 +1837,6 @@ a whole number of times.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the computed color 
      <tr>
@@ -1945,9 +1882,6 @@ a whole number of times.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, with URLs made absolute 
      <tr>
@@ -1983,9 +1917,6 @@ a whole number of times.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified 
@@ -2059,9 +1990,6 @@ a whole number of times.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage 
      <tr>
@@ -2099,9 +2027,6 @@ a whole number of times.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with lengths made absolute and omitted <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css3-background/#valdef-background-size-auto" id="ref-for-valdef-background-size-auto①">auto</a> keywords filled in 
      <tr>
@@ -2136,9 +2061,6 @@ a whole number of times.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a 
      <tr>
-      <th>Media:
-      <td>visual 
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>A list, each item consisting of: two keywords, one per dimension 
      <tr>
@@ -2172,9 +2094,6 @@ a whole number of times.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties 
@@ -2212,9 +2131,6 @@ a whole number of times.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A 
-     <tr>
-      <th>Media:
-      <td>visual 
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>the specified value converted to a <a class="production css" data-link-type="type" href="https://www.w3.org/TR/css3-values/#number-value" id="ref-for-number-value③">&lt;number></a>, clamped to the range [0,1] 
@@ -3668,7 +3584,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -3680,7 +3595,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>See individual properties
       <td>See individual properties
       <td>N/A
-      <td>visual
       <td>See individual properties
       <td>per grammar
       <td>See individual properties
@@ -3691,7 +3605,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>all elements
       <td>yes?
       <td>N/A
-      <td>visual
       <td>No
       <td>per grammar
       <td>as specified
@@ -3702,7 +3615,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as color
       <td>per grammar
       <td>the computed color
@@ -3713,7 +3625,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as repeatable list of images
       <td>per grammar
       <td>as specified, with URLs made absolute
@@ -3724,7 +3635,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as number
       <td>per grammar
       <td>the specified value converted to a &lt;number>, clamped to the range [0,1]
@@ -3735,7 +3645,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3746,7 +3655,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>per grammar
       <td>A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
@@ -3757,7 +3665,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>A list, each item consisting of: two keywords, one per dimension
@@ -3768,7 +3675,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3779,7 +3685,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>per grammar
       <td>as specified, but with lengths made absolute and omitted auto keywords filled in
@@ -3790,7 +3695,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>See individual properties
       <td>See individual properties
       <td>N/A
-      <td>visual
       <td>See individual properties
       <td>per grammar
       <td>See individual properties
@@ -3801,7 +3705,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3812,7 +3715,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>all elements
       <td>?
       <td>N/A
-      <td>visual
       <td>No
       <td>per grammar
       <td>as specified
@@ -3823,7 +3725,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as color
       <td>per grammar
       <td>the computed color
@@ -3834,7 +3735,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>yes, if &lt;length>
       <td>per grammar
       <td>specified value, with lengths made absolute
@@ -3845,7 +3745,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value, with lengths made absolute
@@ -3856,7 +3755,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>relative to the scaled viewport size
-      <td>visual
       <td>as repeated list of length, percentage or calc
       <td>per grammar
       <td>as specified
@@ -3867,7 +3765,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>relative to the scaled viewport size
-      <td>visual
       <td>as repeated list of integers
       <td>per grammar
       <td>as specified
@@ -3878,7 +3775,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as repeatable list of images
       <td>per grammar
       <td>as specified, with URLs made absolute
@@ -3889,7 +3785,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3900,7 +3795,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3911,7 +3805,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>a number
@@ -3922,7 +3815,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>N/A
-      <td>visual
       <td>as number
       <td>per grammar
       <td>the specified value converted to a &lt;number>, clamped to the range [0,1]
@@ -3933,7 +3825,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -3944,7 +3835,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>per grammar
       <td>A list, each item consisting of: a pair of offsets (horizontal and vertical) from the top left origin each given as a combination of an absolute length and a percentage
@@ -3955,7 +3845,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>A list, each item consisting of: two keywords, one per dimension
@@ -3966,7 +3855,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>n/a
-      <td>visual
       <td>as repeatable list of simple list of length, percentage, or calc
       <td>per grammar
       <td>as specified, but with lengths made absolute and omitted auto keywords filled in
@@ -3977,7 +3865,6 @@ which takes the value from the element’s corresponding <a class="property" dat
       <td>inline boxes and SVG shapes
       <td>yes
       <td>relative to the scaled viewport size
-      <td>visual
       <td>as &lt;length-percentage>
       <td>per grammar
       <td>the absolute length, or percentage

--- a/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.bs
@@ -42,7 +42,6 @@ Applies to: All elements. In SVG, it applies to <a>container elements</a> withou
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: yes
 </pre>
 

--- a/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.html
@@ -310,9 +310,6 @@ a "delta", describing any differences from Level 1.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -513,7 +510,6 @@ the bounds of the input, it is clipped to the original bounds.</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -525,7 +521,6 @@ the bounds of the input, it is clipped to the original bounds.</p>
       <td>All elements. In SVG, it applies to container elements without the defs element and all graphics elements
       <td>no
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/fxtf-drafts/motion-1/Overview.bs
+++ b/tests/github/w3c/fxtf-drafts/motion-1/Overview.bs
@@ -102,7 +102,6 @@ Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-el
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: as <<angle>>, <<basic-shape>> or <a href="#offsetpath-pathfunc">path()</a>
 </pre>
 
@@ -456,7 +455,6 @@ Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-el
 Inherited: no
 Percentages: refer to the total path length
 Computed value: For <<length>> the absolute value, otherwise a percentage.
-Media: visual
 Animatable: yes
 </pre>
 
@@ -618,7 +616,6 @@ Name: offset-position
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Value: auto | <<position>>
 Initial: auto
-Media: visual
 Inherited: no
 Percentages: Refer to the size of containing block
 Computed value: For <<length>> the absolute value, otherwise a percentage.
@@ -845,7 +842,6 @@ Name: offset-anchor
 Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">transformable elements</a>
 Value: auto | <<position>>
 Initial: auto
-Media: visual
 Inherited: no
 Percentages: Relative to the width and the height of a box
 Computed value: For <<length>> the absolute value, otherwise a percentage.
@@ -1050,7 +1046,6 @@ Applies to: <a href="https://drafts.csswg.org/css-transforms-1/#transformable-el
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: yes
 </pre>
 
@@ -1233,7 +1228,6 @@ The computed value of <<angle>> is added to the computed value of ''auto'' or ''
 	Inherited: no
 	Percentages: see individual properties
 	Computed value: see individual properties
-	Media: visual
 	Animatable: see individual properties
 </pre>
 

--- a/tests/github/w3c/fxtf-drafts/motion-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/motion-1/Overview.html
@@ -439,9 +439,6 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -762,9 +759,6 @@ and its ancestors have no transformation applied.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the total path length
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
@@ -945,9 +939,6 @@ sub-paths.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>Refer to the size of containing block
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value①" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
@@ -1185,9 +1176,6 @@ and a dimensionless point (zero-sized box) as the object area.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>Relative to the width and the height of a box
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>For <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#length-value" id="ref-for-length-value②" title="Expands to: em | vb | ch | cm | vh | vi | in | ex | vw | ic | pt | px | lh | pc | rem | rlh | vmax | advance measure | vmin | mm | cap | q">&lt;length></a> the absolute value, otherwise a percentage.
      <tr>
@@ -1387,9 +1375,6 @@ as the point that is moved along the <a data-link-type="dfn" href="#offset-path"
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -1570,9 +1555,6 @@ The computed value of <a class="production css" data-link-type="type" href="http
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
@@ -2164,7 +2146,6 @@ for their reviews, comments, and corrections.</p>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -2176,7 +2157,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -2187,7 +2167,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>Relative to the width and the height of a box
-      <td>visual
       <td>as &lt;position>
       <td>per grammar
       <td>For &lt;length> the absolute value, otherwise a percentage.
@@ -2198,7 +2177,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>refer to the total path length
-      <td>visual
       <td>yes
       <td>per grammar
       <td>For &lt;length> the absolute value, otherwise a percentage.
@@ -2209,7 +2187,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>n/a
-      <td>visual
       <td>as &lt;angle>, &lt;basic-shape> or path()
       <td>per grammar
       <td>as specified
@@ -2220,7 +2197,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>Refer to the size of containing block
-      <td>visual
       <td>as position
       <td>per grammar
       <td>For &lt;length> the absolute value, otherwise a percentage.
@@ -2231,7 +2207,6 @@ for their reviews, comments, and corrections.</p>
       <td>transformable elements
       <td>no
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/motion-path/index.bs
+++ b/tests/github/w3c/motion-path/index.bs
@@ -56,7 +56,6 @@ Applies to: All elements. In SVG, it applies to <a href="">container elements</a
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: no
 </pre>
 
@@ -114,7 +113,6 @@ Applies to: All elements. In SVG, it applies to <a href="">container elements</a
 Inherited: no
 Percentages: refer to the total path length
 Computed value: as specified
-Media: visual
 Animatable: yes
 </pre>
 
@@ -149,7 +147,6 @@ Applies to: All elements. In SVG, it applies to <a href="">container elements</a
 Inherited: no
 Percentages: n/a
 Computed value: as specified
-Media: visual
 Animatable: yes
 </pre>
 
@@ -208,7 +205,6 @@ Applies to: All elements. In SVG, it applies to <a href="">container elements</a
 Inherited: no
 Percentages: see individual properties
 Computed value: see individual properties
-Media: visual
 Animatable: see individual properties
 </pre>
 

--- a/tests/github/w3c/motion-path/index.html
+++ b/tests/github/w3c/motion-path/index.html
@@ -325,9 +325,6 @@ pre .property::before, pre .property::after {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -390,9 +387,6 @@ pre .property::before, pre .property::after {
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>refer to the total path length
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
@@ -439,9 +433,6 @@ pre .property::before, pre .property::after {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
@@ -510,9 +501,6 @@ pre .property::before, pre .property::after {
      <tr>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
-     <tr>
-      <th>Media:
-      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
@@ -983,7 +971,6 @@ pre .property::before, pre .property::after {
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
@@ -995,7 +982,6 @@ pre .property::before, pre .property::after {
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
@@ -1006,7 +992,6 @@ pre .property::before, pre .property::after {
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>as specified
@@ -1017,7 +1002,6 @@ pre .property::before, pre .property::after {
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no
       <td>refer to the total path length
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified
@@ -1028,7 +1012,6 @@ pre .property::before, pre .property::after {
       <td>All elements. In SVG, it applies to container elements excluding the defs element and all graphics elements
       <td>no
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified

--- a/tests/github/w3c/svgwg/specs/marker/Overview.html
+++ b/tests/github/w3c/svgwg/specs/marker/Overview.html
@@ -740,14 +740,14 @@ processed.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value" id="ref-for-url-value③">&lt;url></a> values (that are part of a <a class="production css" data-link-type="type" href="#DataTypeMarkerRef" id="ref-for-DataTypeMarkerRef②">&lt;marker-ref></a>) made absolute
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>yes
@@ -823,14 +823,14 @@ will be rendered on that final vertex.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value" id="ref-for-url-value④">&lt;url></a> values (that are part of a <a class="production css" data-link-type="type" href="#DataTypeMarkerRef" id="ref-for-DataTypeMarkerRef⑤">&lt;marker-ref></a>) made absolute
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>yes
@@ -907,14 +907,14 @@ are:</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified, but with <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-3/#url-value" id="ref-for-url-value⑤">&lt;url></a> values (that are part of a <a class="production css" data-link-type="type" href="#DataTypeMarkerRef" id="ref-for-DataTypeMarkerRef⑦">&lt;marker-ref></a>) made absolute
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>yes
@@ -1001,14 +1001,14 @@ at its position.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see individual properties
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>see individual properties
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>see individual properties
@@ -1060,14 +1060,14 @@ knockout shapes is welcome.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>see prose
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>as specified
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>yes
@@ -1982,10 +1982,10 @@ marker-mid and marker-end properties</a>
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker" id="ref-for-propdef-marker③">marker</a>
@@ -1994,10 +1994,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>no
       <td>see individual properties
-      <td>visual
       <td>see individual properties
       <td>per grammar
       <td>see individual properties
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-end" id="ref-for-propdef-marker-end①⑤">marker-end</a>
       <td>none | &lt;marker-ref>
@@ -2005,10 +2005,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified, but with &lt;url> values (that are part of a &lt;marker-ref>) made absolute
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-knockout-left" id="ref-for-propdef-marker-knockout-left⑤">marker-knockout-left</a>
       <td>&lt;knockout-offset> | &lt;knockout-shape> [ at &lt;knockout-offset> ]?
@@ -2016,10 +2016,10 @@ marker-mid and marker-end properties</a>
       <td>marker
       <td>no
       <td>see prose
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-knockout-right" id="ref-for-propdef-marker-knockout-right⑤">marker-knockout-right</a>
       <td>&lt;knockout-offset> | &lt;knockout-shape> [ at &lt;knockout-offset> ]?
@@ -2027,10 +2027,10 @@ marker-mid and marker-end properties</a>
       <td>marker
       <td>no
       <td>see prose
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-mid" id="ref-for-propdef-marker-mid①③">marker-mid</a>
       <td>none | &lt;marker-ref>
@@ -2038,10 +2038,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified, but with &lt;url> values (that are part of a &lt;marker-ref>) made absolute
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-pattern" id="ref-for-propdef-marker-pattern①⑥">marker-pattern</a>
       <td>&lt;marker-gap>? &lt;marker-ref-group> [ &lt;marker-gap> &lt;marker-gap> ]* &lt;marker-gap>?
@@ -2049,10 +2049,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified, but with &lt;url> values (that are part of a &lt;marker-ref>) made absolute
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-segment" id="ref-for-propdef-marker-segment①②">marker-segment</a>
       <td>none | &lt;marker-ref>
@@ -2060,10 +2060,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified, but with &lt;url> values (that are part of a &lt;marker-ref>) made absolute
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-marker-start" id="ref-for-propdef-marker-start①⑥">marker-start</a>
       <td>none | &lt;marker-ref>
@@ -2071,10 +2071,10 @@ marker-mid and marker-end properties</a>
       <td>markable elements
       <td>yes
       <td>n/a
-      <td>visual
       <td>yes
       <td>per grammar
       <td>as specified, but with &lt;url> values (that are part of a &lt;marker-ref>) made absolute
+      <td>visual
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>

--- a/tests/github/whatwg/compat/compatibility.html
+++ b/tests/github/whatwg/compat/compatibility.html
@@ -506,9 +506,6 @@ be performant.)</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>"text"
      <tr>
@@ -517,6 +514,9 @@ be performant.)</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>discrete
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>The <code><a class="property" data-link-type="propdesc" href="#propdef--webkit-background-clip" id="ref-for-propdef--webkit-background-clip①">-webkit-background-clip</a></code> property—when its value is <a class="css" data-link-type="maybe" href="#valdef--webkit-background-clip-text" id="ref-for-valdef--webkit-background-clip-text">text</a>—creates a background <a data-link-type="dfn" href="https://drafts.fxtf.org/css-masking-1/#clipping-region" id="ref-for-clipping-region">clipping region</a> from the outer text stroke of the foreground text (including alpha transparency).</p>
    <p>The <code><a class="property" data-link-type="propdesc" href="#propdef--webkit-background-clip" id="ref-for-propdef--webkit-background-clip②">-webkit-background-clip</a></code> property is a simple alias of the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip" id="ref-for-propdef-background-clip">background-clip</a> property for all other <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box" id="ref-for-typedef-box">&lt;box></a> values.</p>
@@ -566,9 +566,6 @@ be performant.)</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>an RGBA color
      <tr>
@@ -577,6 +574,9 @@ be performant.)</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>as <a data-link-type="dfn" href="https://drafts.csswg.org/css-transitions/#animtype-color" id="ref-for-animtype-color">color</a>
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef--webkit-text-fill-color" id="ref-for-propdef--webkit-text-fill-color②">-webkit-text-fill-color</a> property defines the foreground fill color of an element’s text
 content.</p>
@@ -618,9 +618,6 @@ foreground fill color of an element’s text.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>an RGBA color
      <tr>
@@ -629,6 +626,9 @@ foreground fill color of an element’s text.
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>as <a data-link-type="dfn" href="https://drafts.csswg.org/css-transitions/#animtype-color" id="ref-for-animtype-color①">color</a>
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef--webkit-text-stroke-color" id="ref-for-propdef--webkit-text-stroke-color①">-webkit-text-stroke-color</a> property specifies a stroke color for an element’s text.</p>
    <h5 class="heading settled" data-level="3.4.6.3" id="the-webkit-text-stroke-width"><span class="secno">3.4.6.3. </span><span class="content">Text Stroke Thickness: the <code> <a class="property" data-link-type="propdesc" href="#propdef--webkit-text-stroke-width" id="ref-for-propdef--webkit-text-stroke-width">-webkit-text-stroke-width</a></code> property</span><a class="self-link" href="#the-webkit-text-stroke-width"></a></h5>
@@ -653,9 +653,6 @@ foreground fill color of an element’s text.
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>absolute length
      <tr>
@@ -664,6 +661,9 @@ foreground fill color of an element’s text.
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>discrete
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef--webkit-text-stroke-width" id="ref-for-propdef--webkit-text-stroke-width①">-webkit-text-stroke-width</a> property specifies the width of the stroke drawn at the edge of each
 glyph of an element’s text. A zero value results in no stroke being painted. A negative value is
@@ -690,9 +690,6 @@ invalid.</p>
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>See individual properties
      <tr>
@@ -701,6 +698,9 @@ invalid.</p>
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>See individual properties
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef--webkit-text-stroke" id="ref-for-propdef--webkit-text-stroke①">-webkit-text-stroke</a> property is a shorthand property for setting the stroke width and stroke
 color of an element’s text.</p>
@@ -748,9 +748,6 @@ rendered as follows:
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>N/A
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>Same as specified value
      <tr>
@@ -759,6 +756,9 @@ rendered as follows:
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animation type:</a>
       <td>discrete
+     <tr>
+      <th>Media:
+      <td>visual
    </table>
    <p>When specified, the <code>pinch-zoom</code> token enables multi-finger panning and zooming of the page.
 For zooming to occur, all fingers must start on an element that has the pinch-zoom behavior enabled
@@ -1748,10 +1748,10 @@ if ("serviceWorker" in navigator) {
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Anim­ation type
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef--webkit-background-clip" id="ref-for-propdef--webkit-background-clip⑥">-webkit-background-clip</a>
@@ -1760,10 +1760,10 @@ if ("serviceWorker" in navigator) {
       <td>all elements
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>"text"
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef--webkit-text-fill-color" id="ref-for-propdef--webkit-text-fill-color④">-webkit-text-fill-color</a>
       <td>&lt;color>
@@ -1771,10 +1771,10 @@ if ("serviceWorker" in navigator) {
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>as color
       <td>per grammar
       <td>an RGBA color
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef--webkit-text-stroke" id="ref-for-propdef--webkit-text-stroke③">-webkit-text-stroke</a>
       <td>&lt;line-width> || &lt;color>
@@ -1782,10 +1782,10 @@ if ("serviceWorker" in navigator) {
       <td>See individual properties
       <td>yes
       <td>N/A
-      <td>visual
       <td>See individual properties
       <td>per grammar
       <td>See individual properties
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef--webkit-text-stroke-color" id="ref-for-propdef--webkit-text-stroke-color②">-webkit-text-stroke-color</a>
       <td>&lt;color>
@@ -1793,10 +1793,10 @@ if ("serviceWorker" in navigator) {
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>as color
       <td>per grammar
       <td>an RGBA color
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef--webkit-text-stroke-width" id="ref-for-propdef--webkit-text-stroke-width②">-webkit-text-stroke-width</a>
       <td>&lt;line-width>
@@ -1804,10 +1804,10 @@ if ("serviceWorker" in navigator) {
       <td>all elements
       <td>yes
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>absolute length
+      <td>visual
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-touch-action" id="ref-for-propdef-touch-action">touch-action</a>
       <td>auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation
@@ -1815,10 +1815,10 @@ if ("serviceWorker" in navigator) {
       <td>all elements except: non-replaced inline elements, table rows, row groups, table columns, and column groups.
       <td>no
       <td>N/A
-      <td>visual
       <td>discrete
       <td>per grammar
       <td>Same as specified value
+      <td>visual
    </table>
   </div>
   <h3 class="no-num no-ref heading settled" id="media-descriptor-table"><span class="content"><a class="css" data-link-type="at-rule" href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media" id="ref-for-at-ruledef-media②">@media</a> Descriptors</span><a class="self-link" href="#media-descriptor-table"></a></h3>

--- a/tests/pre002.html
+++ b/tests/pre002.html
@@ -319,14 +319,14 @@ baz
       <th><a href="https://drafts.csswg.org/css-values/#percentages">Percentages:</a>
       <td>n/a
      <tr>
-      <th>Media:
-      <td>visual
-     <tr>
       <th><a href="https://drafts.csswg.org/css-cascade/#computed">Computed value:</a>
       <td>specified value
      <tr>
       <th>Canonical order:
       <td>per grammar
+     <tr>
+      <th>Media:
+      <td>visual
      <tr>
       <th><a href="https://drafts.csswg.org/css-transitions/#animatable-properties">Animatable:</a>
       <td>no
@@ -383,10 +383,10 @@ baz
       <th scope="col">Applies to
       <th scope="col">Inh.
       <th scope="col">%ages
-      <th scope="col">Media
       <th scope="col">Ani­mat­able
       <th scope="col">Canonical order
       <th scope="col">Com­puted value
+      <th scope="col">Media
     <tbody>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-justify-self" id="ref-for-propdef-justify-self">justify-self</a>
@@ -395,10 +395,10 @@ baz
       <td>block-level boxes, absolutely-positioned boxes, and grid items
       <td>no
       <td>n/a
-      <td>visual
       <td>no
       <td>per grammar
       <td>specified value
+      <td>visual
    </table>
   </div>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span></h2>


### PR DESCRIPTION
This is needed to update specs in accordance to https://logs.csswg.org/irc.w3.org/css/2018-07-03/#e1045220