### PR TITLE
Tracking Vector documentation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2040,7 +2040,13 @@ Tracking Vectors {#tracking-vectors}
 A <a>tracking vector</a> can be annotated with the `tracking-vector` attribute on the enclosing element.
 This will result in a link containing an image being prepended to the element.
 
-<p tracking-vector>This is an example of an element annotated with that attribute.
+<div class=example id=example-tracking-vector>
+  <xmp highlight=html>
+    <p tracking-vector>This is an example of an element annotated with that attribute.
+  </xmp>
+
+  <p tracking-vector>This is an example of an element annotated with that attribute.
+</div>
 
 The various "Tracking Vector *" metadata keys can be used to customize the appearance of this annotation,
 though it's encouraged to leave those in their default state for a consistent appearance across standards.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1212,6 +1212,13 @@ There are several additional optional keys:
 		that specifies a common path prefix for all of the tests in your <{wpt}> elements.
 	* <dfn>WPT Display</dfn> takes the values "none" or "inline",
 		and specifies whether or not <{wpt}> elements display anything in the output document.
+	* <dfn>Tracking Vector Class</dfn> is the HTML `class` attribute value used on the link inserted in elements annotated with the `tracking-vector` attribute.
+	* <dfn>Tracking Vector Image</dfn> is an image URL that can be used to represent tracking vectors with an external image.
+		Otherwise an inline SVG is used. The image is a child of the aforementioned link.
+	* <dfn>Tracking Vector Image Width</dfn> is the width of the external image, if any.
+	* <dfn>Tracking Vector Image Height</dfn> is the height of the external image, if any.
+	* <dfn>Tracking Vector Alt Text</dfn> is the replacement text for the inline SVG or external image.
+	* <dfn>Tracking Vector Title</dfn> is the title for the inline SVG or external image.
 </ul>
 
 Note: A <dfn>boolish</dfn> value is a string representing a boolean value (true or false).
@@ -2025,6 +2032,18 @@ in case some things move to being part of syntax processing.
 For example, inline autolinking shorthands currently aren't,
 and so will work in include-raw substitutions,
 but that will change in the future.
+
+
+Tracking Vectors {#tracking-vectors}
+----------------
+
+A <a>tracking vector</a> can be annotated with the `tracking-vector` attribute on the enclosing element.
+This will result in a link containing an image being prepended to the element.
+
+<p tracking-vector>This is an example of an element annotated with that attribute.
+
+The various "Tracking Vector *" metadata keys can be used to customize the appearance of this annotation,
+though it's encouraged to leave those in their default state for a consistent appearance across standards.
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1221,9 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version cb95c65050328853ca53a105cdeb08fff91e3a62" name="generator">
+  <meta content="Bikeshed version 3fcf77dd022e78b9ba17d9e685243312927878e3" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="cb95c65050328853ca53a105cdeb08fff91e3a62" name="document-revision">
+  <meta content="3fcf77dd022e78b9ba17d9e685243312927878e3" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -3473,7 +3473,12 @@ but that will change in the future.</p>
    <h3 class="heading settled" data-level="5.12" id="tracking-vectors"><span class="secno">5.12. </span><span class="content">Tracking Vectors</span><a class="self-link" href="#tracking-vectors"></a></h3>
    <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#tracking-vector" id="ref-for-tracking-vector">tracking vector</a> can be annotated with the <code>tracking-vector</code> attribute on the enclosing element.
 This will result in a link containing an image being prepended to the element.</p>
-   <p><a class="tracking-vector" href="https://infra.spec.whatwg.org/#tracking-vector"><svg aria-label="(This is a tracking vector.)" height="64" role="img" width="46"><title>There is a tracking vector here.</title><use href="#b732b3fe"></use></svg></a> This is an example of an element annotated with that attribute. </p>
+   <div class="example" id="example-tracking-vector">
+    <a class="self-link" href="#example-tracking-vector"></a> 
+<pre class="highlight"><c- p>&lt;</c-><c- f>p</c-> <c- e>tracking-vector</c-><c- p>></c->This is an example of an element annotated with that attribute.
+</pre>
+    <p><a class="tracking-vector" href="https://infra.spec.whatwg.org/#tracking-vector"><svg aria-label="(This is a tracking vector.)" height="64" role="img" width="46"><title>There is a tracking vector here.</title><use href="#b732b3fe"></use></svg></a> This is an example of an element annotated with that attribute. </p>
+   </div>
    <p>The various "Tracking Vector *" metadata keys can be used to customize the appearance of this annotation,
 though it’s encouraged to leave those in their default state for a consistent appearance across standards.</p>
    <h2 class="heading settled" data-level="6" id="definitions"><span class="secno">6. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1221,8 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 1c30f364edf130f99c9528d3fcb3db571f91958f" name="generator">
+  <meta content="Bikeshed version 08e11a2e13bbb61fd770bb30f69e33b9f696a1c0" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
+  <meta content="08e11a2e13bbb61fd770bb30f69e33b9f696a1c0" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1538,7 +1539,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2020-01-15">15 January 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2020-01-17">17 January 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1553,7 +1554,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 15 January 2020,
+In addition, as of 17 January 2020,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1654,6 +1655,7 @@ Parts of this work may be from another specification document.  If so, those par
         <li><a href="#including-code"><span class="secno">5.11.1</span> <span class="content">Including Code Files</span></a>
         <li><a href="#including-raw"><span class="secno">5.11.2</span> <span class="content">Including Non-Bikeshed HTML/SVG/etc</span></a>
        </ol>
+      <li><a href="#tracking-vectors"><span class="secno">5.12</span> <span class="content">Tracking Vectors</span></a>
      </ol>
     <li>
      <a href="#definitions"><span class="secno">6</span> <span class="content">Definitions</span></a>
@@ -2820,6 +2822,19 @@ that specifies a common path prefix for all of the tests in your <code><a data-l
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-wpt-display">WPT Display</dfn> takes the values "none" or "inline",
 and specifies whether or not <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element①">wpt</a></code> elements display anything in the output document.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-class">Tracking Vector Class<a class="self-link" href="#metadata-tracking-vector-class"></a></dfn> is the HTML <code>class</code> attribute value used on the link inserted in elements annotated with the <code>tracking-vector</code> attribute.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image">Tracking Vector Image<a class="self-link" href="#metadata-tracking-vector-image"></a></dfn> is an image URL that can be used to represent tracking vectors with an external image.
+Otherwise an inline SVG is used. The image is a child of the aforementioned link.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-width">Tracking Vector Image Width<a class="self-link" href="#metadata-tracking-vector-image-width"></a></dfn> is the width of the external image, if any.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-image-height">Tracking Vector Image Height<a class="self-link" href="#metadata-tracking-vector-image-height"></a></dfn> is the height of the external image, if any.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-alt-text">Tracking Vector Alt Text<a class="self-link" href="#metadata-tracking-vector-alt-text"></a></dfn> is the replacement text for the inline SVG or external image.</p>
+    <li data-md>
+     <p><dfn data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-tracking-vector-title">Tracking Vector Title<a class="self-link" href="#metadata-tracking-vector-title"></a></dfn> is the title for the inline SVG or external image.</p>
    </ul>
    <p class="note" role="note"><span>Note:</span> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="boolish">boolish</dfn> value is a string representing a boolean value (true or false).
 The string "yes", "on", "true", and "y" all represent true values,
@@ -3455,6 +3470,12 @@ in case some things move to being part of syntax processing.
 For example, inline autolinking shorthands currently aren’t,
 and so will work in include-raw substitutions,
 but that will change in the future.</p>
+   <h3 class="heading settled" data-level="5.12" id="tracking-vectors"><span class="secno">5.12. </span><span class="content">Tracking Vectors</span><a class="self-link" href="#tracking-vectors"></a></h3>
+   <p>A <a data-link-type="dfn">tracking vector</a> can be annotated with the <code>tracking-vector</code> attribute on the enclosing element.
+This will result in a link containing an image being prepended to the element.</p>
+   <p><a class="tracking-vector" href="https://infra.spec.whatwg.org/#tracking-vector"><svg aria-label="(This is a tracking vector.)" height="64" role="img" width="46"><title>There is a tracking vector here.</title><use href="#b732b3fe"></use></svg></a> This is an example of an element annotated with that attribute. </p>
+   <p>The various "Tracking Vector *" metadata keys can be used to customize the appearance of this annotation,
+though it’s encouraged to leave those in their default state for a consistent appearance across standards.</p>
    <h2 class="heading settled" data-level="6" id="definitions"><span class="secno">6. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>
    <p>Defining a term is as easy as wrapping a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element⑤">dfn</a></code> element around it.
 Most of the time, this is all you’ll need to do -
@@ -5261,6 +5282,12 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
    <li><a href="#macro-title">[TITLE]</a><span>, in §11.3</span>
    <li><a href="#metadata-toggle-diffs">Toggle Diffs</a><span>, in §4</span>
    <li><a href="#metadata-tr">TR</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-alt-text">Tracking Vector Alt Text</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-class">Tracking Vector Class</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-image">Tracking Vector Image</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-image-height">Tracking Vector Image Height</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-image-width">Tracking Vector Image Width</a><span>, in §4</span>
+   <li><a href="#metadata-tracking-vector-title">Tracking Vector Title</a><span>, in §4</span>
    <li><a href="#metadata-translate-ids">Translate IDs</a><span>, in §4</span>
    <li><a href="#metadata-translation">Translation</a><span>, in §4</span>
    <li><a href="#metadata-url">URL</a><span>, in §4</span>
@@ -5838,3 +5865,8 @@ document.body.addEventListener("click", function(e) {
 
 });
 </script>
+  <svg style="display:none" viewBox="0 0 46 64">
+   <defs>
+    <path d="M2 23Q17 -16 40 12M1 35Q17 -20 43 20M2 40Q18 -19 44 25M3 43Q19 -16 45 29M5 46Q20 -12 45 32M5 49Q11 40 15 27T27 16T45 37M5 49Q15 38 19 25T34 27T44 41M6 52Q17 40 21 28T32 29T43 44M6 52Q21 42 23 31T30 32T42 47M7 54Q23 47 24 36T28 34T41 50M8 56Q26 50 26 35Q28 48 40 53M10 58Q24 54 27 45Q30 52 38 55M27 50Q28 53 36 57M25 52Q28 56 31 57M22 55L26 57M10 58L37 57M13 60L32 60M16 62L28 63" fill="none" id="b732b3fe" stroke="black" stroke-dasharray="3,2,35,2,20,2" stroke-linecap="round" stroke-linejoin="round"></path>
+   </defs>
+  </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1221,9 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 08e11a2e13bbb61fd770bb30f69e33b9f696a1c0" name="generator">
+  <meta content="Bikeshed version cb95c65050328853ca53a105cdeb08fff91e3a62" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="08e11a2e13bbb61fd770bb30f69e33b9f696a1c0" name="document-revision">
+  <meta content="cb95c65050328853ca53a105cdeb08fff91e3a62" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -3471,7 +3471,7 @@ For example, inline autolinking shorthands currently aren’t,
 and so will work in include-raw substitutions,
 but that will change in the future.</p>
    <h3 class="heading settled" data-level="5.12" id="tracking-vectors"><span class="secno">5.12. </span><span class="content">Tracking Vectors</span><a class="self-link" href="#tracking-vectors"></a></h3>
-   <p>A <a data-link-type="dfn">tracking vector</a> can be annotated with the <code>tracking-vector</code> attribute on the enclosing element.
+   <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#tracking-vector" id="ref-for-tracking-vector">tracking vector</a> can be annotated with the <code>tracking-vector</code> attribute on the enclosing element.
 This will result in a link containing an image being prepended to the element.</p>
    <p><a class="tracking-vector" href="https://infra.spec.whatwg.org/#tracking-vector"><svg aria-label="(This is a tracking vector.)" height="64" role="img" width="46"><title>There is a tracking vector here.</title><use href="#b732b3fe"></use></svg></a> This is an example of an element annotated with that attribute. </p>
    <p>The various "Tracking Vector *" metadata keys can be used to customize the appearance of this annotation,
@@ -5476,6 +5476,12 @@ Autolink Shortcuts That Work Anywhere: the l element</a>
     <li><a href="#ref-for-xmp③">5.6.2. xmp To Avoid Escaping Markup</a> <a href="#ref-for-xmp④">(2)</a> <a href="#ref-for-xmp⑤">(3)</a> <a href="#ref-for-xmp⑥">(4)</a> <a href="#ref-for-xmp⑦">(5)</a> <a href="#ref-for-xmp⑧">(6)</a> <a href="#ref-for-xmp⑨">(7)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-tracking-vector">
+   <a href="https://infra.spec.whatwg.org/#tracking-vector">https://infra.spec.whatwg.org/#tracking-vector</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-tracking-vector">5.12. Tracking Vectors</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-elementdef-svg">
    <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
@@ -5512,6 +5518,11 @@ Autolink Shortcuts That Work Anywhere: the l element</a>
      <li><span class="dfn-paneled" id="term-for-xmp" style="color:initial">xmp</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-tracking-vector" style="color:initial">tracking vector</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-elementdef-svg" style="color:initial">svg</span>
@@ -5522,6 +5533,8 @@ Autolink Shortcuts That Work Anywhere: the l element</a>
   <dl>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]


### PR DESCRIPTION
This needs #1587 to land first and then I'll regenerate. It would also be better if Infra's tracking vector definition was indexed so no warnings are generated.