### PR TITLE
Test Bikeshed with both Python 3.7 and 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
  - "3.7"
+ - "3.8"
 before_install:
  - pip install flake8
 install:


### PR DESCRIPTION
This doesn't test 3.9-dev since it's not worth the build spam for any failures
while they're beta-testing.

Since #1690 tells users to use 3.8, the automated build should probably flag if anything stops working there.