### PR TITLE
Add "Direction" to the list of valid "Audience" values.

### DIFF
--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -673,7 +673,7 @@ def parseAudience(key, val, lineNum):
         return ["all"]
     elif len(values) >= 1:
         ret = []
-        validAudiences = set(["CWG", "LWG", "EWG", "LEWG"])
+        validAudiences = set(["CWG", "LWG", "EWG", "LEWG", "DIRECTION"])
         for v in values:
             if v in validAudiences:
                 ret.append(v)


### PR DESCRIPTION
This change allows the WG21 direction group to be named in the "Audience" field.

```
$ cat t.bs
<pre class='metadata'>
Audience: Direction
</pre>

$ bikeshed
LINE 2: Unknown 'Audience' value 'DIRECTION'.
 ✘  Did not generate, due to fatal errors
```