### PR TITLE
Use tox for testing everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ secrets.json
 .idea
 *.iml
 *.pyc
+.tox
 /dist
 /build
 /bikeshed/spec-data/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: python
 python:
  - "3.7"
  - "3.8"
-before_install:
- - pip install flake8
+ - "3.9-dev"
 install:
- - pip install --editable .
-before_script:
- - flake8 --exclude=./bikeshed/requests/*,./bikeshed/apiclient/*,./bikeshed/widlparser/* ; true
-script: bikeshed test
+ - pip install tox
+script:
+ - tox -e flake8 ; true
+ - tox -e integration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,9 @@ environment:
   - PYTHON: C:\\Python37-x64
 install:
 - cmd: >-
-    %PYTHON%\\python -m pip install -U pip wheel setuptools
-
-    %PYTHON%\\python -m pip install -U flake8
-build_script:
-- cmd: '%PYTHON%\\python.exe -m pip install --editable .'
+    %PYTHON%\\python -m pip install -U --upgrade-strategy=eager pip
+    %PYTHON%\\python -m pip install -U --upgrade-strategy=eager tox
 test_script:
 - cmd: >-
-    %PYTHON%\\python.exe -m flake8 --exclude=./bikeshed/requests/*,./bikeshed/apiclient/*,./bikeshed/widlparser/* || cmd /c "exit /b 0"
-
-    %PYTHON%\\Scripts\\bikeshed.exe test
+    %PYTHON%\\python.exe -m tox -e flake || cmd /c "exit /b 0"
+    %PYTHON%\\python.exe -m tox -e integration || cmd /c "exit /b 0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,9 @@
-[pep8]
-ignore = E203,E231,E265,E501,F403
 [flake8]
 ignore = E203,E231,E265,E501,F403
+exclude =
+  .git
+  __pycache__
+  .tox
+  ./bikeshed/requests/*
+  ./bikeshed/apiclient/*
+  ./bikeshed/widlparser/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py{37,38}-{flake,integration}
+
+[testenv]
+usedevelop =
+  integration: true
+skip_install =
+  flake: true
+deps =
+  flake: flake8>=3.8.3,<3.9
+commands =
+  integration: bikeshed test
+  flake: flake8


### PR DESCRIPTION
This avoids going through all the dancing of setting up appropriate environments for each supported version locally

(That we run `flake8` and then ignore everything seems… sad. We should either run it and care about it, or drop it, IMO.)