### PR TITLE
Documentation: remove command line prefixes

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -64,7 +64,7 @@ Linux steps {#install-linux}
 ----------------------------
 
 ```
-$ sudo apt-get install python2.7 python-dev python-pip python-wheel libxslt1-dev libxml2-dev
+sudo apt-get install python2.7 python-dev python-pip python-wheel libxslt1-dev libxml2-dev
 ```
 
 The `apt-get` command works on Debian-based systems like Ubuntu; if you work on some other type of system, and can figure out how to get things working on your own, let me know and I'll add instructions for your system.
@@ -72,14 +72,14 @@ The `apt-get` command works on Debian-based systems like Ubuntu; if you work on 
 Then, we'll need to install lxml and Pygments.
 
 ```
-$ sudo pip install pygments
-$ sudo pip install lxml
+sudo pip install pygments
+sudo pip install lxml
 ```
 
 **Important**: If this command reports that you already have lxml, instead run:
 
 ```
-$ sudo pip install lxml --upgrade
+sudo pip install lxml --upgrade
 ```
 
 That'll spew a lot of console trash, but don't worry about it.
@@ -87,7 +87,7 @@ That'll spew a lot of console trash, but don't worry about it.
 In some installations you'll need to also upgrade `setuptools` for `html5lib`'s entertainment:
 
 ```
-$ sudo pip install lxml setuptools --upgrade
+sudo pip install lxml setuptools --upgrade
 ```
 
 From here, you can proceed to [[#install-common]].
@@ -135,7 +135,7 @@ xcode-select --install
 Install or update lxml and Pygments.
 
 ```
-$ pip install pygments lxml --upgrade
+pip install pygments lxml --upgrade
 ```
 
 That'll spew a lot of console trash, but don't worry about it.
@@ -183,11 +183,11 @@ This is how to set up bikeshed on your android phone or tablet using <a href="ht
 1. Install Termux from <a href="https://play.google.com/store/apps/details?id=com.termux">Google Play</a> or <a href="https://f-droid.org/repository/browse/?fdid=com.termux">F-Droid</a>.
 2. Install python, git, a c compiler, and the native dependencies:
 	```
-	$ apt install python2 python2-dev clang libxml2-dev libxslt-dev git
+	apt install python2 python2-dev clang libxml2-dev libxslt-dev git
 	```
 3. Install the Python dependencies:
 	```
-	$ pip2 install pygments lxml --upgrade
+	pip2 install pygments lxml --upgrade
 	```
 
 From here, you can proceed to [[#install-common]].
@@ -201,7 +201,7 @@ you can now install the Bikeshed repository itself.
 Run the following in your favorite command line:
 
 ```
-$ git clone https://github.com/tabatkins/bikeshed.git
+git clone https://github.com/tabatkins/bikeshed.git
 ```
 
 (This’ll download bikeshed to a `bikeshed` folder,
@@ -215,29 +215,29 @@ Finally, depending on your environment, run:
 : In a Virtualenv environment:
 ::
     ```
-    (venv) $ pip install --editable /path/to/cloned/bikeshed
-    (venv) $ bikeshed update
+    pip install --editable /path/to/cloned/bikeshed
+    bikeshed update
     ```
 
 : For Linux/OSX (Omit the `sudo` for OSX under Homebrew):
 ::
     ```
-    $ sudo pip install --editable /path/to/cloned/bikeshed
-    $ bikeshed update
+    sudo pip install --editable /path/to/cloned/bikeshed
+    bikeshed update
     ```
 
 : On Windows:
 ::
     ```
-    $ python -m pip install --editable /path/to/cloned/bikeshed
-    $ bikeshed update
+    python -m pip install --editable /path/to/cloned/bikeshed
+    bikeshed update
     ```
 
 : On Termux:
 ::
     ```
-    $ pip2 install --editable /path/to/cloned/bikeshed
-    $ bikeshed update
+    pip2 install --editable /path/to/cloned/bikeshed
+    bikeshed update
     ```
 
 This’ll install Bikeshed,
@@ -300,8 +300,8 @@ To update bikeshed to its latest version at any time,
 just enter Bikeshed’s folder and run:
 
 ```
-$ git pull --rebase
-$ bikeshed update
+git pull --rebase
+bikeshed update
 ```
 
 This’ll pull the latest version of Bikeshed,
@@ -618,7 +618,7 @@ On a Linux-like command line,
 it should be used like:
 
 ```
-$ bikeshed template > index.bs
+bikeshed template > index.bs
 ```
 
 `bikeshed echidna` {#cli-echidna}


### PR DESCRIPTION
Makes copy-and-paste easier and less error prone.