### PR TITLE
Add Khronos Group and boilerplate for Khronos WebGL

### DIFF
--- a/bikeshed/boilerplate/webgl/copyright.include
+++ b/bikeshed/boilerplate/webgl/copyright.include
@@ -1,0 +1,1 @@
+<a href="https://www.khronos.org/registry/speccopyright.html">Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification, published by the <a href="https://www.khronos.org/webgl/wiki/Main_Page">Khronos WebGL Working Group</a> under the <a href="https://www.khronos.org/registry/speccopyright.html">Khronos Group License Agreement</a>.

--- a/bikeshed/boilerplate/webgl/defaults.include
+++ b/bikeshed/boilerplate/webgl/defaults.include
@@ -1,0 +1,3 @@
+{
+    "Boilerplate": "repository-issue-tracking off"
+}

--- a/bikeshed/boilerplate/webgl/header.include
+++ b/bikeshed/boilerplate/webgl/header.include
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>[TITLE]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style data-fill-with="stylesheet">
+  </style>
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="subtitle" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div class="p-summary" data-fill-with="abstract"></div>
+<div data-fill-with="at-risk"></div>
+
+<h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>

--- a/bikeshed/boilerplate/webgl/status.include
+++ b/bikeshed/boilerplate/webgl/status.include
@@ -1,0 +1,3 @@
+<p>This document is an editor's draft. Do not cite this document as other than work in progress.</p>
+
+<p>[STATUSTEXT]</p>

--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -76,7 +76,8 @@ shortToLongStatus = {
     "fido/RD": "Review Draft",
     "fido/ID": "Implementation Draft",
     "fido/PS": "Proposed Standard",
-    "fido/FD": "Final Document"
+    "fido/FD": "Final Document",
+    "khronos/ED": "Editor's Draft"
 }
 snapshotStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO"]
 datedStatuses = ["w3c/WD", "w3c/FPWD", "w3c/LCWD", "w3c/CR", "w3c/PR", "w3c/REC", "w3c/PER", "w3c/WG-NOTE", "w3c/IG-NOTE", "w3c/NOTE", "w3c/MO", "whatwg/RD"]
@@ -90,7 +91,8 @@ megaGroups = {
     "tc39": frozenset(["tc39"]),
     "iso": frozenset(["wg14", "wg21"]),
     "fido": frozenset(["fido"]),
-    "priv-sec": frozenset(["audiowg", "csswg", "dap", "fxtf", "fxtf-csswg", "geolocation", "houdini", "html", "mediacapture", "ricg", "svg", "texttracks", "uievents", "web-bluetooth-cg", "webappsec", "webplatform", "webspecs", "whatwg"])
+    "priv-sec": frozenset(["audiowg", "csswg", "dap", "fxtf", "fxtf-csswg", "geolocation", "houdini", "html", "mediacapture", "ricg", "svg", "texttracks", "uievents", "web-bluetooth-cg", "webappsec", "webplatform", "webspecs", "whatwg"]),
+    "khronos": frozenset(["webgl"])
 }
 
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3136,6 +3136,7 @@ Several groups are already accommodated with appropriate inclusion files:
 * "wg14", for the C Standards Committee
 * "wg21", for the C++ Standards Committee
 * "tc39", for ECMAScript TC-39
+* "khronos", for the Khronos Group
 
 You can put whatever value you want into the "Group" value, though.
 Unrecognized values will just use the default boilerplate files.


### PR DESCRIPTION
PTAL. Thank you very much. 

Khronos WebGL WG tend to use bikeshed to write its specification for WebGL 2 compute. But Khronos Group (https://www.khronos.org/) is not included in bikeshed. So I simply added Khronos Group and a boilerplate for Khronos WebGL Working Group, in order to support its own copyright and other things. Then my change to add WebGL 2 compute specification (https://github.com/KhronosGroup/WebGL/pull/2769) for Khronos WebGL Working Group can work. 

I am a new guy for bikeshed project. If this is not the correct way or if there are any other concerns, please let me know. Thank you. 

FYI, @kenrussell, @gyagp. 
