### PR TITLE
WHATWG: separate IPR

### DIFF
--- a/bikeshed/boilerplate/whatwg/defaults-RD.include
+++ b/bikeshed/boilerplate/whatwg/defaults-RD.include
@@ -9,6 +9,6 @@
   "Informative Classes": "domintro",
   "Metadata Include": "Translations no",
   "Informative Classes": "domintro",
-  "Tracking Vector Image": "https://resources.whatwg.org/tracking-vector.svg"
+  "Tracking Vector Image": "https://resources.whatwg.org/tracking-vector.svg",
   "Slim Build Artifact": "yes"
 }

--- a/bikeshed/boilerplate/whatwg/footer-RD.include
+++ b/bikeshed/boilerplate/whatwg/footer-RD.include
@@ -1,3 +1,7 @@
+<h2 id="ipr" class="no-num">Intellectual property rights</h2>
+
+<div data-fill-with="ipr" include-if="boilerplate:ipr"></div>
+
 <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution
 4.0 International License</a>.

--- a/bikeshed/boilerplate/whatwg/footer.include
+++ b/bikeshed/boilerplate/whatwg/footer.include
@@ -1,6 +1,14 @@
+<h2 id="ipr" class="no-num">Intellectual property rights</h2>
+
+<div data-fill-with="ipr" include-if="boilerplate:ipr"></div>
+
 <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution
 4.0 International License</a>.
+
+<p include-if="text macro: LATESTRD">This is the Living Standard. Those interested in the
+patent-review version should view the
+<a href="/review-drafts/[LATESTRD]/">Living Standard Review Draft</a>.</p>
 
 </main>
 

--- a/tests/github/whatwg/compat/compatibility.html
+++ b/tests/github/whatwg/compat/compatibility.html
@@ -139,6 +139,7 @@
        </ol>
      </ol>
     <li><a href="#acknowledgements"><span class="secno"></span> <span class="content">Acknowledgements</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -837,6 +838,7 @@ to avoid disabling zooming unnecessarily.</div>
    <p>Thanks to Mounir Lamouri and Marcos Cáceres for defining the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/screen-orientation/#screenorientation-interface" id="ref-for-screenorientation-interface①">ScreenOrientation</a></code> interface. <a data-link-type="biblio" href="#biblio-screen-orientation">[screen-orientation]</a></p>
    <p>Special thanks to Apple and the WebKit.org blog authors for providing initial descriptions of much of the content defined in this specification.</p>
    <p>This standard is written by <a href="https://miketaylr.com/">Mike Taylor</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:miket@mozilla.com">miket@mozilla.com</a>).</p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/console/index.html
+++ b/tests/github/whatwg/console/index.html
@@ -142,6 +142,7 @@
       <li><a href="#reporting-warnings"><span class="secno">2.4</span> <span class="content">Reporting warnings to the console</span></a>
      </ol>
     <li><a href="#acks"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -682,6 +683,7 @@ Victor Costan
 for their contributions to this specification. You are awesome!</p>
    <p>This standard is written by <a href="https://terinstock.com">Terin Stock</a> (<a href="mailto:terin@terinstock.com">terin@terinstock.com</a>), <a href="http://kowalski.gd">Robert Kowalski</a> (<a href="mailto:rok@kowalski.gd">rok@kowalski.gd</a>), and <a href="https://domfarolino.com">Dominic Farolino</a> (<a href="mailto:domfarolino@gmail.com">domfarolino@gmail.com</a>)
 with major help from <a href="https://domenic.me/">Domenic Denicola</a> (<a href="https://google.com">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>).</p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/dom/dom.html
+++ b/tests/github/whatwg/dom/dom.html
@@ -213,6 +213,7 @@ APIs</span></a>
       <li><a href="#dom-traversal-changes"><span class="secno">9.4</span> <span class="content">DOM Traversal</span></a>
      </ol>
     <li><a href="#acks"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -6401,6 +6402,7 @@ with substantial contributions from Aryeh Gregor (<a href="mailto:ayg@aryeh.name
 and Ms2ger (<a href="mailto:ms2ger@gmail.com">ms2ger@gmail.com</a>). </p>
    <p>Part of the revision history of the integration points related to <a data-link-type="dfn" href="#concept-element-custom" id="ref-for-concept-element-custom⑦">custom</a> elements can be found in <a href="https://github.com/w3c/webcomponents">the w3c/webcomponents repository</a>, which is
 available under the <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Permissive Document License</a>. </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/encoding/encoding.html
+++ b/tests/github/whatwg/encoding/encoding.html
@@ -214,6 +214,7 @@
     <li><a href="#browser-ui"><span class="secno">15</span> <span class="content">Browser UI</span></a>
     <li><a href="#implementation-considerations"><span class="secno"></span> <span class="content">Implementation considerations</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#section-index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -2928,6 +2929,7 @@ Vyacheslav Matva, and
 for being awesome. </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). The <a href="#api">API</a> chapter
 was initially written by Joshua Bell (<a href="https://www.google.com/">Google</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/fetch/fetch.html
+++ b/tests/github/whatwg/fetch/fetch.html
@@ -175,6 +175,7 @@
       <li><a href="#cors-protocol-and-http-caches"><span class="secno"></span> <span class="content">CORS protocol and HTTP caches</span></a>
      </ol>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -5035,6 +5036,7 @@ Youenn Fablet,
 Zhenbin Xu
 for being awesome. </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/fullscreen/fullscreen.html
+++ b/tests/github/whatwg/fullscreen/fullscreen.html
@@ -98,6 +98,7 @@
     <li><a href="#feature-policy-integration"><span class="secno">6</span> <span class="content">Feature Policy Integration</span></a>
     <li><a href="#security-and-privacy-considerations"><span class="secno">7</span> <span class="content">Security and Privacy Considerations</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -616,6 +617,7 @@ Vincent Scheib, and
 Xidorn Quan
 for also being awesome. </p>
    <p>This standard is edited by <a href="https://foolip.org/" lang="sv">Philip Jägenstedt</a> (<a href="https://google.com/">Google</a>, <a href="mailto:philip@foolip.org">philip@foolip.org</a>). It was originally written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). <a href="http://tantek.com/" lang="tr">Tantek Çelik</a> (<a class="p-org org h-org h-card" href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:tantek@cs.stanford.edu">tantek@cs.stanford.edu</a>) sorted out legal hassles. </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/infra/infra.html
+++ b/tests/github/whatwg/infra/infra.html
@@ -129,6 +129,7 @@
     <li><a href="#forgiving-base64"><span class="secno">7</span> <span class="content">Forgiving base64</span></a>
     <li><a href="#namespaces"><span class="secno">8</span> <span class="content">Namespaces</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1147,6 +1148,7 @@ triple-underscore,
 and Xue Fuqiao
 for being awesome! </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>) and <a href="https://domenic.me/">Domenic Denicola</a> (<a href="https://www.google.com/">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/loader/index.html
+++ b/tests/github/whatwg/loader/index.html
@@ -280,6 +280,7 @@ loading process and customizing loading behavior.</p>
      <ol class="toc">
       <li><a href="#list-of-well-known-intrinsic-objects"><span class="secno"></span> <span class="content">List of Well-Known Intrinsic Objects</span></a>
      </ol>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1375,6 +1376,7 @@ Reflective modules are always already instantiated.
       <td>%ModuleStatusPrototype%
       <td>The initial value of the *prototype* data property of %ModuleStatus% (<a href="#module-status-prototype">5.3.1</a>)
    </table>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/mimesniff/mimesniff.html
+++ b/tests/github/whatwg/mimesniff/mimesniff.html
@@ -137,6 +137,7 @@
       <li><a href="#sniffing-in-a-cache-manifest-context"><span class="secno">8.9</span> <span class="content">Sniffing in a cache manifest context</span></a>
      </ol>
     <li><a href="#acknowledgements"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1682,6 +1683,7 @@ type</dfn>: </p>
  triple-underscore
  for their invaluable contributions. </p>
    <p>This standard is written by <a href="https://gphemsley.org/">Gordon P. Hemsley</a> (<a href="mailto:me@gphemsley.org">me@gphemsley.org</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/notifications/notifications.html
+++ b/tests/github/whatwg/notifications/notifications.html
@@ -116,6 +116,7 @@
      </ol>
     <li><a href="#service-worker-api"><span class="secno">4</span> <span class="content">Service worker API</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -883,6 +884,7 @@ triple-underscore
 for being awesome. </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). An earlier iteration was written
 by John Gregg (<a href="https://www.google.com/">Google</a>, <a href="mailto:johnnyg@google.com">johnnyg@google.com</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/quirks/quirks.html
+++ b/tests/github/whatwg/quirks/quirks.html
@@ -141,6 +141,7 @@ quirk</span></a>
      </ol>
     <li><a href="#security-privacy"><span class="secno"></span> <span class="content">Security and Privacy Considerations</span></a>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -506,6 +507,7 @@ for their useful comments. </p>
    <p>Special thanks to Boris Zbarsky and David Baron for documenting <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Mozilla_quirks_mode_behavior">Mozilla’s
 quirks in MDN</a>. </p>
    <p>This standard is written by Simon Pieters (<a href="https://bocoup.com/">Bocoup</a>, <a href="mailto:zcorpan@gmail.com">zcorpan@gmail.com</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/storage/storage.html
+++ b/tests/github/whatwg/storage/storage.html
@@ -99,6 +99,7 @@
      </ol>
     <li><a href="#api"><span class="secno">7</span> <span class="content">API</span></a>
     <li><a href="#acks"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -365,6 +366,7 @@ Shachar Zohar,
 簡冠庭 (Timothy Guan-tin Chien)
 for being awesome!</p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>).</p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/streams/index.html
+++ b/tests/github/whatwg/streams/index.html
@@ -594,6 +594,7 @@ CountQueuingStrategy({ <var>highWaterMark</var> })</span></a>
      </ol>
     <li><a href="#conventions"><span class="secno"></span> <span class="content">Conventions</span></a>
     <li><a href="#acks"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -5060,6 +5061,7 @@ Xabier Rodríguez
 for their contributions to this specification. Community involvement in this specification has been above and beyond; we
 couldn’t have done it without you.</p>
    <p>This standard is written by Adam Rice (<a href="https://google.com">Google</a>, <a href="mailto:ricea@chromium.org">ricea@chromium.org</a>), <a href="https://domenic.me/">Domenic Denicola</a> (<a href="https://google.com">Google</a>, <a href="mailto:d@domenic.me">d@domenic.me</a>), and 吉野剛史 (Takeshi Yoshino, <a href="https://google.com">Google</a>, <a href="mailto:tyoshino@chromium.org">tyoshino@chromium.org</a>).</p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/url/url.html
+++ b/tests/github/whatwg/url/url.html
@@ -136,6 +136,7 @@
       <li><a href="#url-apis-elsewhere"><span class="secno">6.3</span> <span class="content">URL APIs elsewhere</span></a>
      </ol>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -2548,6 +2549,7 @@ Wei Wang,
 成瀬ゆい (Yui Naruse)
 for being awesome! </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>

--- a/tests/github/whatwg/xhr/xhr.html
+++ b/tests/github/whatwg/xhr/xhr.html
@@ -140,6 +140,7 @@
       <li><a href="#example"><span class="secno">6.4</span> <span class="content">Example</span></a>
      </ol>
     <li><a href="#acknowledgments"><span class="secno"></span> <span class="content">Acknowledgments</span></a>
+    <li><a href="#ipr"><span class="secno"></span> <span class="content">Intellectual property rights</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
@@ -1588,6 +1589,7 @@ Windows Internet Explorer browser. </p>
 the HTML Standard (then Web Applications 1.0). <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
    <p>Special thanks to the W3C SVG WG for drafting the original <code class="idl"><a data-link-type="idl" href="#progressevent" id="ref-for-progressevent①⑤">ProgressEvent</a></code> class as part of the <a href="https://www.w3.org/TR/2008/REC-SVGTiny12-20081222/svgudom.html">SVG Micro DOM</a>. </p>
    <p>This standard is written by <a href="https://annevankesteren.nl/" lang="nl">Anne van Kesteren</a> (<a href="https://www.mozilla.org/">Mozilla</a>, <a href="mailto:annevk@annevk.nl">annevk@annevk.nl</a>). </p>
+   <h2 class="no-num heading settled" id="ipr"><span class="content">Intellectual property rights</span><a class="self-link" href="#ipr"></a></h2>
    <p>Copyright © WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution
 4.0 International License</a>. </p>
   </main>


### PR DESCRIPTION
As per https://github.com/whatwg/sg/issues/124.

@tabatkins is this enough to go on? Basically, if "Latest RD" or some such metadata is available the conditional bit should end up saying:

```html
<p>This is the Living Standard. Those interested in the patent-review version should view the 
<a href="/review-drafts/[Review RD]/">Living Standard Review Draft</a>.</p>
```