### PR TITLE
Add reference to new WHATWG shared-with-dev stylesheet

### DIFF
--- a/bikeshed/boilerplate/whatwg/header.include
+++ b/bikeshed/boilerplate/whatwg/header.include
@@ -6,6 +6,7 @@
 <title>[TITLE]</title>
 <link href="https://resources.whatwg.org/spec.css" rel="stylesheet">
 <link href="https://resources.whatwg.org/standard.css" rel="stylesheet">
+<link href="https://resources.whatwg.org/standard-shared-with-dev.css" rel="stylesheet">
 <link href="[LOGO]" rel="icon">
 <script src=https://resources.whatwg.org/file-issue.js async></script>
 <script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js async></script>


### PR DESCRIPTION
Follows https://github.com/whatwg/whatwg.org/pull/234.

Should be merged after that is approved.