### PR TITLE
Add missing continue statements in parseConditions

### DIFF
--- a/bikeshed/conditional.py
+++ b/bikeshed/conditional.py
@@ -84,8 +84,10 @@ def parseConditions(s, el=None):
 		match = re.match(r"text macro:\s*(.+)$", sub, re.I)
 		if match:
 			yield {"type":"text macro", "value":match.group(1).strip()}
+			continue
 		match = re.match(r"boilerplate:\s*(.+)$", sub, re.I)
 		if match:
 			yield {"type":"boilerplate", "value":match.group(1).strip()}
+			continue
 		die(f"Unknown include/exclude-if condition '{sub}'", el=el)
 		continue


### PR DESCRIPTION
Looks like this was missed in e632b349.

(The weird thing is that I cannot trigger this in a test. I guess the tests don't record fatal errors or warnings? That's kinda problematic for the WHATWG regression tests as our build system does break on those.)