### PR TITLE
[CI/DevOps] Update Docker/CI configs to use Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
- - "2.7"
+ - "3.7"
 before_install:
  - pip install flake8
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-jessie as base
+FROM python:3.7-stretch as base
 
 # Get the latest spec-data, then cache it so we don't have to redo this on every rebuild
 from base as specdata


### PR DESCRIPTION
The tests are failing on `python3` branch as we are trying to run python3 programs on a python2.7 system. I have updated the `Dockerfile` and `.travis.yml` to correct this error.

**Some updates are still required, needs discussion**