### PR TITLE
Bump requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 aiofiles>=0.5.0<1
 aiohttp>=3.6.2,<4
-attrs>=19.3.0
-certifi>=2020.4.5.1
+attrs>=20.2.0
+certifi>=2020.6.20
 cssselect>=1.1.0,<1.2
-html5lib>=1.0.1,<1.1
+html5lib>=1.1,<1.2
 isodate>=0.6.0
 json_home_client>=1.1.1,<2
 lxml>=4.5,<4.6
 pygments>=2.6.1,<2.7
-requests>=2.23,<3
+requests>=2.24.0,<3
 retrying>=1.3.3,<2
 widlparser>=1.0.6,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiofiles>=0.5.0<1
+aiofiles>=0.5.0,<1
 aiohttp>=3.6.2,<4
 attrs>=20.2.0
 certifi>=2020.6.20


### PR DESCRIPTION
Excludes pygments 2.7, as https://github.com/pygments/pygments/commit/5ec283a3592dfdef7aff34ab00ca8685c4d37470 appears to be the pygments change that broke tests. I'm leaving this up to the maintainers to follow up with pygments.

e.g.:

```diff
1/1: github/WICG/WebOTP/index.bs
--- golden
+++ suspect
@@ -6489,15 +6489,15 @@
 <c-
 p>},</c->
 <c-
-mi>2</c->
+mf>2</c->
 <c-
 o>*</c->
 <c-
-mi>60</c->
+mf>60</c->
 <c-
 o>*</c->
 <c-
-mi>1000</c-><c-
+mf>1000</c-><c-
 p>);</c->
 <c-
 k>try</c->
```