### PR TITLE
Replace trailing with leading in documentation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2098,7 +2098,7 @@ or by manually specifying the linking text on the <{a}>.
 
 In addition to English variations,
 these "conjugations" handle some IDL variations as well.
-For example, IDL terms that match an IDL keyword must be defined in IDL with a trailing underscore,
+For example, IDL terms that match an IDL keyword must be defined in IDL with a leading underscore,
 to avoid grammatical ambiguities,
 but actually define the term without the underscore.
 You can link to the term with either syntax.


### PR DESCRIPTION
Currently, the documentation about IDL keyword says trailing which should be replaced with leading.
Closes #1488 