### PR TITLE
Show the inline markdown sequences.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1255,8 +1255,11 @@ In particular, it recognizes all of the Markdown "block elements" except for ind
 If the `Markup Shorthands: markdown yes` metadata is specified,
 it also recognizes several of the Markdown "inline elements":
 
-* *emphasis* and **strong** elements
-* inline `code` elements
+* *emphasis* (`*emphasis*`) and **strong** (`**strong**`) elements
+* inline `code` (`` `code` ``) elements, which can include literal backticks by
+    delimiting the content with multiple-backtick sequences: ``` `` ` `` ```
+    produces `` ` ``. (Note that spaces at the beginning and end of the code
+    element are stripped.)
 * inline links, with optional title
 
 It does not recognize "autolinks" (surrounded by &lt;&gt; characters),

--- a/docs/index.html
+++ b/docs/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version fcc415631048dc853fb05bf76f2b421987cae69b" name="generator">
+  <meta content="Bikeshed version f168e9e768df676e3c9c49525fc1d754533d7501" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="fcc415631048dc853fb05bf76f2b421987cae69b" name="document-revision">
+  <meta content="f168e9e768df676e3c9c49525fc1d754533d7501" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1525,7 +1525,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-07-06">6 July 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-07-16">16 July 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1540,7 +1540,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 6 July 2018,
+In addition, as of 16 July 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2839,9 +2839,11 @@ making it easier to read and write.</p>
 it also recognizes several of the Markdown "inline elements":</p>
    <ul>
     <li data-md="">
-     <p><em>emphasis</em> and <strong>strong</strong> elements</p>
+     <p><em>emphasis</em> (<code>*emphasis*</code>) and <strong>strong</strong> (<code>**strong**</code>) elements</p>
     <li data-md="">
-     <p>inline <code>code</code> elements</p>
+     <p>inline <code>code</code> (<code>`code`</code>) elements, which can include literal backticks by
+delimiting the content with multiple-backtick sequences: <code>`` ` ``</code> produces <code>`</code>. (Note that spaces at the beginning and end of the code
+element are stripped.)</p>
     <li data-md="">
      <p>inline links, with optional title</p>
    </ul>


### PR DESCRIPTION
Including backtick escapes from #788.