### PR TITLE
PING is an Interest Group; their EDs are not on the REC track.

### DIFF
--- a/bikeshed/boilerplate/ping/status-ED.include
+++ b/bikeshed/boilerplate/ping/status-ED.include
@@ -38,12 +38,7 @@
     href="https://www.w3.org/2004/01/pp-impl/52497/status"
     rel="disclosure">public list of any patent disclosures</a> made in
     connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent. An individual who has actual knowledge
-    of a patent which the individual believes contains <a
-    href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential
-    Claim(s)</a> must disclose the information in accordance with <a
-    href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6
-    of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+    instructions for disclosing a patent.
   </p>
 
   <p>

--- a/bikeshed/boilerplate/ping/status-ED.include
+++ b/bikeshed/boilerplate/ping/status-ED.include
@@ -10,7 +10,7 @@
   <p>
     This document was published by the
     <a href="https://www.w3.org/2019/privacy/">Privacy Interest Group</a> as an
-    [LONGSTATUS]. This document is intended to become a W3C Recommendation.
+    [LONGSTATUS].
     Publication as an [LONGSTATUS] does not imply endorsement by the
     <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a
     draft document and may be updated, replaced or obsoleted by other documents


### PR DESCRIPTION
In bfa9581 I remove the claim that PING EDs are on the REC track.

In 139b6a2 I remove the disclosure request, per [the patent policy](https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-disclosure-requests).