### PR TITLE
Include the W3C stylesheet in CG documents.

### DIFF
--- a/bikeshed/boilerplate/privacycg/header.include
+++ b/bikeshed/boilerplate/privacycg/header.include
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width">
 <style data-fill-with="stylesheet">
 </style>
+<link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 <body>
 <header>
 <p data-fill-with="logo"></p>

--- a/bikeshed/boilerplate/ricg/header.include
+++ b/bikeshed/boilerplate/ricg/header.include
@@ -6,6 +6,7 @@
   <title>[TITLE]</title>
   <style data-fill-with="stylesheet">
   </style>
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/boilerplate/sacg/header.include
+++ b/bikeshed/boilerplate/sacg/header.include
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <style data-fill-with="stylesheet">
   </style>
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/boilerplate/web-bluetooth-cg/header.include
+++ b/bikeshed/boilerplate/web-bluetooth-cg/header.include
@@ -6,6 +6,7 @@
   <title>[TITLE]</title>
   <style data-fill-with="stylesheet">
   </style>
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">


### PR DESCRIPTION
I noticed that https://webbluetoothcg.github.io/web-bluetooth/ was missing the background we were trying to get from #1602, and it turns out that the WICG was the only group adding the right stylesheet. This PR fixes that problem, but it looks error-prone to hope all the CGs write their `header.include` correctly.