### PR TITLE
WHATWG: exlude LATESTRD on RDs

### DIFF
--- a/bikeshed/boilerplate/whatwg/footer.include
+++ b/bikeshed/boilerplate/whatwg/footer.include
@@ -6,8 +6,8 @@
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution
 4.0 International License</a>.
 
-<p include-if="text macro: LATESTRD">This is the Living Standard. Those interested in the
-patent-review version should view the
+<p include-if="Text Macro: LATESTRD" exclude-if="whatwg/RD">This is the Living Standard. Those
+interested in the patent-review version should view the
 <a href="/review-drafts/[LATESTRD?]/">Living Standard Review Draft</a>.</p>
 
 </main>


### PR DESCRIPTION
Only the Living Standard should have this paragraph. See https://github.com/whatwg/whatwg.org/pull/344 for context.

We could also exclude this from LS-COMMIT and LS-PR, but it seems fine to me to include it there. (Note that adding LS to include-if would not work, as it's OR, not AND.)