### PR TITLE
Add "proposed" attribute for IDL

### DIFF
--- a/bikeshed/idl.py
+++ b/bikeshed/idl.py
@@ -54,6 +54,8 @@ class IDLMarker(object):
     def markupConstruct(self, text, construct):
         # Fires for every 'construct' in the WebIDL.
         # Some things are "productions", not "constructs".
+        if 'proposed' in construct.extendedAttributes:
+          return ("<span class='proposed'>", "</span>")
         return (None, None)
 
     def markupType(self, text, construct):

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -665,6 +665,21 @@ def classifyDfns(doc, dfns):
                     el.set('data-noexport', 'by-default')
                 else:
                     el.set('data-export', 'by-default')
+        # Mark 'proposed' if necessary
+        if dfnType in ('attribute', 'method', 'dict-member'):
+          for construct in [c for c in doc.widl.constructs if
+                            c.name == dfnFor and hasattr(c, 'members')]:
+            if any([m for m in construct.members if
+                    m.name == primaryDfnText and 'proposed' in m.extendedAttributes]):
+              dt = el
+              while dt is not None and dt.tag != 'dt':
+                dt = dt.getparent()
+              if dt is not None:
+                addClass(dt, 'proposed')
+                dd = dt.getnext()
+                if dd is not None and dd.tag == 'dd':
+                  addClass(dd, 'proposed')
+              break
         # If it's an code-ish type such as IDL,
         # and doesn't already have a sole <code> child,
         # wrap the contents in a <code>.


### PR DESCRIPTION
When an IDL declaration has the 'proposed' extended attribute (i.e.,
it begins with the literal text '[proposed]'), then the generated
html for both the declaration and the definition will be enclosed in
an element with class='proposed'.