### PR TITLE
Add "immersivewebwg" to megaGroups/w3c

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -86,7 +86,7 @@ deadlineStatuses = ["w3c/LCWD", "w3c/PR"]
 noEDStatuses = ["LS", "LS-COMMIT", "LS-BRANCH", "LD", "FINDING", "DRAFT-FINDING", "DREAM", "iso/NP", "whatwg/RD"]
 
 megaGroups = {
-    "w3c": frozenset(["act-framework", "audiowg", "csswg", "dap", "fxtf", "fxtf-csswg", "geolocation", "houdini", "html", "i18n", "mediacapture", "processcg", "ricg", "sacg", "serviceworkers", "svg", "texttracks", "uievents", "wasm", "web-bluetooth-cg", "webappsec", "webauthn", "webml", "web-payments", "webperf", "webplatform", "webrtc", "webspecs", "webvr", "wicg"]),
+    "w3c": frozenset(["act-framework", "audiowg", "csswg", "dap", "fxtf", "fxtf-csswg", "geolocation", "houdini", "html", "i18n", "immersivewebwg", "mediacapture", "processcg", "ricg", "sacg", "serviceworkers", "svg", "texttracks", "uievents", "wasm", "web-bluetooth-cg", "webappsec", "webauthn", "webml", "web-payments", "webperf", "webplatform", "webrtc", "webspecs", "webvr", "wicg"]),
     "whatwg": frozenset(["whatwg"]),
     "tc39": frozenset(["tc39"]),
     "iso": frozenset(["wg14", "wg21"]),


### PR DESCRIPTION
(sorry if this is not a right way to ask adding...)
Coming from https://github.com/immersive-web/webxr/pull/594, it seems immersive-web WG is not listed in W3C groups. Let us add immesive-web WG into W3C WGs.