### PR TITLE
Use correct URL for SVGWG homepage

### DIFF
--- a/bikeshed/boilerplate/fxtf/status-WD.include
+++ b/bikeshed/boilerplate/fxtf/status-WD.include
@@ -21,7 +21,7 @@
 
 <p>
 	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	and the <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Main_Page">SVG Working Group</a>.
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under


### PR DESCRIPTION
so that we can actually publish things with this template