### PR TITLE
MDN annos: Prevent exception for “ID not found”

### DIFF
--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -132,34 +132,34 @@ def panelsFromData(doc, data):
         onlyTwoEngines = 0
         allEngines = 0
         featureDivs = []
+        targetElement = find(f"[id='{elementId}']", doc)
+        if targetElement is None:
+            msg = f"No '{elementId}' ID found."
+            if "slug" in feature:
+                msg += f" Update {mdnBaseUrl}{feature['slug']} Specifications Table?"
+            warn(msg)
+            continue
+        else:
+            panels = True
+            if targetElement.tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+                isAnnoForHeadingContent = True
+            else:
+                for ancestor in targetElement.iterancestors():
+                    if ancestor.tag in ['body', 'main', 'article', 'aside',
+                                        'nav', 'section', 'header', 'footer']:
+                        break
+                    targetElement = ancestor
+                    if ancestor.tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+                        isAnnoForHeadingContent = True
+                        break
+                    if ancestor.tag in ['td', 'dt', 'dd', 'li']:
+                        isAnnoForListItemOrTableContent = True
+                        break
+                    if ancestor.tag in ['pre', 'xmp', 'p']:
+                        break
         for feature in features:
             isAnnoForHeadingContent = False
             isAnnoForListItemOrTableContent = False
-            targetElement = find(f"[id='{elementId}']", doc)
-            if targetElement is None:
-                msg = f"No '{elementId}' ID found."
-                if "slug" in feature:
-                    msg += f" Update {mdnBaseUrl}{feature['slug']} Specifications Table?"
-                warn(msg)
-                continue
-            else:
-                panels = True
-                if targetElement.tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
-                    isAnnoForHeadingContent = True
-                else:
-                    for ancestor in targetElement.iterancestors():
-                        if ancestor.tag in ['body', 'main', 'article', 'aside',
-                                            'nav', 'section', 'header', 'footer']:
-                            break
-                        targetElement = ancestor
-                        if ancestor.tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
-                            isAnnoForHeadingContent = True
-                            break
-                        if ancestor.tag in ['td', 'dt', 'dd', 'li']:
-                            isAnnoForListItemOrTableContent = True
-                            break
-                        if ancestor.tag in ['pre', 'xmp', 'p']:
-                            break
             if "engines" in feature:
                 engines = len(feature["engines"])
                 if engines < 2:


### PR DESCRIPTION
This change prevents Bikeshed from throwing an exception and failing when the MDN-handling code runs into a “No 'foo' ID found” case.

Otherwise, without this change, when the code runs into a “No 'foo' ID found” case, the code throws an exception and fails.

---

The cause is that the processing of the MDN data is a place where the code uses two loops: an outer loop and an inner loop — and the code without this change was checking for the “No 'foo' ID found” within the inner loop, and doing a continue to the next iteration of the inner loop when an ID is not found. But the code needs to instead do the “No 'foo' ID found” check inside the outer loop, and continue to the next iteration of the outer loop when an ID is not found.

Fixes https://github.com/tabatkins/bikeshed/issues/1731