### PR TITLE
Modified web apps boilerplate to resolve a bad link issue for some specifications

### DIFF
--- a/bikeshed/boilerplate/webapps/status-ED.include
+++ b/bikeshed/boilerplate/webapps/status-ED.include
@@ -14,7 +14,7 @@
     as a Working Draft.
 
     Feedback and comments on this specification are welcome. Please use
-    <a href="https://github.com/w3c/[SHORTNAME]/issues">GitHub issues</a>
+    <a href="https://github.com/[REPOSITORY]/issues">GitHub issues</a>
     Historical discussions can be found in the
     <a href="https://lists.w3.org/Archives/Public/public-webapps/">public-webapps@w3.org archives</a>.
   </p>

--- a/bikeshed/boilerplate/webapps/status-WD.include
+++ b/bikeshed/boilerplate/webapps/status-WD.include
@@ -14,7 +14,7 @@
     as a Working Draft.
 
     Feedback and comments on this specification are welcome. Please use
-    <a href="https://github.com/w3c/[SHORTNAME]/issues">GitHub issues</a>
+    <a href="https://github.com/[REPOSITORY]/issues">GitHub issues</a>
     Historical discussions can be found in the
     <a href="https://lists.w3.org/Archives/Public/public-webapps/">public-webapps@w3.org archives</a>.
   </p>


### PR DESCRIPTION
use the proper link to GH issues, useful in case of discrepancy between short-name and repository name