### PR TITLE
Recommend running `pip3`

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -102,18 +102,18 @@ installation is a breeze.
 Run the following command:
 
 ```bash
-pip install bikeshed && bikeshed update
+pip3 install bikeshed && bikeshed update
 ```
 
 When this is completed, Bikeshed should be installed,
 and the `bikeshed` command should work in your shell.
 
 Note: Depending on your system and python/pip install,
-you might instead need to run `pip3`, `python -m pip`, or `python3 -m pip`,
+you might instead need to run `pip`, `python -m pip`, or `python3 -m pip`,
 instead of the plain `pip`.
 
 Note: If you'd prefer a user-local install rather than a global,
-add a `--user` flag to the `pip install` invocation.
+add a `--user` flag to the `pip3 install` invocation.
 If you haven't done a user-local install before,
 `pip` will warn you about having to add new things to your `$PATH`
 before `bikeshed` becomes available to use as a command.
@@ -142,7 +142,7 @@ in the current folder you're in)
 and run:
 
 ```bash
-pip install -e .
+pip3 install -e .
 ```
 
 This will spam your console with a bunch of install progress.
@@ -173,7 +173,7 @@ If you're a user of `pipenv`,
 Bikeshed's folder contains a `Pipfile` and `Pipfile.lock` for you.
 
 Follow the same instructions as above,
-but instead of running `pip install`,
+but instead of running `pip3 install`,
 run:
 
 ```bash
@@ -198,7 +198,7 @@ To update bikeshed to its latest version at any time,
 just run:
 
 ```
-pip install --upgrade bikeshed && bikeshed update
+pip3 install --upgrade bikeshed && bikeshed update
 ```
 
 This’ll pull the latest version of Bikeshed,
@@ -206,7 +206,7 @@ and ensure that you’re looking at the latest version of the data files,
 rather than whatever stale version is currently sitting in the repo.
 
 Note: If you did a user-local install up above,
-by passing the `--user` flag to `pip install`,
+by passing the `--user` flag to `pip3 install`,
 pass it here as well to update your local copy;
 otherwise this command will install it globally.
 


### PR DESCRIPTION
`pip3` seems to be available even when `pyenv` picks Python 3, and it'll be a little more reliable on systems that have both Python 2 and Python 3 installed.