### PR TITLE
Fix #1687: Watch includes

### DIFF
--- a/bikeshed/InputSource.py
+++ b/bikeshed/InputSource.py
@@ -57,6 +57,9 @@ class InputSource:
     def __str__(self) -> str:
         pass
 
+    def __repr__(self) -> str:
+        return "{}({!r})".format(self.__class__.__name__, str(self))
+
     def __hash__(self):
         return hash(str(self))
 
@@ -182,7 +185,10 @@ class FileInputSource(InputSource):
     def cheaplyExists(self, relativePath) -> bool:
         return os.access(self.relative(relativePath).sourceName, os.R_OK)
 
-    def mtime(self) -> float:
-        """Returns the last modification time of this source, if that's known.
+    def mtime(self) -> Optional[float]:
+        """Returns the last modification time of this file, or None if it doesn't exist.
         """
-        return os.stat(self.sourceName).st_mtime
+        try:
+            return os.stat(self.sourceName).st_mtime
+        except FileNotFoundError:
+            return None

--- a/bikeshed/InputSource.py
+++ b/bikeshed/InputSource.py
@@ -57,6 +57,12 @@ class InputSource:
     def __str__(self) -> str:
         pass
 
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
     @abstractmethod
     def read(self) -> InputContent:
         """Fully reads the source.

--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -50,6 +50,7 @@ class Spec(object):
             die("No input file specified, and no *.bs or *.src.html files found in current directory.\nPlease specify an input file, or use - to pipe from STDIN.")
             return
         self.inputSource = InputSource(inputFilename)
+        self.transitiveDependencies = set()
         self.debug = debug
         self.token = token
         self.testing = testing
@@ -100,10 +101,13 @@ class Spec(object):
 
         return True
 
+    def recordDependencies(self, *inputSources):
+        self.transitiveDependencies.update(inputSources)
+
     def preprocess(self):
-        recursiveIncludes = self.assembleDocument()
+        self.transitiveDependencies.clear()
+        self.assembleDocument()
         self.processDocument()
-        return recursiveIncludes
 
     def assembleDocument(self):
         # Textual hacks
@@ -152,9 +156,8 @@ class Spec(object):
         self.head = find("head", self)
         self.body = find("body", self)
         correctH1(self)
-        recursiveIncludes = includes.processInclusions(self)
+        includes.processInclusions(self)
         metadata.parseDoc(self)
-        return recursiveIncludes
 
     def processDocument(self):
         # Fill in and clean up a bunch of data
@@ -335,22 +338,25 @@ class Spec(object):
         mdCommandLine = self.mdCommandLine
 
         try:
-            lastInputModified = {self.inputSource: self.inputSource.mtime()}
-            for include in self.preprocess():
-                lastInputModified[include] = include.mtime()
+            self.preprocess()
             self.finish(outputFilename)
+            lastInputModified = {dep: dep.mtime()
+                                 for dep in self.transitiveDependencies}
             p("==============DONE==============")
             try:
                 while True:
-                    inputModified = self.inputSource.mtime()
-                    if any(input.mtime() > lastModified for input, lastModified in lastInputModified.items()):
+                    # Comparing mtimes with "!=" handles when a file starts or
+                    # stops existing, and it's fine to rebuild if an mtime
+                    # somehow gets older.
+                    if any(input.mtime() != lastModified for input, lastModified in lastInputModified.items()):
                         resetSeenMessages()
                         p("Source file modified. Rebuilding...")
                         self.initializeState()
                         self.mdCommandLine = mdCommandLine
-                        for include in self.preprocess().union(lastInputModified.keys()):
-                            lastInputModified[include] = include.mtime()
+                        self.preprocess()
                         self.finish(outputFilename)
+                        lastInputModified = {dep: dep.mtime()
+                                             for dep in self.transitiveDependencies}
                         p("==============DONE==============")
                     time.sleep(1)
             except KeyboardInterrupt:

--- a/bikeshed/config/retrieve.py
+++ b/bikeshed/config/retrieve.py
@@ -97,6 +97,10 @@ def retrieveBoilerplateFile(doc, name, group=None, status=None, error=True):
     sources.append(InputSource(boilerplatePath(statusFile)))
     sources.append(InputSource(boilerplatePath(genericFile)))
 
+    # Watch all the possible sources, not just the one that got used, because if
+    # an earlier one appears, we want to rebuild.
+    doc.recordDependencies(*sources)
+
     for source in sources:
         if source is not None:
             try:


### PR DESCRIPTION
This attempt is the simplest thing that could possibly work. It doesn't cover watching boilerplate files and abandons trying to print which file changed.