### PR TITLE
Make the reference to sibling WebAssembly docs be a complete sentence

### DIFF
--- a/bikeshed/boilerplate/wasm/abstract.include
+++ b/bikeshed/boilerplate/wasm/abstract.include
@@ -1,7 +1,8 @@
 <h2 class='no-num no-toc no-ref' id='abstract'>Abstract</h2>
 
 [ABSTRACT]
-Part of a collection of related documents:
+
+This is part of a collection of related documents:
 the <a href="https://www.w3.org/TR/wasm-core/">Core WebAssembly Specification</a>,
 the <a href="https://www.w3.org/TR/wasm-js-api/">WebAssembly JS Interface</a>,
 and the <a href="https://www.w3.org/TR/wasm-web-api/">WebAssembly Web API</a>.


### PR DESCRIPTION
Co-authored-by: Eric Prud'hommeaux <eric@w3.org>