### PR TITLE
Get rid of <dfn> for "processing equivalence" in webplatform footer.

### DIFF
--- a/bikeshed/boilerplate/webplatform/footer.include
+++ b/bikeshed/boilerplate/webplatform/footer.include
@@ -37,7 +37,7 @@
     "should", "may", etc) used in introducing the algorithm.</p>
 
     <p>Conformance requirements phrased as algorithms or specific steps can be
-    implemented in any manner, so long as the end result is <dfn lt="processing equivalence" id="dfn-processing-equivalence">equivalent</dfn>. In
+    implemented in any manner, so long as the end result is equivalent. In
     particular, the algorithms defined in this specification are intended to
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>


### PR DESCRIPTION
Having this as a `<dfn>` just seems to result in warnings when you're not actually
referencing it from the spec. Footers for other groups don't have this as a dfn either,
so just don't make it a `<dfn>`.