### PR TITLE
Update Travis instructions

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -222,10 +222,9 @@ Travis CI steps {#travis-ci}
 To use bikeshed on [Travis CI](https://travis-ci.org/)'s github integration, you'll need the following `.travis.yml` commands:
 
 ```
-sudo: false
 language: python
 python:
-  - "3.7"
+  - "3.8"
 install:
   - pip install bikeshed
   - bikeshed update


### PR DESCRIPTION
`sudo: false` is no longer needed and generates a warning on Travis CI.

Use Python 3.8 as it's now stable, to not require updates if support for
3.7 is dropped in the future.