### PR TITLE
change status code in errorAndExit

### DIFF
--- a/bikeshed/messages.py
+++ b/bikeshed/messages.py
@@ -188,4 +188,4 @@ def formatMessage(type, text, lineNum=None):
 
 def errorAndExit():
     failure("Did not generate, due to fatal errors")
-    sys.exit(1)
+    sys.exit(2)


### PR DESCRIPTION
This allows bikeshed-web to tell the difference between a bikeshed error and a bikeshed crash (which will use a status code of 1)