### PR TITLE
Wg21 wording colors

### DIFF
--- a/bikeshed/boilerplate/wg21/header.include
+++ b/bikeshed/boilerplate/wg21/header.include
@@ -21,59 +21,62 @@
       text-align: center;
     }
 
-    blockquote code.highlight:not(.idl) { background: initial }
-    blockquote c-[a] { color: inherit } /* Keyword.Declaration */
-    blockquote c-[b] { color: inherit } /* Keyword.Type */
-    blockquote c-[c] { color: inherit } /* Comment */
-    blockquote c-[d] { color: inherit } /* Comment.Multiline */
-    blockquote c-[e] { color: inherit } /* Name.Attribute */
-    blockquote c-[f] { color: inherit } /* Name.Tag */
-    blockquote c-[g] { color: inherit } /* Name.Variable */
-    blockquote c-[k] { color: inherit } /* Keyword */
-    blockquote c-[l] { color: inherit } /* Literal */
-    blockquote c-[m] { color: inherit } /* Literal.Number */
-    blockquote c-[n] { color: inherit } /* Name */
-    blockquote c-[o] { color: inherit } /* Operator */
-    blockquote c-[p] { color: inherit } /* Punctuation */
-    blockquote c-[s] { color: inherit } /* Literal.String */
-    blockquote c-[t] { color: inherit } /* Literal.String.Single */
-    blockquote c-[u] { color: inherit } /* Literal.String.Double */
-    blockquote c-[cp] { color: inherit } /* Comment.Preproc */
-    blockquote c-[c1] { color: inherit } /* Comment.Single */
-    blockquote c-[cs] { color: inherit } /* Comment.Special */
-    blockquote c-[kc] { color: inherit } /* Keyword.Constant */
-    blockquote c-[kn] { color: inherit } /* Keyword.Namespace */
-    blockquote c-[kp] { color: inherit } /* Keyword.Pseudo */
-    blockquote c-[kr] { color: inherit } /* Keyword.Reserved */
-    blockquote c-[ld] { color: inherit } /* Literal.Date */
-    blockquote c-[nc] { color: inherit } /* Name.Class */
-    blockquote c-[no] { color: inherit } /* Name.Constant */
-    blockquote c-[nd] { color: inherit } /* Name.Decorator */
-    blockquote c-[ni] { color: inherit } /* Name.Entity */
-    blockquote c-[ne] { color: inherit } /* Name.Exception */
-    blockquote c-[nf] { color: inherit } /* Name.Function */
-    blockquote c-[nl] { color: inherit } /* Name.Label */
-    blockquote c-[nn] { color: inherit } /* Name.Namespace */
-    blockquote c-[py] { color: inherit } /* Name.Property */
-    blockquote c-[ow] { color: inherit } /* Operator.Word */
-    blockquote c-[mb] { color: inherit } /* Literal.Number.Bin */
-    blockquote c-[mf] { color: inherit } /* Literal.Number.Float */
-    blockquote c-[mh] { color: inherit } /* Literal.Number.Hex */
-    blockquote c-[mi] { color: inherit } /* Literal.Number.Integer */
-    blockquote c-[mo] { color: inherit } /* Literal.Number.Oct */
-    blockquote c-[sb] { color: inherit } /* Literal.String.Backtick */
-    blockquote c-[sc] { color: inherit } /* Literal.String.Char */
-    blockquote c-[sd] { color: inherit } /* Literal.String.Doc */
-    blockquote c-[se] { color: inherit } /* Literal.String.Escape */
-    blockquote c-[sh] { color: inherit } /* Literal.String.Heredoc */
-    blockquote c-[si] { color: inherit } /* Literal.String.Interpol */
-    blockquote c-[sx] { color: inherit } /* Literal.String.Other */
-    blockquote c-[sr] { color: inherit } /* Literal.String.Regex */
-    blockquote c-[ss] { color: inherit } /* Literal.String.Symbol */
-    blockquote c-[vc] { color: inherit } /* Name.Variable.Class */
-    blockquote c-[vg] { color: inherit } /* Name.Variable.Global */
-    blockquote c-[vi] { color: inherit } /* Name.Variable.Instance */
-    blockquote c-[il] { color: inherit } /* Literal.Number.Integer.Long */
+    del { background: #fcc; color: #000; text-decoration: line-through; }
+    ins { background: #cfc; color: #000; }
+    blockquote .highlight:not(.idl) { background: initial; margin: initial; padding: 0.5em }
+    blockquote code.highlight:not(.idl) { padding: initial; }
+    blockquote c-[a] { color: inherit; } /* Keyword.Declaration */
+    blockquote c-[b] { color: inherit; } /* Keyword.Type */
+    blockquote c-[c] { color: inherit; } /* Comment */
+    blockquote c-[d] { color: inherit; } /* Comment.Multiline */
+    blockquote c-[e] { color: inherit; } /* Name.Attribute */
+    blockquote c-[f] { color: inherit; } /* Name.Tag */
+    blockquote c-[g] { color: inherit; } /* Name.Variable */
+    blockquote c-[k] { color: inherit; } /* Keyword */
+    blockquote c-[l] { color: inherit; } /* Literal */
+    blockquote c-[m] { color: inherit; } /* Literal.Number */
+    blockquote c-[n] { color: inherit; } /* Name */
+    blockquote c-[o] { color: inherit; } /* Operator */
+    blockquote c-[p] { color: inherit; } /* Punctuation */
+    blockquote c-[s] { color: inherit; } /* Literal.String */
+    blockquote c-[t] { color: inherit; } /* Literal.String.Single */
+    blockquote c-[u] { color: inherit; } /* Literal.String.Double */
+    blockquote c-[cp] { color: inherit; } /* Comment.Preproc */
+    blockquote c-[c1] { color: inherit; } /* Comment.Single */
+    blockquote c-[cs] { color: inherit; } /* Comment.Special */
+    blockquote c-[kc] { color: inherit; } /* Keyword.Constant */
+    blockquote c-[kn] { color: inherit; } /* Keyword.Namespace */
+    blockquote c-[kp] { color: inherit; } /* Keyword.Pseudo */
+    blockquote c-[kr] { color: inherit; } /* Keyword.Reserved */
+    blockquote c-[ld] { color: inherit; } /* Literal.Date */
+    blockquote c-[nc] { color: inherit; } /* Name.Class */
+    blockquote c-[no] { color: inherit; } /* Name.Constant */
+    blockquote c-[nd] { color: inherit; } /* Name.Decorator */
+    blockquote c-[ni] { color: inherit; } /* Name.Entity */
+    blockquote c-[ne] { color: inherit; } /* Name.Exception */
+    blockquote c-[nf] { color: inherit; } /* Name.Function */
+    blockquote c-[nl] { color: inherit; } /* Name.Label */
+    blockquote c-[nn] { color: inherit; } /* Name.Namespace */
+    blockquote c-[py] { color: inherit; } /* Name.Property */
+    blockquote c-[ow] { color: inherit; } /* Operator.Word */
+    blockquote c-[mb] { color: inherit; } /* Literal.Number.Bin */
+    blockquote c-[mf] { color: inherit; } /* Literal.Number.Float */
+    blockquote c-[mh] { color: inherit; } /* Literal.Number.Hex */
+    blockquote c-[mi] { color: inherit; } /* Literal.Number.Integer */
+    blockquote c-[mo] { color: inherit; } /* Literal.Number.Oct */
+    blockquote c-[sb] { color: inherit; } /* Literal.String.Backtick */
+    blockquote c-[sc] { color: inherit; } /* Literal.String.Char */
+    blockquote c-[sd] { color: inherit; } /* Literal.String.Doc */
+    blockquote c-[se] { color: inherit; } /* Literal.String.Escape */
+    blockquote c-[sh] { color: inherit; } /* Literal.String.Heredoc */
+    blockquote c-[si] { color: inherit; } /* Literal.String.Interpol */
+    blockquote c-[sx] { color: inherit; } /* Literal.String.Other */
+    blockquote c-[sr] { color: inherit; } /* Literal.String.Regex */
+    blockquote c-[ss] { color: inherit; } /* Literal.String.Symbol */
+    blockquote c-[vc] { color: inherit; } /* Name.Variable.Class */
+    blockquote c-[vg] { color: inherit; } /* Name.Variable.Global */
+    blockquote c-[vi] { color: inherit; } /* Name.Variable.Instance */
+    blockquote c-[il] { color: inherit; } /* Literal.Number.Integer.Long */
   </style>
 </head>
 <body class="h-entry">

--- a/bikeshed/boilerplate/wg21/header.include
+++ b/bikeshed/boilerplate/wg21/header.include
@@ -20,6 +20,60 @@
     th {
       text-align: center;
     }
+
+    blockquote code.highlight:not(.idl) { background: initial }
+    blockquote c-[a] { color: inherit } /* Keyword.Declaration */
+    blockquote c-[b] { color: inherit } /* Keyword.Type */
+    blockquote c-[c] { color: inherit } /* Comment */
+    blockquote c-[d] { color: inherit } /* Comment.Multiline */
+    blockquote c-[e] { color: inherit } /* Name.Attribute */
+    blockquote c-[f] { color: inherit } /* Name.Tag */
+    blockquote c-[g] { color: inherit } /* Name.Variable */
+    blockquote c-[k] { color: inherit } /* Keyword */
+    blockquote c-[l] { color: inherit } /* Literal */
+    blockquote c-[m] { color: inherit } /* Literal.Number */
+    blockquote c-[n] { color: inherit } /* Name */
+    blockquote c-[o] { color: inherit } /* Operator */
+    blockquote c-[p] { color: inherit } /* Punctuation */
+    blockquote c-[s] { color: inherit } /* Literal.String */
+    blockquote c-[t] { color: inherit } /* Literal.String.Single */
+    blockquote c-[u] { color: inherit } /* Literal.String.Double */
+    blockquote c-[cp] { color: inherit } /* Comment.Preproc */
+    blockquote c-[c1] { color: inherit } /* Comment.Single */
+    blockquote c-[cs] { color: inherit } /* Comment.Special */
+    blockquote c-[kc] { color: inherit } /* Keyword.Constant */
+    blockquote c-[kn] { color: inherit } /* Keyword.Namespace */
+    blockquote c-[kp] { color: inherit } /* Keyword.Pseudo */
+    blockquote c-[kr] { color: inherit } /* Keyword.Reserved */
+    blockquote c-[ld] { color: inherit } /* Literal.Date */
+    blockquote c-[nc] { color: inherit } /* Name.Class */
+    blockquote c-[no] { color: inherit } /* Name.Constant */
+    blockquote c-[nd] { color: inherit } /* Name.Decorator */
+    blockquote c-[ni] { color: inherit } /* Name.Entity */
+    blockquote c-[ne] { color: inherit } /* Name.Exception */
+    blockquote c-[nf] { color: inherit } /* Name.Function */
+    blockquote c-[nl] { color: inherit } /* Name.Label */
+    blockquote c-[nn] { color: inherit } /* Name.Namespace */
+    blockquote c-[py] { color: inherit } /* Name.Property */
+    blockquote c-[ow] { color: inherit } /* Operator.Word */
+    blockquote c-[mb] { color: inherit } /* Literal.Number.Bin */
+    blockquote c-[mf] { color: inherit } /* Literal.Number.Float */
+    blockquote c-[mh] { color: inherit } /* Literal.Number.Hex */
+    blockquote c-[mi] { color: inherit } /* Literal.Number.Integer */
+    blockquote c-[mo] { color: inherit } /* Literal.Number.Oct */
+    blockquote c-[sb] { color: inherit } /* Literal.String.Backtick */
+    blockquote c-[sc] { color: inherit } /* Literal.String.Char */
+    blockquote c-[sd] { color: inherit } /* Literal.String.Doc */
+    blockquote c-[se] { color: inherit } /* Literal.String.Escape */
+    blockquote c-[sh] { color: inherit } /* Literal.String.Heredoc */
+    blockquote c-[si] { color: inherit } /* Literal.String.Interpol */
+    blockquote c-[sx] { color: inherit } /* Literal.String.Other */
+    blockquote c-[sr] { color: inherit } /* Literal.String.Regex */
+    blockquote c-[ss] { color: inherit } /* Literal.String.Symbol */
+    blockquote c-[vc] { color: inherit } /* Name.Variable.Class */
+    blockquote c-[vg] { color: inherit } /* Name.Variable.Global */
+    blockquote c-[vi] { color: inherit } /* Name.Variable.Instance */
+    blockquote c-[il] { color: inherit } /* Literal.Number.Integer.Long */
   </style>
 </head>
 <body class="h-entry">

--- a/bikeshed/boilerplate/wg21/header.include
+++ b/bikeshed/boilerplate/wg21/header.include
@@ -24,6 +24,7 @@
     del { background: #fcc; color: #000; text-decoration: line-through; }
     ins { background: #cfc; color: #000; }
     blockquote .highlight:not(.idl) { background: initial; margin: initial; padding: 0.5em }
+    blockquote ul { background: inherit; }
     blockquote code.highlight:not(.idl) { padding: initial; }
     blockquote c-[a] { color: inherit; } /* Keyword.Declaration */
     blockquote c-[b] { color: inherit; } /* Keyword.Type */


### PR DESCRIPTION
NOTE: CI is not passing. @jfbastien will generate new "golden" papers if the change is approved.

WG21 code syntax highlighting and code background removed for wording paragraphs identified by a `<blockquote>`. Additionally colors for `<ins>` and `<del>` were adjusted,

New style has been consulted and accepted by the key WG21 representatives on the ISO C++ Committee meeting at Kona.

Here is the before and after comparison:
![bikeshed](https://user-images.githubusercontent.com/506260/53227065-373bd700-3621-11e9-9537-45184ef9804e.PNG)
