### PR TITLE
imply plain printMode on dumb terminals

### DIFF
--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -196,7 +196,7 @@ def main():
     config.setErrorLevel(options.errorLevel)
     config.dryRun = options.dryRun
     if options.printMode is None:
-        if "NO_COLOR" in os.environ or os.environ["TERM"] == "dumb":
+        if "NO_COLOR" in os.environ or os.environ.get("TERM") == "dumb":
             config.printMode = "plain"
         else:
             config.printMode = "console"

--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -196,7 +196,7 @@ def main():
     config.setErrorLevel(options.errorLevel)
     config.dryRun = options.dryRun
     if options.printMode is None:
-        if "NO_COLOR" in os.environ:
+        if "NO_COLOR" in os.environ or os.environ["TERM"] == "dumb":
             config.printMode = "plain"
         else:
             config.printMode = "console"


### PR DESCRIPTION
Dumb terminals only recognise a limited subset of escape sequences
and are identified by TERM=dumb.

With this change, bikeshed will imply the plain printMode (equal
to NO_COLOR=1) for dumb terminals.