### PR TITLE
Use the `[SPECTITLE]` macro in WG14 and WG21 boilerplate

### DIFF
--- a/bikeshed/boilerplate/wg14/header.include
+++ b/bikeshed/boilerplate/wg14/header.include
@@ -25,7 +25,7 @@
 <body class="h-entry">
 <div class="head">
   <p data-fill-with="logo"></p>
-  <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[TITLE]</h1>
+  <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[SPECTITLE]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>

--- a/bikeshed/boilerplate/wg21/header.include
+++ b/bikeshed/boilerplate/wg21/header.include
@@ -25,7 +25,7 @@
 <body class="h-entry">
 <div class="head">
   <p data-fill-with="logo"></p>
-  <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[TITLE]</h1>
+  <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[SPECTITLE]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>


### PR DESCRIPTION
In the `<h1>` in the WG14 and WG21 boilerplate, use the `[SPECTITLE]` macro, so that users can specify different text for `<title>` and the `<h1>`

This is useful when you want to put `<code>` in your document's title, but you don't want the `<code>` element appearing in your `<title>`.

See #1306 for background. This PR assumes that the inconsistency in naming between the H1 metadata field and the `[SPECDATA]` text macro is intentional, and the Bikeshed documentation is out of date.

**Either this PR or #1307 should be taken, but not both; they are mutually exclusive.**