### PR TITLE
Fix pip requirements syntax to include a comma between constraints.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pygments>=2.3.0<2.4
-lxml>=4.2.5<4.3
-html5lib>=1.0.1<1.1
-cssselect>=1.0.3<1.1
+pygments>=2.3.0,<2.4
+lxml>=4.2.5,<4.3
+html5lib>=1.0.1,<1.1
+cssselect>=1.0.3,<1.1

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pygments>=2.3.0<2.4',
-        'lxml>=4.2.5<4.3',
-        'html5lib>=1.0.1<1.1',
-        'cssselect>=1.0.3<1.1',
+        'pygments>=2.3.0,<2.4',
+        'lxml>=4.2.5,<4.3',
+        'html5lib>=1.0.1,<1.1',
+        'cssselect>=1.0.3,<1.1',
     ],
     entry_points={'console_scripts': ['bikeshed = bikeshed:main']},
 )


### PR DESCRIPTION
This seems to fix the version of lxml being installed.

#1437 