### PR TITLE
MANIFEST.in should include dirs recursively

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
 include README.md
 include Bikeshed.tmLanguage
-include docs/*
-include bikeshed/include/*
-include bikeshed/spec-data/*
+graft docs
+graft bikeshed/spec-data
 include bikeshed/widlparser/README.md
-


### PR DESCRIPTION
`bikeshed/include` no longer exists.

The other two directories should be recursively included rather than just including their direct children.

This shouldn't have any affect on editable installs (given data files aren't installed), but should fix `pip install bikeshed` (and, assuming Python and other system library dependencies are met, should make `pip install git+https://github.com/tabatkins/bikeshed` work).