### PR TITLE
Create status-NOTE.include

### DIFF
--- a/bikeshed/boilerplate/csswg/status-NOTE.include
+++ b/bikeshed/boilerplate/csswg/status-NOTE.include
@@ -1,0 +1,27 @@
+  <p><em>This section describes the status of this document at the time of
+   its publication. Other documents may supersede this document. A list of
+   current W3C publications and the latest revision of this technical report
+   can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
+   index at https://www.w3.org/TR/.</a></em>
+
+  <p>Publication as a Working Group Note does not imply endorsement by the 
+    W3C Membership. This is a draft document and may be updated, replaced or 
+    obsoleted by other documents at any time. It is inappropriate to cite this 
+    document as other than work in progress.
+
+  <p><a href="https://github.com/w3c/csswg-drafts/issues">GitHub Issues</a> are preferred for discussion of this specification.
+    When filing an issue, please put the text “[SHORTNAME]” in the title,
+    preferably like this:
+    “[<!---->[SHORTNAME]] <i lt>…summary of comment…</i>”.
+    All issues and comments are <a href="https://lists.w3.org/Archives/Public/public-css-archive/">archived</a>,
+    and there is also a <a href="https://lists.w3.org/Archives/Public/www-style/">historical archive</a>.
+
+  <p data-deliverer="32061">This document was produced by the <a
+   href="https://www.w3.org/Style/CSS/members">CSS Working Group</a>.
+
+  <p>This document was produced by a group operating under the <a
+   href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2018/Process-20180201/">1 February 2018 W3C Process Document</a>.</p>
+
+  <p>[STATUSTEXT]


### PR DESCRIPTION
Status was missing for notes, so was not being generated. Notice changes in 2018, like `data-deliverer`.