### PR TITLE
Link argument types in argumentdef tables to their definitions

### DIFF
--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1158,7 +1158,14 @@ def formatArgumentdefTables(doc):
             argName = textContent(tds[0]).strip()
             arg = method.find_argument(argName)
             if arg:
-                appendChild(tds[1], str(arg.type))
+                argType = str(arg.type).strip()
+                # If the argument is a sequence, link to the element type
+                if (arg.type.type.type.sequence):
+                    baseType = str(arg.type.type.type.type).strip()
+                    appendChild(tds[1], E.a({"data-link-type":"idl-name", "data-lt":baseType}, argType))
+                else:
+                    appendChild(tds[1], E.a({"data-link-type":"idl-name"}, argType))
+
                 if str(arg.type).strip().endswith("?"):
                     appendChild(tds[2],
                                 E.span({"class":"yes"}, "✔"))


### PR DESCRIPTION
We're using argumentdef tables extensively now in the [WebGPU spec](https://gpuweb.github.io/gpuweb/) and generally find them to be a really nice way of documenting method arguments, but were disappointed to see that they didn't provide links to the argument type definitions.

This change attempts to address that, though it could probably stand to be a bit more robust. I'm not a fan of the way that sequences are special-cased, but couldn't find a more elegant way to handle that (largely due to not being very familiar with the bikeshed codebase.) I also suspect that there will be other similar situations that just aren't encountered in the docs I've tested against.

Of particular concern is the fact that if this code gets the linked type name wrong it generates a build error that the spec author doesn't have much control over. It would be great if this bit of code in particular could silently fail if the type isn't recognized rather than breaking the build. But, again, I'm not familiar enough with bikeshed to know how to best approach that. Would love feedback on the matter! 