### PR TITLE
Add support for table numbers

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -533,7 +533,7 @@ dfn > a.self-link::before      { content: "#"; }'''
 
 styleCounters = '''
 body {
-    counter-reset: example figure issue;
+    counter-reset: example figure issue table;
 }
 .issue {
     counter-increment: issue;
@@ -558,4 +558,17 @@ figcaption {
 }
 figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
-}'''
+}
+
+figure.table {
+    counter-increment: table;
+}
+figure.table figcaption {
+    counter-increment: none;
+}
+figure.table figcaption:not(.no-marker)::before {
+    content: "Table " counter(table) " ";
+}
+'''
+
+# For some reason, doing the counter-increment on `figure.table figcaption` like with figures does not seem to work for tables...


### PR DESCRIPTION
This is ported from w3c/webauthn#994, and adds support for annotating tables with numbers by placing them inside a `<figure class="table">` element.

This should probably include some update to documentation too; I'll happily write some, but there doesn't seem to be anything existing about figure numbers, so I'm not sure where it should go. Perhaps in section 5. Markup Shortcuts?

I also tried regenerating the test files, but many of them failed even without these changes, so I decided to leave that be for now instead of including an only half-working update.

Also: for some reason, doing the counter-increment on `figure.table figcaption` like with figures does not seem to work for tables...