### PR TITLE
Fix "GPU for the Web Community Group" URL

### DIFF
--- a/bikeshed/boilerplate/webgpu/status.include
+++ b/bikeshed/boilerplate/webgpu/status.include
@@ -1,4 +1,4 @@
-This specification was published by the <a href="https://www.w3.org/community/gpuweb/">GPU for the Web Community Group</a>.
+This specification was published by the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a>.
 It is not a W3C Standard nor is it on the W3C Standards Track.
 
 Please note that under the


### PR DESCRIPTION
This PR fixes URL used for the "GPU for the Web Community Group" used in https://gpuweb.github.io/gpuweb/

FYI @grorg @kangz @kainino0x