### PR TITLE
CSSWG boilerplate: remove speech, leave XML

### DIFF
--- a/bikeshed/boilerplate/csswg/abstract.include
+++ b/bikeshed/boilerplate/csswg/abstract.include
@@ -3,4 +3,4 @@
 [ABSTRACT]
 <a href='http://www.w3.org/TR/CSS/'>CSS</a> is a language for describing the rendering of structured documents
 (such as HTML and XML)
-on screen, on paper, in speech, etc.
+on screen, on paper, etc.


### PR DESCRIPTION
Consensus from https://github.com/w3c/csswg-drafts/issues/3133

- remove mention of speech (because css speech is retired note)
- keep XML (because intranet, offline etc use CSS and we claim to care about these use cases)