### PR TITLE
Wait to add MDN panels til after all IDs generated

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -201,7 +201,6 @@ class Spec(object):
         biblio.dedupBiblioReferences(self)
         verifyUsageOfAllLocalBiblios(self)
         caniuse.addCanIUsePanels(self)
-        mdnspeclinks.addMdnPanels(self)
         boilerplate.addIndexSection(self)
         boilerplate.addExplicitIndexes(self)
         boilerplate.addStyles(self)
@@ -217,6 +216,8 @@ class Spec(object):
         processAutolinks(self)
         boilerplate.addAnnotations(self)
         boilerplate.removeUnwantedBoilerplate(self)
+        # Add MDN panels after all IDs/anchors have been added
+        mdnspeclinks.addMdnPanels(self)
         highlight.addSyntaxHighlighting(self)
         boilerplate.addBikeshedBoilerplate(self)
         fingerprinting.addTrackingVector(self)


### PR DESCRIPTION
This change moves the code for generating the MDN panels until after all other code has run that adds any IDs/anchors in the output.

Otherwise, without this change, it’s possible that Bikeshed will fail to find an expected ID, and will emit a “WARNING: No 'foo' ID found” message and not generate an MDN panel at the expected place.

For example, see https://github.com/tabatkins/bikeshed/issues/1731, where the root cause of the bug was that the code for generating the MDN panels runs before the `boilerplate.addPropertyIndex` code — and so, the generated `media-descriptor-table` ID does not exist yet at the point where the code for generating the MDN panels is trying to find it.