### PR TITLE
WG21: add convenience mapping

### DIFF
--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -673,10 +673,15 @@ def parseAudience(key, val, lineNum):
         return ["all"]
     elif len(values) >= 1:
         ret = []
-        validAudiences = set(["CWG", "LWG", "EWG", "LEWG", "DIRECTION"])
+        validAudiences = set(["CWG", "LWG", "EWG", "EWGI", "LEWG", "LEWGI", "DIRECTION"])
         for v in values:
             if v in validAudiences:
-                ret.append(v)
+                if v == "EWGI":
+                    ret.append("SG17")
+                elif v == "LEWGI":
+                    ret.append("SG18")
+                else:
+                    ret.append(v)
             elif re.match(r"WG\d+|SG\d+", v):
                 ret.append(v)
             else:

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -673,15 +673,13 @@ def parseAudience(key, val, lineNum):
         return ["all"]
     elif len(values) >= 1:
         ret = []
-        validAudiences = set(["CWG", "LWG", "EWG", "EWGI", "LEWG", "LEWGI", "DIRECTION"])
+        namedAudiences = set(["CWG", "LWG", "EWG", "LEWG", "DIRECTION"])
+        pseudonymAudiences = {"EWGI":"SG17", "LEWG":"SG18"}
         for v in values:
-            if v in validAudiences:
-                if v == "EWGI":
-                    ret.append("SG17")
-                elif v == "LEWGI":
-                    ret.append("SG18")
-                else:
-                    ret.append(v)
+            if v in namedAudiences:
+                ret.append(v)
+            elif v in pseudonymAudiences:
+                ret.append(pseudonymAudiences[v])
             elif re.match(r"WG\d+|SG\d+", v):
                 ret.append(v)
             else:


### PR DESCRIPTION
Maybe we should map all of the convenience names to their actual SG name? These two seem pretty neat to have.

Or maybe we should allow either convenience name or SG name, and print out both? i.e. EWGI gets you "SG17: EWGI"?