### PR TITLE
Also require `display:contents` before using the grid-specific ToC styles

### DIFF
--- a/bikeshed/boilerplate/stylesheet.include
+++ b/bikeshed/boilerplate/stylesheet.include
@@ -991,7 +991,7 @@ Possible extra rowspan handling
 	.toc > li li li li li { font-size:   85%;    }
 	.toc > li li li li li .secno { font-size: 100%; }
 
-	/* @supports not (display:grid) { */
+	/* @supports not ((display:grid) and (display:contents)) { */
 		.toc > li             { margin: 1.5rem 0;    }
 		.toc > li li          { margin: 0.3rem 0;    }
 		.toc > li li li       { margin-left: 2rem;   }
@@ -1024,7 +1024,7 @@ Possible extra rowspan handling
 		}
 	/* } */
 
-	@supports (display:grid) {
+	@supports (display:grid) and (display:contents) {
 		/* Use #toc over .toc to override non-@supports rules. */
 		#toc {
 			display: grid;


### PR DESCRIPTION
Fixes #1423.

Note that I haven't actually tested this locally since I was too lazy to set up a bikeshed tree on a Windows machine or to copy generated specs around, but based on the discussion I think it should be fine.