### PR TITLE
Update FXTF boilerplate

### DIFF
--- a/bikeshed/boilerplate/fxtf/bs-extensions.include
+++ b/bikeshed/boilerplate/fxtf/bs-extensions.include
@@ -1,0 +1,9 @@
+def BSPrepTR(doc):
+	for el in findAll("link", doc):
+		# default.css gets bundled locally, rather than included in the parent folder
+		if el.get("href") == "../default.css":
+			el.set("href", "default.css")
+
+def BSPublishAdditionalFiles(defaultFiles):
+	defaultFiles.append(["../default.css", "default.css"])
+	return defaultFiles

--- a/bikeshed/boilerplate/fxtf/status-WD.include
+++ b/bikeshed/boilerplate/fxtf/status-WD.include
@@ -21,7 +21,7 @@
 
 <p>
 	This document was published by the <a href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>
-	and the <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Main_Page">SVG Working Group</a>.
+	and the <a href="https://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a>.
 
 <p>
 	This document was produced by groups operating under


### PR DESCRIPTION
This is what I needed to do to publish Web Animations (an FXTF spec) from csswg-drafts today.