### PR TITLE
Phrasing tweak in the documentation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -199,35 +199,35 @@ If you think you might want to commit back to Bikeshed,
 instead download it over SSH.
 I won’t explain how to do that here.)
 
-Finally, run:
+Finally, depending on your environment, run:
 
-In a Virtualenv environment:
+: In a Virtualenv environment:
+::
+    ```
+    (venv) $ pip install --editable /path/to/cloned/bikeshed
+    (venv) $ bikeshed update
+    ```
 
-```
-(venv) $ pip install --editable /path/to/cloned/bikeshed
-(venv) $ bikeshed update
-```
+: For Linux/OSX (Omit the `sudo` for OSX under Homebrew):
+::
+    ```
+    $ sudo pip install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
+    ```
 
-For Linux/OSX (Omit the `sudo` for OSX under Homebrew):
+: On Windows:
+::
+    ```
+    $ python -m pip install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
+    ```
 
-```
-$ sudo pip install --editable /path/to/cloned/bikeshed
-$ bikeshed update
-```
-
-On Windows:
-
-```
-$ python -m pip install --editable /path/to/cloned/bikeshed
-$ bikeshed update
-```
-
-On Termux:
-
-```
-$ pip2 install --editable /path/to/cloned/bikeshed
-$ bikeshed update
-```
+: On Termux:
+::
+    ```
+    $ pip2 install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
+    ```
 
 This’ll install Bikeshed,
 making it available to your Python environment as the `bikeshed` package,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1212,9 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version c162ffa3135b60854f4a1133b003c178d67d8b91" name="generator">
+  <meta content="Bikeshed version 4d208866a95a1121fceca549a36bfb09c5bf1705" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="c162ffa3135b60854f4a1133b003c178d67d8b91" name="document-revision">
+  <meta content="4d208866a95a1121fceca549a36bfb09c5bf1705" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1530,7 +1530,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2019-02-15">15 February 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2019-04-13">13 April 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1545,7 +1545,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 15 February 2019,
+In addition, as of 13 April 2019,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1845,23 +1845,29 @@ created wherever you’re currently at.
 If you think you might want to commit back to Bikeshed,
 instead download it over SSH.
 I won’t explain how to do that here.)</p>
-   <p>Finally, run:</p>
-   <p>In a Virtualenv environment:</p>
-<pre>(venv) $ pip install --editable /path/to/cloned/bikeshed
-(venv) $ bikeshed update
+   <p>Finally, depending on your environment, run:</p>
+   <dl>
+    <dt data-md>In a Virtualenv environment:
+    <dd data-md>
+<pre>    (venv) $ pip install --editable /path/to/cloned/bikeshed
+    (venv) $ bikeshed update
 </pre>
-   <p>For Linux/OSX (Omit the <code>sudo</code> for OSX under Homebrew):</p>
-<pre>$ sudo pip install --editable /path/to/cloned/bikeshed
-$ bikeshed update
+    <dt data-md>For Linux/OSX (Omit the <code>sudo</code> for OSX under Homebrew):
+    <dd data-md>
+<pre>    $ sudo pip install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
 </pre>
-   <p>On Windows:</p>
-<pre>$ python -m pip install --editable /path/to/cloned/bikeshed
-$ bikeshed update
+    <dt data-md>On Windows:
+    <dd data-md>
+<pre>    $ python -m pip install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
 </pre>
-   <p>On Termux:</p>
-<pre>$ pip2 install --editable /path/to/cloned/bikeshed
-$ bikeshed update
+    <dt data-md>On Termux:
+    <dd data-md>
+<pre>    $ pip2 install --editable /path/to/cloned/bikeshed
+    $ bikeshed update
 </pre>
+   </dl>
    <p>This’ll install Bikeshed,
 making it available to your Python environment as the <code>bikeshed</code> package,
 automatically add a <code>bikeshed</code> command to your path,
@@ -3328,7 +3334,7 @@ path: relative/to/spec/location
 except that metadata blocks aren’t processed.
 (For various reasons, they have to be parsed before <em>any</em> other processing occurs).
 This means that the include file can use markdown,
-data blocks of various kinds (&lt;pre class=anchors>, &lt;pre class=railroad-diagram>, etc),
+data blocks of various kinds (&lt;pre class=anchors>, &lt;pre class=railroad>, etc),
 and both provide definitions for the outer document
 and refer to ones defined by the outer document.</p>
    <p>If you’re including a block of repetitive markup multiple times,
@@ -4372,6 +4378,8 @@ However, to obtain correct boilerplate for a given standards body,
      <p>"wg21", for the C++ Standards Committee</p>
     <li data-md>
      <p>"tc39", for ECMAScript TC-39</p>
+    <li data-md>
+     <p>"khronos", for the Khronos Group</p>
    </ul>
    <p>You can put whatever value you want into the "Group" value, though.
 Unrecognized values will just use the default boilerplate files.


### PR DESCRIPTION
As currently phrased, the "finally" part of the common steps in the installation section can be a bit confusing, as it may look like it tells you that the first step is to do something in a virtual environment, which is confusing if you're not using one, as instead of reading further and noticing it has instructions for other environments, you want instead go back to read earlier steps to figure out if you missed something that asked you to set up one.

Rephrase to make it more obvious that this subsection is a list of alternatives rather than a series of steps.