### PR TITLE
Logo the right way round (for LTR languages)

### DIFF
--- a/docs/icon.svg
+++ b/docs/icon.svg
@@ -1,11 +1,11 @@
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <g stroke='blue' stroke-width='6' fill='none'>
-    <path fill='blue' stroke='none' d="M 5 95 L 5 35 L 50 10 L 50 95"/>
-    <path fill='blue' stroke='none' d="M 1 40 v -6 l 60 -32 v 6 z" />
-    <circle cx='75' cy='79' r='15' />
-    <circle fill='blue' stroke='none' cx='75' cy='79' r='4' />
-    <path d="M 75 79 L 65 49 L 55 49" />
-    <path d="M 67 55 L 48 69" />
+    <path fill='blue' stroke='none' d="M 95 95 L 95 35 L 50 10 L 50 95"/>
+    <path fill='blue' stroke='none' d="M 99 40 v -6 l -60 -32 v 6 z" />
+    <circle cx='25' cy='79' r='15' />
+    <circle fill='blue' stroke='none' cx='25' cy='79' r='4' />
+    <path d="M 25 79 L 35 49 L 45 49" />
+    <path d="M 33 55 L 52 69" />
   </g>
   <style>
     @keyframes fill {


### PR DESCRIPTION
While looking at a CSS spec I saw an unfamiliar logo in the corner. Stopping to look at it, it appeared to be a shed with a bike coming out of it. “Shed. Bike. Shed-bike? Oh, I think I've heard of a spec-generation tool called Bikeshed.”

Given you are called Bikeshed and not Shedbike, flipping your logo horizontally would make it more intuitive for people encountering it for the first time.

Well, at least for people used to reading left to right. But given the word ‘bikeshed’ is English and needs to be read left to right, you're already requiring that.