### PR TITLE
Add a boilerplate for W3C HTTPS in Local Network Community Group

### DIFF
--- a/bikeshed/boilerplate/httpslocal/copyright.include
+++ b/bikeshed/boilerplate/httpslocal/copyright.include
@@ -1,0 +1,2 @@
+<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification, published by the <a href="https://www.w3.org/community/httpslocal/">HTTPS in Local Network Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.

--- a/bikeshed/boilerplate/httpslocal/header.include
+++ b/bikeshed/boilerplate/httpslocal/header.include
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>[TITLE]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style data-fill-with="stylesheet">
+  </style>
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div class="p-summary" data-fill-with="abstract"></div>
+<div data-fill-with="at-risk"></div>
+
+<h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>

--- a/bikeshed/boilerplate/httpslocal/status-CG-DRAFT.include
+++ b/bikeshed/boilerplate/httpslocal/status-CG-DRAFT.include
@@ -1,0 +1,14 @@
+<p>
+  This specification was published by the <a href="https://www.w3.org/community/httpslocal/">HTTPS in Local Network Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the
+  <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
+  there is a limited opt-out and other conditions apply.
+
+  Learn more about
+  <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
+</p>
+
+<p>
+	[STATUSTEXT]

--- a/bikeshed/boilerplate/httpslocal/status-CG-FINAL.include
+++ b/bikeshed/boilerplate/httpslocal/status-CG-FINAL.include
@@ -1,0 +1,14 @@
+<p>
+  This specification was published by the <a href="https://www.w3.org/community/httpslocal/">HTTPS in Local Network Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the
+  <a href="http://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>
+  other conditions apply.
+
+  Learn more about
+  <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
+</p>
+
+<p>
+	[STATUSTEXT]


### PR DESCRIPTION
This PR requests adding a boilerplate for [HTTPS in Local Network Community Group](https://www.w3.org/community/httpslocal).

cc @dajiaji @igarashi50