### PR TITLE
Rename the `[SPECTITLE]` text macro to `[H1]` and use it in the WG14 and WG21 boilerplate.

### DIFF
--- a/bikeshed/boilerplate/wg14/header.include
+++ b/bikeshed/boilerplate/wg14/header.include
@@ -25,7 +25,7 @@
 <body class="h-entry">
 <div class="head">
   <p data-fill-with="logo"></p>
-  <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[TITLE]</h1>
+  <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[H1]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>

--- a/bikeshed/boilerplate/wg21/header.include
+++ b/bikeshed/boilerplate/wg21/header.include
@@ -25,7 +25,7 @@
 <body class="h-entry">
 <div class="head">
   <p data-fill-with="logo"></p>
-  <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[TITLE]</h1>
+  <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[H1]</h1>
   <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -221,9 +221,9 @@ class MetadataManager:
         # Fills up a set of text macros based on metadata.
         if self.title:
             macros["title"] = self.title
-            macros["spectitle"] = self.title
+            macros["h1"] = self.title
         if self.h1:
-            macros["spectitle"] = self.h1
+            macros["h1"] = self.h1
         macros["shortname"] = self.displayShortname
         if self.statusText:
             macros["statustext"] = "\n".join(markdown.parse(self.statusText, self.indent))


### PR DESCRIPTION
* Rename the `[SPECTITLE]` macro to `[H1]`, to match the metadata field and the docs.
* In the `<h1>` in the WG14 and WG21 boilerplate, use the `[H1]` macro.

See #1306 for background. This PR assumes that the inconsistency in naming between the H1 metadata field and the `[SPECDATA]` text macro is a mistake, and renames the `[SPECDATA]` to `[H1]`, which is what the Bikeshed documentation says it should be called.

**Either this Pull Request or #1305 should be taken, but not both; they are mutually exclusive.**