### PR TITLE
Match more GitHub repository URL formats

### DIFF
--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -839,12 +839,15 @@ def getSpecRepository(doc):
             with open(os.devnull, "wb") as fnull:
                 remotes = subprocess.check_output(["git", "remote", "-v"], stderr=fnull)
             os.chdir(old_dir)
-            search = re.search(r"origin\tgit@github\.([\w.-]+):([\w-]+)/([\w-]+)\.git \(\w+\)", remotes)
-            if search:
-                return GithubRepository(*search.groups())
-            search = re.search(r"origin\thttps://github\.([\w.-]+)/([\w-]+)/([\w-]+)\.git \(\w+\)", remotes)
-            if search:
-                return GithubRepository(*search.groups())
+            searches = [
+              r"origin\tgit@github\.([\w.-]+):([\w-]+)/([\w-]+)\.git \(\w+\)",
+              r"origin\thttps://github\.([\w.-]+)/([\w-]+)/([\w-]+)\.git \(\w+\)",
+              r"origin\thttps://github\.([\w.-]+)/([\w-]+)/([\w-]+)/? \(\w+\)",
+            ]
+            for search_re in searches:
+                search = re.search(search_re, remotes)
+                if search:
+                    return GithubRepository(*search.groups())
             return config.Nil()
         except subprocess.CalledProcessError:
             # check_output will throw CalledProcessError when not in a git repo


### PR DESCRIPTION
A GitHub repo can be `git clone`d with more than one URL format.
For example:
  git@github.XYZ:foo/bar.git
  https://github.XYZ/foo/bar.git
  https://github.XYZ/foo/bar
  https://github.XYZ/foo/bar/

.. all point to the same GitHub repo.  After the repo is cloned,
`git remote -v` will print the URL that was used to clone.  Bikeshed
previously only understood the first 2 of those 4 URL forms.

This PR adds the last 2 of those 4 URL forms to |getSpecRepository|
so that the GitHub repository is correctly computed in those cases.