### PR TITLE
Make MDN annos not block caniuse minimize control

### DIFF
--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -119,6 +119,7 @@ def addMdnPanels(doc):
             .mdn-anno > .feature > .support > .samsunginternet_android::before { background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg); }
             .mdn-anno > .feature > .support > .webview_android::before { background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png); }
             .name-slug-mismatch { color: red }
+            .caniuse-status:hover { z-index: 9; }
             '''  # noqa
 
 def panelsFromData(doc, data):


### PR DESCRIPTION
This change ensures it’s possible for users to click on a caniuse panel minimization control (diagonal ellipses) even when there’s an MDN button in the same position as the caniuse panel.

Fixes https://github.com/tabatkins/bikeshed/issues/1713