### PR TITLE
Use W3C-STYLESHEET-URL for up-left W3C status logo instead of url with STATUS in immersivewebwg

### DIFF
--- a/bikeshed/boilerplate/immersivewebwg/header.include
+++ b/bikeshed/boilerplate/immersivewebwg/header.include
@@ -6,7 +6,7 @@
   <title>[TITLE]</title>
   <style data-fill-with="stylesheet">
   </style>
-  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-[STATUS]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
 </head>
 <body class="h-entry">
 <div class="head">


### PR DESCRIPTION
(sorry if this is not a right way to ask adding...)
Coming from https://github.com/immersive-web/webxr/pull/594 and https://github.com/immersive-web/editor-collab/pull/33, stylesheet URL seems not possible to be generated correctly from STATUS (or similar macro generated in processor) when we use w3c/XX as "Status" metadata.
In bikeshed/metadata.py, "w3c-stylesheet-url" macro is defined from "Status" metadata with processed, it seems we are better to use that macro instead.

@dontcallmedom please let me know if this is not the best way to fix things...