### PR TITLE
Restore newlines when saving the remote manifest.

### DIFF
--- a/bikeshed/update/manifest.py
+++ b/bikeshed/update/manifest.py
@@ -158,7 +158,7 @@ def updateByManifest(path, dryRun=False):
                 lastMsgTime = currFileTime
         try:
             with io.open(os.path.join(path, "manifest.txt"), 'w', encoding="utf-8") as fh:
-                fh.write("".join(remoteManifest))
+                fh.write("\n".join(remoteManifest))
         except Exception as e:
             warn("Couldn't save new manifest file.\n{0}", e)
             return False


### PR DESCRIPTION
This was broken in #1644, as the elements of remoteManifest no longer have
traiing newlines.