### PR TITLE
Add new feature for injecting MDN panels

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from . import biblio
 from . import boilerplate
 from . import caniuse
+from . import mdnspeclinks
 from . import config
 from . import constants
 from . import datablocks
@@ -73,6 +74,7 @@ class Spec(object):
         self.typeExpansions = {}
         self.macros = defaultdict(lambda x: "???")
         self.canIUse = {}
+        self.mdnSpecLinks = {}
         self.widl = idl.getParser()
         self.testSuites = json.loads(self.dataFile.fetch("test-suites.json", str=True))
         self.languages = json.loads(self.dataFile.fetch("languages.json", str=True))
@@ -200,6 +202,7 @@ class Spec(object):
         biblio.dedupBiblioReferences(self)
         verifyUsageOfAllLocalBiblios(self)
         caniuse.addCanIUsePanels(self)
+        mdnspeclinks.addMdnPanels(self)
         boilerplate.addIndexSection(self)
         boilerplate.addExplicitIndexes(self)
         boilerplate.addStyles(self)

--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -95,6 +95,7 @@ def main():
     updateParser.add_argument("--backrefs", action="store_true", help="Download link backref data.")
     updateParser.add_argument("--biblio", action="store_true", help="Download biblio data.")
     updateParser.add_argument("--caniuse", action="store_true", help="Download Can I Use... data.")
+    updateParser.add_argument("--mdn", action="store_true", help="Download MDN Spec Links... data.")
     updateParser.add_argument("--link-defaults", dest="linkDefaults", action="store_true", help="Download link default data.")
     updateParser.add_argument("--test-suites", dest="testSuites", action="store_true", help="Download test suite data.")
     updateParser.add_argument("--languages", dest="languages", action="store_true", help="Download language/translation data.")
@@ -234,7 +235,7 @@ def main():
 
 
 def handleUpdate(options, extras):
-    update.update(anchors=options.anchors, backrefs=options.backrefs, biblio=options.biblio, caniuse=options.caniuse, linkDefaults=options.linkDefaults, testSuites=options.testSuites, languages=options.languages, wpt=options.wpt, dryRun=constants.dryRun, force=options.force)
+    update.update(anchors=options.anchors, backrefs=options.backrefs, biblio=options.biblio, caniuse=options.caniuse, mdn=options.mdn, linkDefaults=options.linkDefaults, testSuites=options.testSuites, languages=options.languages, wpt=options.wpt, dryRun=constants.dryRun, force=options.force)
 
 
 def handleSpec(options, extras):

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -84,16 +84,16 @@ def addMdnPanels(doc):
     #       https://github.com/whatwg/whatwg.org/pull/267 resolved
     doc.extraStyles["style-mdn-anno"] = '''
         @media (max-width: 767px) { .mdn-anno { opacity: .1 } }
-        .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; top: auto; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; overflow-wrap: normal; word-wrap: normal; hyphens: none}
+        .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; top: auto; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; white-space: nowrap; overflow-wrap: normal; word-wrap: normal; hyphens: none}
         .mdn-anno:not(.wrapped) { opacity: 1}
         .mdn-anno:hover { z-index: 9 }
         .mdn-anno.wrapped { min-width: 0 }
         .mdn-anno.wrapped > :not(button) { display: none; }
-        .mdn-anno > .mdn-anno-btn { cursor: pointer; border: none; color: #000; background: transparent; margin: -8px; outline: none; }
+        .mdn-anno > .mdn-anno-btn { cursor: pointer; border: none; color: #000; background: transparent; margin: -8px; float: right; padding: 10px 8px 8px 8px; outline: none; }
         .mdn-anno > .mdn-anno-btn > .less-than-two-engines-flag { color: red; padding-right: 2px; }
         .mdn-anno > .mdn-anno-btn > .all-engines-flag { color: green; padding-right: 2px; }
         .mdn-anno > .mdn-anno-btn > span { color: #fff; background-color: #000; font-weight: normal; font-family: zillaslab, Palatino, "Palatino Linotype", serif; padding: 2px 3px 0px 3px; line-height: 1.3em; vertical-align: top; }
-        .mdn-anno > .feature { margin-top: 2px; }
+        .mdn-anno > .feature { margin-top: 20px; }
         .mdn-anno > .feature:not(:first-of-type) { border-top: 1px solid #999; margin-top: 6px; padding-top: 2px; }
         .mdn-anno > .feature > .less-than-two-engines-text { color: red }
         .mdn-anno > .feature > .all-engines-text { color: green }

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -77,7 +77,8 @@ def addMdnPanels(doc):
             if (!parentnode) {
                 return;
             }
-            if(parentnode.classList.contains("mdn-anno-btn")) {
+            if (e.composedPath().some(el =>
+                    (el.classList && el.classList.contains("mdn-anno-btn")))) {
                 parentnode.parentNode.classList.toggle("wrapped");
             }
         });'''  # noqa

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -73,13 +73,10 @@ def addMdnPanels(doc):
                  * unless we reposition them where they belong. */
                 positionAnnos()
             }
-            parentnode = e.target.parentNode;
-            if (!parentnode) {
-                return;
-            }
-            if (e.composedPath().some(el =>
-                    (el.classList && el.classList.contains("mdn-anno-btn")))) {
-                parentnode.parentNode.classList.toggle("wrapped");
+            var mdnAnno = e.composedPath().filter(el =>
+                (el.classList && el.classList.contains("mdn-anno")))[0];
+            if (mdnAnno) {
+                mdnAnno.classList.toggle("wrapped");
             }
         });'''  # noqa
 

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -174,7 +174,7 @@ def addMdnPanels(doc):
                         warn("No \"{0}\" ID found." + mdnSuggest, elementID)
                         continue
                     if "engines" in feature:
-                        engines = feature["engines"]
+                        engines = len(feature["engines"])
                         if engines < 2:
                             lessThanTwoEngines = lessThanTwoEngines + 1
                         elif engines == 2:
@@ -283,7 +283,7 @@ def mdnPanelFor(feature, mdnBaseUrl, bcdBaseUrl, nameFromCodeName,
         slugPara = E.p(slugLink)
         appendChild(featureDiv, slugPara)
     if "engines" in feature:
-        engines = feature["engines"]
+        engines = len(feature["engines"])
         enginesPara = None
         if engines == 0:
             enginesPara = E.p({"class": "less-than-two-engines-text"},

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -65,15 +65,17 @@ def addMdnPanels(doc):
             }
         }
         window.addEventListener("load", positionAnnos())
+        document.body.addEventListener("click", (e) => {
+            if(e.target.closest(".mdn-anno-btn")) {
+                e.target.closest(".mdn-anno").classList.toggle("wrapped");
+            }
+        });
         /* If this is a document styled for W3C publication with a ToC
          * sidebar, and the ToC "Collapse Sidebar" button is pushed, some
          * MDN annos seem to end up getting wildly out of place unless we
          * reposition them where they belong. */
         document.querySelector("#toc-toggle").addEventListener("click",
             () => positionAnnos());
-        Array.from(document.querySelectorAll(".mdn-anno"),
-            el => el.addEventListener('click',
-            () => el.classList.toggle("wrapped")));
         '''  # noqa
 
     # FIXME: Update the Edge logo URL when we get

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -65,8 +65,12 @@ def addMdnPanels(doc):
             }
         });
         document.body.addEventListener("click", function(e) {
-            if(e.target.parentNode.classList.contains("mdn-anno-btn")) {
-                e.target.parentNode.parentNode.classList.toggle("wrapped");
+            parentnode = e.target.parentNode;
+            if (!parentnode) {
+                return;
+            }
+            if(parentnode.classList.contains("mdn-anno-btn")) {
+                parentnode.parentNode.classList.toggle("wrapped");
             }
         });'''  # noqa
 

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -45,7 +45,7 @@ def addMdnPanels(doc):
             var annos = [].slice.call(document.querySelectorAll(".mdn-anno"));
             for(var i = 0; i < annos.length; i++) {
                 var anno = annos[i];
-                id = anno.getAttribute("data-dfn-id");
+                id = anno.getAttribute("data-mdn-for");
                 var dfn = document.querySelector("#" + id);
                 if (dfn !== null) {
                     var rect = dfn.getBoundingClientRect(id);
@@ -160,7 +160,7 @@ def addMdnPanels(doc):
                 mdnButton = E.button({"class": "mdn-anno-btn"})
                 mdnLogo = E.span("MDN")
                 appendChild(anno, mdnButton)
-                anno.set("data-dfn-id", escapedElementID)
+                anno.set("data-mdn-for", escapedElementID)
                 appendChild(doc.body, anno)
                 lessThanTwoEngines = 0
                 onlyTwoEngines = 0

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -99,7 +99,7 @@ def addMdnPanels(doc):
         .mdn-anno > .feature > p + p { margin-top: 3px; }
         .mdn-anno > .feature > .support { display: block; font-size: 0.6em; margin: 0; padding: 0; margin-top: 2px }
         .mdn-anno > .feature > .support + div { padding-top: 0.5em; }
-        .mdn-anno > .feature > .support > hr { display: block; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }
+        .mdn-anno > .feature > .support > hr { display: block; border: none; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }
         .mdn-anno > .feature > .support > hr::before { content: ""; }
         .mdn-anno > .feature > .support > span { padding: 0.2em 0; display: block; display: table; }
         .mdn-anno > .feature > .support > span.no { color: #CCCCCC; filter: grayscale(100%); }

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -65,20 +65,16 @@ def addMdnPanels(doc):
             }
         }
         window.addEventListener("load", positionAnnos())
-        document.body.addEventListener("click", function(e) {
-            if (e.composedPath().some(el => (el.id === "toc-toggle"))) {
-                /* If this is a document styled for W3C publication with a ToC
-                 * sidebar, and the ToC "Collapse Sidebar" button is pushed,
-                 * some MDN annos seem to end up getting wildly out of place
-                 * unless we reposition them where they belong. */
-                positionAnnos()
-            }
-            var mdnAnno = e.composedPath().filter(el =>
-                (el.classList && el.classList.contains("mdn-anno")))[0];
-            if (mdnAnno) {
-                mdnAnno.classList.toggle("wrapped");
-            }
-        });'''  # noqa
+        /* If this is a document styled for W3C publication with a ToC
+         * sidebar, and the ToC "Collapse Sidebar" button is pushed, some
+         * MDN annos seem to end up getting wildly out of place unless we
+         * reposition them where they belong. */
+        document.querySelector("#toc-toggle").addEventListener("click",
+            () => positionAnnos());
+        Array.from(document.querySelectorAll(".mdn-anno"),
+            el => el.addEventListener('click',
+            () => el.classList.toggle("wrapped")));
+        '''  # noqa
 
     # FIXME: Update the Edge logo URL when we get
     #       https://github.com/whatwg/whatwg.org/pull/267 resolved

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -141,7 +141,7 @@ def addMdnPanels(doc):
                                             vSpecShortname + ".json"))
         p = pV if os.path.exists(pV) else p
         with io.open(p, "r", encoding="utf-8") as fh:
-            data = json.loads(unicode(fh.read()), encoding="utf-8",
+            data = json.loads(fh.read(), encoding="utf-8",
                               object_pairs_hook=OrderedDict)
             for elementID in data.keys():
                 features = data[elementID]

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -41,7 +41,7 @@ def addMdnPanels(doc):
     }
 
     doc.extraScripts["script-mdn-anno"] = '''
-        window.addEventListener("load", function(){
+        function positionAnnos() {
             var annos = [].slice.call(document.querySelectorAll(".mdn-anno"));
             for(var i = 0; i < annos.length; i++) {
                 var anno = annos[i];
@@ -63,8 +63,16 @@ def addMdnPanels(doc):
                     console.error('MDN anno references non-existent element ID "%s".%o', id, anno);
                 }
             }
-        });
+        }
+        window.addEventListener("load", positionAnnos())
         document.body.addEventListener("click", function(e) {
+            if (e.composedPath().some(el => (el.id === "toc-toggle"))) {
+                /* If this is a document styled for W3C publication with a ToC
+                 * sidebar, and the ToC "Collapse Sidebar" button is pushed,
+                 * some MDN annos seem to end up getting wildly out of place
+                 * unless we reposition them where they belong. */
+                positionAnnos()
+            }
             parentnode = e.target.parentNode;
             if (!parentnode) {
                 return;

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, unicode_literals
 import io
 import json
 import os

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -114,8 +114,8 @@ def addMdnPanels(doc):
         .mdn-anno > .feature > .support > .chrome_android::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
         .mdn-anno > .feature > .support > .firefox_android::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
         .mdn-anno > .feature > .support > .chrome::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
-        .mdn-anno > .feature > .support > .edge_blink::before { background-image: url(https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_16x16.png); }
-        .mdn-anno > .feature > .support > .edge::before { background-image: url(https://resources.whatwg.org/browser-logos/edge.svg); }
+        .mdn-anno > .feature > .support > .edge_blink::before { background-image: url(https://resources.whatwg.org/browser-logos/edge.svg); }
+        .mdn-anno > .feature > .support > .edge::before { background-image: url(https://resources.whatwg.org/browser-logos/edge_legacy.svg); }
         .mdn-anno > .feature > .support > .firefox::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
         .mdn-anno > .feature > .support > .ie::before { background-image: url(https://resources.whatwg.org/browser-logos/ie.png); }
         .mdn-anno > .feature > .support > .safari_ios::before { background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg); }

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -74,7 +74,7 @@ def addMdnPanels(doc):
     #       https://github.com/whatwg/whatwg.org/pull/267 resolved
     doc.extraStyles["style-mdn-anno"] = '''
         @media (max-width: 767px) { .mdn-anno { opacity: .1 } }
-        .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; top: auto; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; overflow-wrap: normal; word-wrap: normal; }
+        .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; top: auto; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; overflow-wrap: normal; word-wrap: normal; hyphens: none}
         .mdn-anno:not(.wrapped) { opacity: 1}
         .mdn-anno:hover { z-index: 9 }
         .mdn-anno.wrapped { min-width: 0 }

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -74,8 +74,10 @@ def addMdnPanels(doc):
          * sidebar, and the ToC "Collapse Sidebar" button is pushed, some
          * MDN annos seem to end up getting wildly out of place unless we
          * reposition them where they belong. */
-        document.querySelector("#toc-toggle").addEventListener("click",
-            () => positionAnnos());
+        const tocToggle = document.querySelector("#toc-toggle");
+        if (tocToggle) {
+            tocToggle.addEventListener("click", () => positionAnnos());
+        }
         '''  # noqa
 
     # FIXME: Update the Edge logo URL when we get

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -46,7 +46,7 @@ def addMdnPanels(doc):
             for(var i = 0; i < annos.length; i++) {
                 var anno = annos[i];
                 id = anno.getAttribute("data-mdn-for");
-                var dfn = document.querySelector("#" + id);
+                var dfn = document.querySelector("[id='" + id +"']");
                 if (dfn !== null) {
                     var rect = dfn.getBoundingClientRect(id);
                     anno.style.top = (window.scrollY + rect.top) + "px";
@@ -127,7 +127,6 @@ def addMdnPanels(doc):
         .mdn-anno > .feature > .support > .webview_android::before { background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png); }
         .name-slug-mismatch { color: red }
         '''  # noqa
-    charactersDisallowedInSelectors = "!\"#$%&'()*+,./:;<=>?@[\]^`{|}~"
 
     try:
         # TODO: If may turn out that for some specs, in order to make Bikeshed
@@ -145,30 +144,23 @@ def addMdnPanels(doc):
             data = json.loads(unicode(fh.read()), encoding="utf-8",
                               object_pairs_hook=OrderedDict)
             for elementID in data.keys():
-                # Some specs have IDs with characters not allowed in selectors;
-                # e.g., https://xhr.spec.whatwg.org/#the-abort()-method
-                escapedElementID = elementID
-                # FIXME: There must be a more efficient/idiomatic way to do this
-                for char in elementID:
-                    if char in charactersDisallowedInSelectors:
-                        escapedElementID = \
-                            escapedElementID.replace(char, "\\" + char)
-                # TODO: This find() is expensive, but if we add an anno to the
-                # document with a reference to an ID that doesn't actually exist
-                # in the document, the anno won't actually get displayed next to
-                # whatever feature in the spec it's intended to annotate...
                 features = data[elementID]
                 anno = E.aside({"class": "mdn-anno wrapped", "data-deco": ""})
                 mdnButton = E.button({"class": "mdn-anno-btn"})
                 mdnLogo = E.span("MDN")
                 appendChild(anno, mdnButton)
-                anno.set("data-mdn-for", escapedElementID)
+                anno.set("data-mdn-for", elementID)
                 appendChild(doc.body, anno)
                 lessThanTwoEngines = 0
                 onlyTwoEngines = 0
                 allEngines = 0
                 for feature in features:
-                    if find("#" + escapedElementID, doc) is None:
+                    # TODO: This find() is expensive, but if we add an anno to
+                    # the document with a reference to an ID that doesn't
+                    # actually exist in the document, the anno won't actually
+                    # get displayed next to whatever feature in the spec it's
+                    # intended to annotate...
+                    if find("[id='%s']" % elementID, doc) is None:
                         mdnSuggest = ""
                         if "slug" in feature:
                             mdnSuggest = " Update " + mdnBaseUrl \

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -212,13 +212,31 @@ def addSupportRow(browserCodeName, nameFromCodeName, support, supportData):
     if isinstance(thisBrowserSupport, dict):
         if "version_added" in thisBrowserSupport:
             versionAdded = thisBrowserSupport["version_added"]
+            if "prefix" in thisBrowserSupport or \
+                    'alternative_name' in thisBrowserSupport or \
+                    'partial_implementation' in thisBrowserSupport:
+                versionAdded = False
         if "version_removed" in thisBrowserSupport:
             versionRemoved = thisBrowserSupport["version_removed"]
     if isinstance(thisBrowserSupport, list):
-        if "version_added" in thisBrowserSupport[0]:
-            versionAdded = thisBrowserSupport[0]["version_added"]
-        if "version_removed" in thisBrowserSupport[0]:
-            versionRemoved = thisBrowserSupport[0]["version_removed"]
+        for versionDetails in thisBrowserSupport:
+            if "version_removed" in versionDetails:
+                versionRemoved = versionDetails["version_removed"]
+                continue
+            if "version_added" in versionDetails:
+                if versionDetails["version_added"] is False:
+                    versionAdded = False
+                    continue
+                if versionDetails["version_added"] is None:
+                    versionAdded = None
+                    continue
+                if "prefix" in versionDetails or \
+                        'alternative_name' in versionDetails or \
+                        'partial_implementation' in versionDetails:
+                    continue
+                versionAdded = versionDetails["version_added"]
+                versionRemoved = None
+                break
     statusCode = "n"
     if versionAdded is None:
         minVersion = "?"

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -174,7 +174,7 @@ def addMdnPanels(doc):
                         elif engines == 2:
                             onlyTwoEngines = onlyTwoEngines + 1
                         elif engines >= len(browsersProvidingCurrentEngines):
-                            allEngines = allEngines + 1l
+                            allEngines = allEngines + 1
                     featureDiv = mdnPanelFor(feature, mdnBaseUrl, bcdBaseUrl,
                                              nameFromCodeName,
                                              browsersProvidingCurrentEngines,

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -92,7 +92,7 @@ def addMdnPanels(doc):
         .mdn-anno > .feature > .less-than-two-engines-text { color: red }
         .mdn-anno > .feature > .all-engines-text { color: green }
         .mdn-anno > .feature > p { font-size: .75em; margin-top: 6px; margin-bottom: 0; }
-        .mdn-anno > .feature > p + p { margin-top: 0; }
+        .mdn-anno > .feature > p + p { margin-top: 3px; }
         .mdn-anno > .feature > .support { display: block; font-size: 0.6em; margin: 0; padding: 0; margin-top: 2px }
         .mdn-anno > .feature > .support + div { padding-top: 0.5em; }
         .mdn-anno > .feature > .support > hr { display: block; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, unicode_literals
+import io
+import json
+import os
+from collections import OrderedDict
+from . import config
+from .htmlhelpers import *  # noqa
+
+
+def addMdnPanels(doc):
+    if not doc.md.includeMdnPanels:
+        return
+
+    mdnBaseUrl = "https://developer.mozilla.org/en-US/docs/Web/"
+    bcdBaseUrl = "https://github.com/mdn/browser-compat-data/blob/master/"
+
+    browsersProvidingCurrentEngines = ["firefox", "safari", "chrome"]
+    browsersWithBorrowedEngines = ["opera", "edge_blink"]
+    browsersWithRetiredEngines = ["edge", "ie"]
+    browsersForMobileDevices = ["firefox_android", "safari_ios",
+                                "chrome_android", "webview_android",
+                                "samsunginternet_android", "opera_android"]
+
+    # BCD/mdn-spec-links shortnames to full names
+    nameFromCodeName = {
+        "chrome": "Chrome",
+        "chrome_android": "Chrome for Android",
+        "edge": "Edge (Legacy)",
+        "edge_blink": "Edge",
+        "firefox": "Firefox",
+        "firefox_android": "Firefox for Android",
+        "ie": "IE",
+        "nodejs": "Node.js",
+        "opera": "Opera",
+        "opera_android": "Opera Mobile",
+        "safari": "Safari",
+        "samsunginternet_android": "Samsung Internet",
+        "safari_ios": "iOS Safari",
+        "webview_android": "Android WebView"
+    }
+
+    doc.extraScripts["script-mdn-anno"] = '''
+        window.addEventListener("load", function(){
+            var annos = [].slice.call(document.querySelectorAll(".mdn-anno"));
+            for(var i = 0; i < annos.length; i++) {
+                var anno = annos[i];
+                id = anno.getAttribute("data-dfn-id");
+                var dfn = document.querySelector("#" + id);
+                if (dfn !== null) {
+                    var rect = dfn.getBoundingClientRect(id);
+                    anno.style.top = (window.scrollY + rect.top) + "px";
+                    /* See https://domspec.herokuapp.com/#dom-event-cancelable
+                     * for an example of a spec that defines multiple terms in
+                     * the same sentence on the same line. In such cases, we
+                     * need to offset the vertical positioning of each Nth anno
+                     * for that term, to prevent the annos from being placed
+                     * exactly on top of the previous ones at that position. */
+                    var top = anno.style.top;
+                    var offset = 10 * (document.querySelectorAll("[style='top: " + top + ";']").length - 1)
+                    anno.style.top = (Number(top.slice(0, -2)) + offset) + "px";
+                } else {
+                    console.error('MDN anno references non-existent element ID "%s".%o', id, anno);
+                }
+            }
+        });
+        document.body.addEventListener("click", function(e) {
+            if(e.target.parentNode.classList.contains("mdn-anno-btn")) {
+                e.target.parentNode.parentNode.classList.toggle("wrapped");
+            }
+        });'''  # noqa
+
+    # FIXME: Update the Edge logo URL when we get
+    #       https://github.com/whatwg/whatwg.org/pull/267 resolved
+    doc.extraStyles["style-mdn-anno"] = '''
+        @media (max-width: 767px) { .mdn-anno { opacity: .1 } }
+        .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; top: auto; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; overflow-wrap: normal; word-wrap: normal; }
+        .mdn-anno:not(.wrapped) { opacity: 1}
+        .mdn-anno:hover { z-index: 9 }
+        .mdn-anno.wrapped { min-width: 0 }
+        .mdn-anno.wrapped > :not(button) { display: none; }
+        .mdn-anno > .mdn-anno-btn { cursor: pointer; border: none; color: #000; background: transparent; margin: -8px; outline: none; }
+        .mdn-anno > .mdn-anno-btn > .less-than-two-engines-flag { color: red; padding-right: 2px; }
+        .mdn-anno > .mdn-anno-btn > .all-engines-flag { color: green; padding-right: 2px; }
+        .mdn-anno > .mdn-anno-btn > span { color: #fff; background-color: #000; font-weight: normal; font-family: zillaslab, Palatino, "Palatino Linotype", serif; padding: 2px 3px 0px 3px; line-height: 1.3em; vertical-align: top; }
+        .mdn-anno > .feature { margin-top: 2px; }
+        .mdn-anno > .feature:not(:first-of-type) { border-top: 1px solid #999; margin-top: 6px; padding-top: 2px; }
+        .mdn-anno > .feature > .less-than-two-engines-text { color: red }
+        .mdn-anno > .feature > .all-engines-text { color: green }
+        .mdn-anno > .feature > p { font-size: .75em; margin-top: 6px; margin-bottom: 0; }
+        .mdn-anno > .feature > p + p { margin-top: 0; }
+        .mdn-anno > .feature > .support { display: block; font-size: 0.6em; margin: 0; padding: 0; margin-top: 2px }
+        .mdn-anno > .feature > .support + div { padding-top: 0.5em; }
+        .mdn-anno > .feature > .support > hr { display: block; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }
+        .mdn-anno > .feature > .support > hr::before { content: ""; }
+        .mdn-anno > .feature > .support > span { padding: 0.2em 0; display: block; display: table; }
+        .mdn-anno > .feature > .support > span.no { color: #CCCCCC; filter: grayscale(100%); }
+        .mdn-anno > .feature > .support > span.no::before { opacity: 0.5; }
+        .mdn-anno > .feature > .support > span:first-of-type { padding-top: 0.5em; }
+        .mdn-anno > .feature > .support > span > span { padding: 0 0.5em; display: table-cell; vertical-align: top; }
+        .mdn-anno > .feature > .support > span > span:first-child { width: 100%; }
+        .mdn-anno > .feature > .support > span > span:last-child { width: 100%; white-space: pre; padding: 0; }
+        .mdn-anno > .feature > .support > span::before { content: ' '; display: table-cell; min-width: 1.5em; height: 1.5em; background: no-repeat center center; background-size: contain; text-align: right; font-size: 0.75em; font-weight: bold; }
+        .mdn-anno > .feature > .support > .chrome_android::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+        .mdn-anno > .feature > .support > .firefox_android::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+        .mdn-anno > .feature > .support > .chrome::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+        .mdn-anno > .feature > .support > .edge_blink::before { background-image: url(https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_16x16.png); }
+        .mdn-anno > .feature > .support > .edge::before { background-image: url(https://resources.whatwg.org/browser-logos/edge.svg); }
+        .mdn-anno > .feature > .support > .firefox::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+        .mdn-anno > .feature > .support > .ie::before { background-image: url(https://resources.whatwg.org/browser-logos/ie.png); }
+        .mdn-anno > .feature > .support > .safari_ios::before { background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg); }
+        .mdn-anno > .feature > .support > .nodejs::before { background-image: url(https://nodejs.org/static/images/favicons/favicon.ico); }
+        .mdn-anno > .feature > .support > .opera_android::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+        .mdn-anno > .feature > .support > .opera::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+        .mdn-anno > .feature > .support > .safari::before { background-image: url(https://resources.whatwg.org/browser-logos/safari.png); }
+        .mdn-anno > .feature > .support > .samsunginternet_android::before { background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg); }
+        .mdn-anno > .feature > .support > .webview_android::before { background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png); }
+        .name-slug-mismatch { color: red }
+        '''  # noqa
+    charactersDisallowedInSelectors = "!\"#$%&'()*+,./:;<=>?@[\]^`{|}~"
+
+    try:
+        # TODO: If may turn out that for some specs, in order to make Bikeshed
+        # match the right filename from https://github.com/w3c/mdn-spec-links,
+        # we need to add an option for controlling whether or not it looks for
+        # a version-numbered filename.
+        specShortname = doc.md.shortname
+        vSpecShortname = doc.md.vshortname
+        p = os.path.join(config.scriptPath("spec-data", "mdnspeclinks",
+                                           specShortname + ".json"))
+        pV = os.path.join(config.scriptPath("spec-data", "mdnspeclinks",
+                                            vSpecShortname + ".json"))
+        p = pV if os.path.exists(pV) else p
+        with io.open(p, "r", encoding="utf-8") as fh:
+            data = json.loads(unicode(fh.read()), encoding="utf-8",
+                              object_pairs_hook=OrderedDict)
+            for elementID in data.keys():
+                # Some specs have IDs with characters not allowed in selectors;
+                # e.g., https://xhr.spec.whatwg.org/#the-abort()-method
+                escapedElementID = elementID
+                # FIXME: There must be a more efficient/idiomatic way to do this
+                for char in elementID:
+                    if char in charactersDisallowedInSelectors:
+                        escapedElementID = \
+                            escapedElementID.replace(char, "\\" + char)
+                # TODO: This find() is expensive, but if we add an anno to the
+                # document with a reference to an ID that doesn't actually exist
+                # in the document, the anno won't actually get displayed next to
+                # whatever feature in the spec it's intended to annotate...
+                features = data[elementID]
+                anno = E.aside({"class": "mdn-anno wrapped", "data-deco": ""})
+                mdnButton = E.button({"class": "mdn-anno-btn"})
+                mdnLogo = E.span("MDN")
+                appendChild(anno, mdnButton)
+                anno.set("data-dfn-id", escapedElementID)
+                appendChild(doc.body, anno)
+                lessThanTwoEngines = 0
+                onlyTwoEngines = 0
+                allEngines = 0
+                for feature in features:
+                    if find("#" + escapedElementID, doc) is None:
+                        mdnSuggest = ""
+                        if "slug" in feature:
+                            mdnSuggest = " Update " + mdnBaseUrl \
+                                + feature["slug"] + " Specifications table?"
+                        warn("No \"{0}\" ID found." + mdnSuggest, elementID)
+                        continue
+                    if "engines" in feature:
+                        engines = feature["engines"]
+                        if engines < 2:
+                            lessThanTwoEngines = lessThanTwoEngines + 1
+                        elif engines == 2:
+                            onlyTwoEngines = onlyTwoEngines + 1
+                        elif engines >= len(browsersProvidingCurrentEngines):
+                            allEngines = allEngines + 1l
+                    featureDiv = mdnPanelFor(feature, mdnBaseUrl, bcdBaseUrl,
+                                             nameFromCodeName,
+                                             browsersProvidingCurrentEngines,
+                                             browsersWithBorrowedEngines,
+                                             browsersWithRetiredEngines,
+                                             browsersForMobileDevices)
+                    appendChild(anno, featureDiv)
+                if lessThanTwoEngines > 0:
+                    appendChild(mdnButton,
+                                E.b({"class": "less-than-two-engines-flag",
+                                     "title": "This feature is in less than" +
+                                     " two current engines."}, u"\u26A0"))
+                elif allEngines > 0 \
+                        and lessThanTwoEngines == 0 \
+                        and onlyTwoEngines == 0:
+                    appendChild(mdnButton,
+                                E.b({"class": "all-engines-flag",
+                                     "title": "This feature is in" +
+                                     " all current engines."}, u"\u2714"))
+                appendChild(mdnButton, mdnLogo)
+    except Exception as e:
+        warn("Couldn't load MDN Spec Links data for this spec.\n{0}", e)
+        return
+
+
+def addSupportRow(browserCodeName, nameFromCodeName, support, supportData):
+    if browserCodeName not in support:
+        return
+    isEdgeLegacy = True if browserCodeName == "edge" else False
+    isIE = True if browserCodeName == "ie" else False
+    versionAdded = None
+    versionRemoved = None
+    minVersion = None
+    thisBrowserSupport = support[browserCodeName]
+    if isinstance(thisBrowserSupport, dict):
+        if "version_added" in thisBrowserSupport:
+            versionAdded = thisBrowserSupport["version_added"]
+        if "version_removed" in thisBrowserSupport:
+            versionRemoved = thisBrowserSupport["version_removed"]
+    if isinstance(thisBrowserSupport, list):
+        if "version_added" in thisBrowserSupport[0]:
+            versionAdded = thisBrowserSupport[0]["version_added"]
+        if "version_removed" in thisBrowserSupport[0]:
+            versionRemoved = thisBrowserSupport[0]["version_removed"]
+    statusCode = "n"
+    if versionAdded is None:
+        minVersion = "?"
+    elif versionAdded is False:
+        minVersion = "None"
+    elif versionAdded is True:
+        minVersion = "Yes"
+        statusCode = "y"
+    else:
+        if versionRemoved is None:
+            statusCode = "y"
+            minVersion = versionAdded + "+"
+            if (isEdgeLegacy and versionAdded == "18"):
+                minVersion = "18"
+            if (isIE and versionAdded == "11"):
+                minVersion = "11"
+        else:
+            statusCode = "n"
+            if versionAdded is not None:
+                minVersion = versionAdded + u"\u2013" + versionRemoved
+            else:
+                minVersion = "None"
+    browserFullName = nameFromCodeName[browserCodeName]
+    appendChild(supportData, browserCompatSpan(browserCodeName, browserFullName,
+                                               statusCode, minVersion))
+
+
+def mdnPanelFor(feature, mdnBaseUrl, bcdBaseUrl, nameFromCodeName,
+                browsersProvidingCurrentEngines, browsersWithBorrowedEngines,
+                browsersWithRetiredEngines, browsersForMobileDevices):
+    featureDiv = E.div({"class": "feature"})
+    featureName = ""
+    if "name" in feature:
+        featureName = feature["name"]
+    if "slug" in feature:
+        slug = feature["slug"]
+        displaySlug = slug.split("/", 1)[1]
+        title = ""
+        if "summary" in feature:
+            title = feature["summary"]
+        mdnURL = mdnBaseUrl + slug
+        nameFromSlug = slug.rsplit("/", 1)[-1]
+        if featureName is not None and featureName != "" \
+                and not featureName.startswith("input-") \
+                and featureName != nameFromSlug:
+            bcdSuggest = ""
+            if "filename" in feature and feature["filename"] is not None:
+                bcdSuggest = \
+                    " Update %s%s file?" % (bcdBaseUrl, feature["filename"])
+            warn("BCD \"{0}\" feature has mismatched MDN URL {1}." + bcdSuggest,
+                 featureName, mdnURL)
+            slugLink = E.a({"class": "name-slug-mismatch", "href": mdnURL,
+                            "title": title}, featureName)
+        else:
+            slugLink = E.a({"href": mdnURL, "title": title}, displaySlug)
+        slugPara = E.p(slugLink)
+        appendChild(featureDiv, slugPara)
+    if "engines" in feature:
+        engines = feature["engines"]
+        enginesPara = None
+        if engines == 0:
+            enginesPara = E.p({"class": "less-than-two-engines-text"},
+                              "In no current engines.")
+        elif engines == 1:
+            enginesPara = E.p({"class": "less-than-two-engines-text"},
+                              "In only one current engine.")
+        elif engines >= len(browsersProvidingCurrentEngines):
+            enginesPara = E.p({"class": "all-engines-text"},
+                              "In all current engines.")
+        if enginesPara is not None:
+            appendChild(featureDiv, enginesPara)
+    supportData = E.div({"class": "support"})
+    appendChild(featureDiv, supportData)
+    support = feature["support"]
+    for browserCodeName in browsersProvidingCurrentEngines:
+        addSupportRow(browserCodeName, nameFromCodeName, support, supportData)
+    appendChild(supportData, E.hr())
+    for browserCodeName in browsersWithBorrowedEngines:
+        addSupportRow(browserCodeName, nameFromCodeName, support, supportData)
+    appendChild(supportData, E.hr())
+    for browserCodeName in browsersWithRetiredEngines:
+        addSupportRow(browserCodeName, nameFromCodeName, support, supportData)
+    appendChild(supportData, E.hr())
+    for browserCodeName in browsersForMobileDevices:
+        addSupportRow(browserCodeName, nameFromCodeName, support, supportData)
+    if "nodejs" in support:
+        appendChild(supportData, E.hr())
+        addSupportRow("nodejs", nameFromCodeName, support, supportData)
+    return featureDiv
+
+
+def browserCompatSpan(browserCodeName, browserFullName, statusCode, minVersion):
+    # browserCodeName: e.g. "chrome"
+    # browserFullName: e.g. "Chrome for Android"
+    statusClass = {"y": "yes", "n": "no"}[statusCode]
+    outer = E.span({"class": browserCodeName + " " + statusClass})
+    appendChild(outer, E.span({}, browserFullName))
+    appendChild(outer, E.span({}, minVersion))
+    return outer

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -75,6 +75,7 @@ class MetadataManager:
         self.ignoredTerms = []
         self.ignoredVars = []
         self.includeCanIUsePanels = False
+        self.includeMdnPanels = False
         self.indent = 4
         self.inferCSSDfns = False
         self.informativeClasses = []
@@ -987,6 +988,7 @@ knownKeys = {
     "Ignored Terms": Metadata("Ignored Terms", "ignoredTerms", joinList, parseCommaSeparated),
     "Ignored Vars": Metadata("Ignored Vars", "ignoredVars", joinList, parseCommaSeparated),
     "Include Can I Use Panels": Metadata("Include Can I Use Panels", "includeCanIUsePanels", joinValue, parseBoolean),
+    "Include Mdn Panels": Metadata("Include Mdn Panels", "includeMdnPanels", joinValue, parseBoolean),
     "Indent": Metadata("Indent", "indent", joinValue, parseInteger),
     "Infer Css Dfns": Metadata("Infer Css Dfns", "inferCSSDfns", joinValue, parseBoolean),
     "Informative Classes": Metadata("Informative Classes", "informativeClasses", joinList, parseCommaSeparated),

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1151,9 +1151,9 @@ def cleanupHTML(doc):
             el.set("data-noexport", "")
 
         if doc.md.slimBuildArtifact:
-            # Remove *all* data- attributes.
+            # Remove *all* data- attributes, except data-mdn-for attributes
             for attrName in el.attrib:
-                if attrName.startswith("data-"):
+                if attrName.startswith("data-") and attrName != "data-mdn-for":
                     removeAttr(el, attrName)
     for el in strayHeadEls:
         head.append(el)

--- a/bikeshed/update/main.py
+++ b/bikeshed/update/main.py
@@ -7,6 +7,7 @@ from . import updateBackRefs
 from . import updateCrossRefs
 from . import updateBiblio
 from . import updateCanIUse
+from . import updateMdnSpecLinks
 from . import updateLinkDefaults
 from . import updateTestSuites
 from . import updateLanguages
@@ -16,7 +17,7 @@ from .. import config
 from ..messages import *
 
 
-def update(anchors=False, backrefs=False, biblio=False, caniuse=False, linkDefaults=False, testSuites=False, languages=False, wpt=False, path=None, dryRun=False, force=False):
+def update(anchors=False, backrefs=False, biblio=False, caniuse=False, mdn=False, linkDefaults=False, testSuites=False, languages=False, wpt=False, path=None, dryRun=False, force=False):
     if path is None:
         path = config.scriptPath("spec-data")
 
@@ -28,14 +29,15 @@ def update(anchors=False, backrefs=False, biblio=False, caniuse=False, linkDefau
             force = True
     if force:
         # If all are False, update everything
-        if  anchors == backrefs == biblio == caniuse == linkDefaults == testSuites == languages == wpt == False:
-            anchors  = backrefs  = biblio  = caniuse  = linkDefaults  = testSuites  = languages  = wpt  = True
+        if  anchors == backrefs == biblio == caniuse == mdn == linkDefaults == testSuites == languages == wpt == False:
+            anchors  = backrefs  = biblio  = caniuse  = mdn = linkDefaults  = testSuites  = languages  = wpt  = True
 
         touchedPaths = {
             "anchors": updateCrossRefs.update(path=path, dryRun=dryRun) if anchors else None,
             "backrefs": updateBackRefs.update(path=path, dryRun=dryRun) if backrefs else None,
             "biblio": updateBiblio.update(path=path, dryRun=dryRun) if biblio else None,
             "caniuse": updateCanIUse.update(path=path, dryRun=dryRun) if caniuse else None,
+            "mdnspeclinks": updateMdnSpecLinks.update(path=path, dryRun=dryRun) if mdn else None,
             "linkDefaults": updateLinkDefaults.update(path=path, dryRun=dryRun) if linkDefaults else None,
             "testSuites": updateTestSuites.update(path=path, dryRun=dryRun) if testSuites else None,
             "languages": updateLanguages.update(path=path, dryRun=dryRun) if languages else None,
@@ -113,6 +115,9 @@ def cleanupFiles(root, touchedPaths, dryRun=False):
         deletableFiles.extend(["caniuse.json"])
         deletableFolders.extend(["caniuse"])
         paths.update(touchedPaths["caniuse"])
+    if touchedPaths["mdnspeclinks"] is not None:
+        deletableFolders.extend(["mdnspeclinks"])
+        paths.update(touchedPaths["mdnspeclinks"])
 
     say("Cleaning up old data files...")
     oldPaths = []

--- a/bikeshed/update/manifest.py
+++ b/bikeshed/update/manifest.py
@@ -49,7 +49,8 @@ knownFolders = [
     "anchors",
     "biblio",
     "headings",
-    "caniuse"
+    "caniuse",
+    "mdnspeclinks"
 ]
 
 

--- a/bikeshed/update/updateMdnSpecLinks.py
+++ b/bikeshed/update/updateMdnSpecLinks.py
@@ -52,7 +52,7 @@ def update(path, dryRun=False):
                 try:
                     with closing(urllib2.urlopen(mdnSpecLinksBaseURL +
                                                  specFilename)) as fh:
-                        fileContents = fh.read()
+                        fileContents = fh.read().decode('utf-8')
                 except Exception as e:
                     die("Couldn't download the MDN Spec Links " + specFilename +
                         " file.\n{0}", e)

--- a/bikeshed/update/updateMdnSpecLinks.py
+++ b/bikeshed/update/updateMdnSpecLinks.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, unicode_literals
 import io
 import json
 import os

--- a/bikeshed/update/updateMdnSpecLinks.py
+++ b/bikeshed/update/updateMdnSpecLinks.py
@@ -30,7 +30,10 @@ def update(path, dryRun=False):
     writtenPaths = set()
     if not dryRun:
         try:
-            p = os.path.join(path, "mdnspeclinks", "SPECMAP.json")
+            mdnSpecLinksDir = os.path.join(path, "mdnspeclinks")
+            if not os.path.exists(mdnSpecLinksDir):
+                os.makedirs(mdnSpecLinksDir)
+            p = os.path.join(mdnSpecLinksDir, "SPECMAP.json")
             writtenPaths.add(p)
             with io.open(p, 'w', encoding="utf-8") as fh:
                 fh.write(unicode(json.dumps(data, indent=1, ensure_ascii=False,
@@ -43,7 +46,7 @@ def update(path, dryRun=False):
             #     ...
             # }
             for specFilename in data.values():
-                p = os.path.join(path, "mdnspeclinks", specFilename)
+                p = os.path.join(mdnSpecLinksDir, specFilename)
                 writtenPaths.add(p)
                 mdnSpecLinksBaseURL = "https://w3c.github.io/mdn-spec-links/"
                 try:

--- a/bikeshed/update/updateMdnSpecLinks.py
+++ b/bikeshed/update/updateMdnSpecLinks.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, unicode_literals
+import io
+import json
+import os
+import urllib2
+from collections import OrderedDict
+from contextlib import closing
+
+from ..messages import *  # noqa
+
+
+def update(path, dryRun=False):
+    say("Downloading MDN Spec Links data...")
+    specMapURL = "https://w3c.github.io/mdn-spec-links/SPECMAP.json"
+    try:
+        with closing(urllib2.urlopen(specMapURL)) as fh:
+            jsonString = fh.read()
+    except Exception as e:
+        die("Couldn't download the MDN Spec Links data.\n{0}", e)
+        return
+
+    try:
+        data = json.loads(unicode(jsonString), encoding="utf-8",
+                          object_pairs_hook=OrderedDict)
+    except Exception as e:
+        die("The MDN Spec Links data wasn't valid JSON for some reason." +
+            " Try downloading again?\n{0}", e)
+        return
+    writtenPaths = set()
+    if not dryRun:
+        try:
+            p = os.path.join(path, "mdnspeclinks", "SPECMAP.json")
+            writtenPaths.add(p)
+            with io.open(p, 'w', encoding="utf-8") as fh:
+                fh.write(unicode(json.dumps(data, indent=1, ensure_ascii=False,
+                                            sort_keys=False)))
+            # SPECMAP.json format:
+            # {
+            #     "https://compat.spec.whatwg.org/": "compat.json",
+            #     "https://console.spec.whatwg.org/": "console.json",
+            #     "https://dom.spec.whatwg.org/": "dom.json",
+            #     ...
+            # }
+            for specFilename in data.values():
+                p = os.path.join(path, "mdnspeclinks", specFilename)
+                writtenPaths.add(p)
+                mdnSpecLinksBaseURL = "https://w3c.github.io/mdn-spec-links/"
+                try:
+                    with closing(urllib2.urlopen(mdnSpecLinksBaseURL +
+                                                 specFilename)) as fh:
+                        fileContents = fh.read()
+                except Exception as e:
+                    die("Couldn't download the MDN Spec Links " + specFilename +
+                        " file.\n{0}", e)
+                    return
+                with io.open(p, 'w', encoding='utf-8') as fh:
+                    print "    " + specFilename
+                    fh.write(unicode(fileContents))
+        except Exception as e:
+            die("Couldn't save MDN Spec Links data to disk.\n{0}", e)
+            return
+    say("Success!")
+    return writtenPaths

--- a/bikeshed/update/updateMdnSpecLinks.py
+++ b/bikeshed/update/updateMdnSpecLinks.py
@@ -3,7 +3,7 @@ from __future__ import division, unicode_literals
 import io
 import json
 import os
-import urllib2
+import urllib.request
 from collections import OrderedDict
 from contextlib import closing
 
@@ -14,14 +14,14 @@ def update(path, dryRun=False):
     say("Downloading MDN Spec Links data...")
     specMapURL = "https://w3c.github.io/mdn-spec-links/SPECMAP.json"
     try:
-        with closing(urllib2.urlopen(specMapURL)) as fh:
+        with closing(urllib.request.urlopen(specMapURL)) as fh:
             jsonString = fh.read()
     except Exception as e:
         die("Couldn't download the MDN Spec Links data.\n{0}", e)
         return
 
     try:
-        data = json.loads(unicode(jsonString), encoding="utf-8",
+        data = json.loads(jsonString, encoding="utf-8",
                           object_pairs_hook=OrderedDict)
     except Exception as e:
         die("The MDN Spec Links data wasn't valid JSON for some reason." +
@@ -36,8 +36,8 @@ def update(path, dryRun=False):
             p = os.path.join(mdnSpecLinksDir, "SPECMAP.json")
             writtenPaths.add(p)
             with io.open(p, 'w', encoding="utf-8") as fh:
-                fh.write(unicode(json.dumps(data, indent=1, ensure_ascii=False,
-                                            sort_keys=False)))
+                fh.write(json.dumps(data, indent=1, ensure_ascii=False,
+                                    sort_keys=False))
             # SPECMAP.json format:
             # {
             #     "https://compat.spec.whatwg.org/": "compat.json",
@@ -50,16 +50,16 @@ def update(path, dryRun=False):
                 writtenPaths.add(p)
                 mdnSpecLinksBaseURL = "https://w3c.github.io/mdn-spec-links/"
                 try:
-                    with closing(urllib2.urlopen(mdnSpecLinksBaseURL +
-                                                 specFilename)) as fh:
+                    with closing(urllib.request.urlopen(mdnSpecLinksBaseURL +
+                                                        specFilename)) as fh:
                         fileContents = fh.read().decode('utf-8')
                 except Exception as e:
                     die("Couldn't download the MDN Spec Links " + specFilename +
                         " file.\n{0}", e)
                     return
                 with io.open(p, 'w', encoding='utf-8') as fh:
-                    print "    " + specFilename
-                    fh.write(unicode(fileContents))
+                    print("    " + specFilename)
+                    fh.write(fileContents)
         except Exception as e:
             die("Couldn't save MDN Spec Links data to disk.\n{0}", e)
             return

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1286,6 +1286,12 @@ There are several additional optional keys:
 		even when it's not necessary to disambiguate things,
 		so it's off by default.
 	* <dfn>Max ToC Depth</dfn> specifies the maximum depth you want the ToC to generate to. It can be the value "none", meaning generate the ToC normally, or an integer between 1 and 5. It defaults to "none".
+	* <dfn>Include MDN Panels</dfn> is a <a>boolish</a> that specifies whether to include \[MDN](https://developer.mozilla.org/en-US/docs/Web) panels or not.
+		If it's turned on, MDN panels will be added automatically in output,
+		positioned to line up with the elements which define the features the panels annotate.
+		Each MDN panel includes a hyperlink to the MDN article for the feature it annotates,
+		as well as browser-support details for the feature
+		(similar to what's shown in the panels added when [=Include Can I Use Panels=] is enabled).
 	* Several keys relate to the [Can I Use](https://caniuse.com/) project:
 		* <dfn>Include Can I Use Panels</dfn> is a <a>boolish</a> that specifies whether to include [Can I Use](https://caniuse.com/) usage-data panels or not. If it's turned on, elements can take a `caniuse="featureID"` attribute, where the `featureID` is the value specified in the url like `https://caniuse.com/#feat=FEATUREIDHERE`, and the panel will be positioned to line up with that element.
 			(When possible, put this on the corresponding <{dfn}>,


### PR DESCRIPTION
This change adds a new feature for automatically including MDN panels (annotations) in spec output. The feature is controlled by the "Include Mdn Panels" boolish.

Sample output for several specs:

* https://domspec.herokuapp.com/
* https://fetchspec.herokuapp.com/
* https://streamsspec.herokuapp.com/
* https://urlspec.herokuapp.com/
* https://xhrspec.herokuapp.com
* https://encodingspec.herokuapp.com/
* https://webidlspec.herokuapp.com/
* https://serviceworkerspec.herokuapp.com/docs/
cc @annevk @domenic