### PR TITLE
Remove the W3C Patent Policy blurb from all of the TAG status boilerplates.

### DIFF
--- a/bikeshed/boilerplate/tag/status-DRAFT-FINDING.include
+++ b/bikeshed/boilerplate/tag/status-DRAFT-FINDING.include
@@ -28,17 +28,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status-ED.include
+++ b/bikeshed/boilerplate/tag/status-ED.include
@@ -28,17 +28,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status-FINDING.include
+++ b/bikeshed/boilerplate/tag/status-FINDING.include
@@ -25,17 +25,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status-NOTE.include
+++ b/bikeshed/boilerplate/tag/status-NOTE.include
@@ -25,17 +25,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status-UD.include
+++ b/bikeshed/boilerplate/tag/status-UD.include
@@ -28,17 +28,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status-WG-NOTE.include
+++ b/bikeshed/boilerplate/tag/status-WG-NOTE.include
@@ -25,17 +25,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.

--- a/bikeshed/boilerplate/tag/status.include
+++ b/bikeshed/boilerplate/tag/status.include
@@ -28,17 +28,6 @@
   </p>
 
   <p>
-    This document was produced by a group operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with the deliverables of the group; that page also includes
-    instructions for disclosing a patent.
-  </p>
-
-  <p>
     This document is governed by the <a id="w3c_process_revision"
     href="https://www.w3.org/2019/Process-20190301/">1 March 2019 W3C Process
     Document</a>.


### PR DESCRIPTION
While I was putting w3ctag/security-questionnaire#86 together I found that the "public list of any patent disclosures" link is wrong in all the TAG boilerplate. So, based on that and some of @frivoal's comments in tabatkins/bikeshed#1663, this PR removes that text.

It should probably be replaced by something more accurate, but we won't know what that replacement looks like  until w3c/AB-memberonly#35 is resolved, so I'd rather drop it now and revisit when we know what we want.