### PR TITLE
WHATWG: mark LATESTRD optional

### DIFF
--- a/bikeshed/boilerplate/whatwg/footer.include
+++ b/bikeshed/boilerplate/whatwg/footer.include
@@ -8,7 +8,7 @@
 
 <p include-if="text macro: LATESTRD">This is the Living Standard. Those interested in the
 patent-review version should view the
-<a href="/review-drafts/[LATESTRD]/">Living Standard Review Draft</a>.</p>
+<a href="/review-drafts/[LATESTRD?]/">Living Standard Review Draft</a>.</p>
 
 </main>
 


### PR DESCRIPTION
7bee8fa0 did not do that and even though it gets excluded it results in a fatal error first.