### PR TITLE
Rough initial draft of bikeshed's announcement features

### DIFF
--- a/bikeshed/boilerplate/csswg/blog.include
+++ b/bikeshed/boilerplate/csswg/blog.include
@@ -1,0 +1,10 @@
+Title: New [STATUS] of [TITLE]
+Categories: Publications
+
+The [LONGGROUP] has published a new [LONGSTATUS] of <a href="[LATEST]">[TITLE]</a>.
+
+[ABSTRACT]
+[STATUSTEXT]
+See also <a href="[VERSION]#changes">the change section</a> for details.
+
+Please send feedback by either <a href="[REPOSITORYURL]/issues">filing an issue in GitHub</a> (preferable) or sending mail to the (<a href="[GROUPMLARCHIVE]">archived</a>) public mailing list <a href="mailto:[GROUPREPLYTO]?Subject=%5B[VSHORTNAME]%5D%20PUT%20SUBJECT%20HERE">[GROUPREPLYTO]</a> with the spec code (<code>[ [VSHORTNAME]</code>) and your comment topic in the subject line.  (Alternatively, you can email one of the editors and ask them to forward your comment.)

--- a/bikeshed/boilerplate/csswg/mail.include
+++ b/bikeshed/boilerplate/csswg/mail.include
@@ -1,0 +1,22 @@
+To: [GROUPLISTS]
+Reply-To: [GROUPREPLYTO]
+Subject: [ [VSHORTNAME]] New [STATUS] of [TITLE]
+
+The [LONGGROUP] has published a new [LONGSTATUS] of [TITLE]:
+
+    [LATEST]
+
+[ABSTRACT]
+[STATUSTEXT]
+See also the change section for details:
+
+    [VERSION]#changes
+
+Please review the draft, and send any comments to this mailing list,
+[GROUPREPLYTO], prefixed with [ [VSHORTNAME]] (as I did on this
+message) or (preferably) file them in the GitHub repository at
+[REPOSITORYURL]/issues
+with the spec code [ [VSHORTNAME]] and your comment topic in the subject line.
+
+For the [LONGGROUP],
+—!!!Your name here!!!

--- a/bikeshed/config/__init__.py
+++ b/bikeshed/config/__init__.py
@@ -8,3 +8,4 @@ from .Nil import Nil
 from .printjson import printjson
 from .retrieve import DataFileRequester, defaultRequester, retrieveBoilerplateFile
 from .status import *
+from .group import *

--- a/bikeshed/config/group.py
+++ b/bikeshed/config/group.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# Full name of variouss groups
+# Accessible throught the [LONGGROUP] macro.
+shortToLongGroup = {
+    "csswg": "CSS Working Group",
+    "svgwg": "SVG Working Group",
+    "psig": "Patent and Standards Interest Group"
+}
+
+# Where email announcements about publications from this group should be sent
+# An array of one or more value is expected.
+# All of them will be used (coma separated) in the "To" field via the [GROUPLISTS] macro
+# and the first one will also be used for the "Reply To" field via the [GROUPREPLYTO] macro.
+groupAnnounceLists = {
+    "csswg": ["www-style@w3.org", "public-review-announce@w3.org"],
+    "svgwg": ["www-svg@w3.org", "public-review-announce@w3.org"],
+    "psig": ["member-psig@w3.org", "w3c-ac-forum@w3.org"]
+}
+
+# URL to the Group's mailing list archive, if any.
+# Accessible via the [GROUPMLARCHIVE] macro.
+groupMLArchive = {
+    "csswg": "http://lists.w3.org/Archives/Public/www-style/",
+    "svgwg": "http://lists.w3.org/Archives/Public/www-svg/",
+    "psig": "https://lists.w3.org/Archives/Member/member-psig/"
+}

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -269,6 +269,16 @@ class MetadataManager:
             macros["status"] = "NOTE"
         else:
             macros["status"] = self.rawStatus
+        if self.group in config.shortToLongGroup:
+            macros["longgroup"] = config.shortToLongGroup[self.group]
+        else:
+            macros["longgroup"] = self.group
+        if self.group in config.groupAnnounceLists:
+            macros["grouplists"] = ", ".join(config.groupAnnounceLists[self.group])
+        if self.group in config.groupAnnounceLists:
+            macros["groupreplyto"] = config.groupAnnounceLists[self.group][0]
+        if self.group in config.groupMLArchive:
+            macros["groupmlarchive"] = config.groupMLArchive[self.group]
         if self.workStatus:
             macros["workstatus"] = self.workStatus
         if self.TR:


### PR DESCRIPTION
This is a rough sketch of what solving https://github.com/tabatkins/bikeshed/issues/1695 might look like.

This is clearly incomplete:
* the code badly needs cleaning up
* I haven't written the wordpress curl part
* `[ABSTRACT]` and `[STATUSTEXT]` generate a `<p line-number=-1>` / `</p>` wrapper that I don't want
* HTML markup should be stripped from the email body (and `<a href="https://foo">link</a>` should probably be turned into something like `link (see https://foo)`

Still, it's a start.