### PR TITLE
EDs expect to become Notes

### DIFF
--- a/bikeshed/boilerplate/ping/status-ED.include
+++ b/bikeshed/boilerplate/ping/status-ED.include
@@ -10,7 +10,7 @@
   <p>
     This document was published by the
     <a href="https://www.w3.org/2019/privacy/">Privacy Interest Group</a> as an
-    [LONGSTATUS]. This document is intended to become a W3C Recommendation.
+    [LONGSTATUS]. This document is intended to become a W3C Interest Group Note.
     Publication as an [LONGSTATUS] does not imply endorsement by the
     <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a
     draft document and may be updated, replaced or obsoleted by other documents


### PR DESCRIPTION
Since interest groups can't publish recommendations per the 2019 process: https://www.w3.org/2019/Process-20190301/#GAGeneral

Thanks @hober