### PR TITLE
Allow manually specifying the snapshot URL

### DIFF
--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -731,7 +731,7 @@ def addSpecMetadataSection(doc):
         md["This version"].append(E.a({"href":mac['version'], "class":"u-url"}, mac['version']))
     if doc.md.TR:
         md["Latest published version"].append(E.a({"href": doc.md.TR}, doc.md.TR))
-    if doc.md.ED and doc.md.status in config.snapshotStatuses:
+    if doc.md.ED and doc.md.status in config.datedStatuses:
         md["Editor's Draft"].append(E.a({"href": doc.md.ED}, doc.md.ED))
     if doc.md.previousVersions:
         md["Previous Versions"] = [E.a({"href":ver, "rel":"prev"}, ver) for ver in doc.md.previousVersions]

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -96,6 +96,7 @@ class MetadataManager:
         self.repository = config.Nil()
         self.requiredIDs = []
         self.slimBuildArtifact = False
+        self.snapshotURL = None
         self.statusText = []
         self.testSuite = None
         self.title = None
@@ -269,7 +270,9 @@ class MetadataManager:
         if self.deadline:
             macros["deadline"] = unicode(self.deadline.strftime("{0} %B %Y".format(self.deadline.day)), encoding="utf-8")
             macros["isodeadline"] = unicode(self.deadline.strftime("%Y-%m-%d"), encoding="utf-8")
-        if self.status in config.snapshotStatuses:
+        if self.snapshotURL and self.status in config.datedStatuses:
+            macros["version"] = self.snapshotURL
+        elif self.status in config.snapshotStatuses:
             macros["version"] = "https://www.w3.org/TR/{year}/{status}-{vshortname}-{cdate}/".format(**macros)
         elif self.ED:
             macros["version"] = self.ED
@@ -987,6 +990,7 @@ knownKeys = {
     "Required Ids": Metadata("Required Ids", "requiredIDs", joinList, parseCommaSeparated),
     "Revision": Metadata("Revision", "level", joinValue, parseLevel),
     "Shortname": Metadata("Shortname", "displayShortname", joinValue, parseLiteral),
+    "Snapshot": Metadata("Snapshot", "snapshotURL", joinValue, parseLiteral),
     "Slim Build Artifact": Metadata("Slim Build Artifact", "slimBuildArtifact", joinValue, parseBoolean),
     "Status Text": Metadata("Status Text", "statusText", joinList, parseLiteralList),
     "Status": Metadata("Status", "rawStatus", joinValue, parseLiteral),

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -911,6 +911,7 @@ There are several additional optional keys:
 
 		If set to "Custom", the metadata keys <a>Custom Warning Title</a> and <a>Custom Warning Text</a> control what the warning contains.
 	* <dfn>Previous Version</dfn> must contain a link that points to a previous (snapshot) version on /TR.  You can specify this key more than once for multiple entries.
+	* <dfn>Snapshot</dfn> must contain a link that points to the dated URL for this document. Only has an effect when used with one of the [=Statuses=] which generate both an <em>Editor's Draft</em> URL and a <em>This Version</em> URL, such as WD, REC, or CR. When ommitted, dated W3C Statuses default to the standard TR dated URL.
 	* <dfn>At Risk</dfn> must contain an at-risk feature.  You can specify this key more than once for multiple entries.
 	* <dfn>Group</dfn> must contain the name of the group the spec is being generated for.  This is used by the boilerplate generation to select the correct file.  If omitted, it defaults to a generic set of boilerplate.
 	* <dfn>Status Text</dfn> allows adding an additional customized sentence that can be used in the document status section.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
+  <meta content="Bikeshed version c0666156be5f5d51afe5d02b7fb235b0eefaab0b" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="018be3f805d3272ce699a232398d6e3902d1ea8d" name="document-revision">
+  <meta content="c0666156be5f5d51afe5d02b7fb235b0eefaab0b" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1530,7 +1530,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-11-05">5 November 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2018-12-13">13 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1545,7 +1545,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 5 November 2018,
+In addition, as of 13 December 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2483,6 +2483,8 @@ and is by default used by the <code>logo</code> boilerplate section (<a href="#b
      <p>If set to "Custom", the metadata keys <a data-link-type="dfn" href="#metadata-custom-warning-title" id="ref-for-metadata-custom-warning-title">Custom Warning Title</a> and <a data-link-type="dfn" href="#metadata-custom-warning-text" id="ref-for-metadata-custom-warning-text">Custom Warning Text</a> control what the warning contains.</p>
     <li data-md>
      <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-previous-version">Previous Version<a class="self-link" href="#metadata-previous-version"></a></dfn> must contain a link that points to a previous (snapshot) version on /TR.  You can specify this key more than once for multiple entries.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-snapshot">Snapshot<a class="self-link" href="#metadata-snapshot"></a></dfn> must contain a link that points to the dated URL for this document. Only has an effect when used with one of the <a data-link-type="dfn">Statuses</a> which generate both an <em>Editor’s Draft</em> URL and a <em>This Version</em> URL, such as WD, REC, or CR. When ommitted, dated W3C Statuses default to the standard TR dated URL.</p>
     <li data-md>
      <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-at-risk">At Risk<a class="self-link" href="#metadata-at-risk"></a></dfn> must contain an at-risk feature.  You can specify this key more than once for multiple entries.</p>
     <li data-md>
@@ -5143,6 +5145,7 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#metadata-shortname">Shortname</a><span>, in §4</span>
    <li><a href="#railroad-skip">Skip</a><span>, in §12.1</span>
    <li><a href="#metadata-slim-build-artifact">Slim Build Artifact</a><span>, in §4</span>
+   <li><a href="#metadata-snapshot">Snapshot</a><span>, in §4</span>
    <li><a href="#railroad-stack">Stack</a><span>, in §12.1</span>
    <li><a href="#railroad-star">Star</a><span>, in §12.1</span>
    <li><a href="#metadata-status">Status</a><span>, in §4</span>
@@ -5385,7 +5388,7 @@ Autolink Shortcuts That Work Anywhere: the l element</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 7 August 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
+   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 4 October 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">


### PR DESCRIPTION
This comes handy if you want to use bikeshed with one of the snapshotStatues to produce something that looks exactly like one of the things that goes on TR, without actually going on TR. For instance, the Process (or the patent policy, or any number of official dated documents that do or should have an ED as well).

In addition, creating a new status (accessible to anyone?) within datedStatuses group would also be useful, so that I didn't have to use header.include to suppress the insertion of `<h2>[LONGSTATUS]</h2>` would also be nice, but:
* That's an addition, not an alternative to this patch, so you should still take this in
* for now, I can indeed use header.include and to abuse another Status (like REC), so that's not a pressing need
* Creating a new status means I need to pick a name for it, and naming is hard :)