### PR TITLE
Use <div> rather than <aside> for MDN panels

### DIFF
--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -95,7 +95,7 @@ def addMdnPanels(doc):
             '''  # noqa
 
 def createAnno(className, mdnButton, featureDivs):
-    return E.aside({"class": className}, mdnButton, featureDivs)
+    return E.div({"class": className}, mdnButton, featureDivs)
 
 def panelsFromData(doc, data):
     mdnBaseUrl = "https://developer.mozilla.org/en-US/docs/Web/"


### PR DESCRIPTION
This change makes Bikeshed emit `<div>` elements for MDN panels, rather than `<aside>` elements.

Otherwise, without this change, some markup that Bikeshed emits for MDN panels doesn’t conform to current HTML spec requirements. Specifically, the HTML spec currently doesn’t allow `<aside>` elements as descendants of `<dt>` elements — but we are intentionally inserting MDN panels as `<dt>` descendants (to get them aligned at point of use). So because of that, for now at least we need to use `<div>` for the panels, rather than `<aside>`.

Relates to https://github.com/whatwg/wattsi/issues/129