### PR TITLE
Update audiowg header-ED.include

### DIFF
--- a/bikeshed/boilerplate/audiowg/header-ED.include
+++ b/bikeshed/boilerplate/audiowg/header-ED.include
@@ -7,12 +7,6 @@
   <meta name="w3c-status" content="[STATUS]">
   <style data-fill-with="stylesheet">
   </style>
-  <style>
-    body {
-      background: url("https://www.w3.org/StyleSheets/TR/logo-ED") top left no-repeat white;
-      background-attachment: fixed;
-    }
-  </style>
 </head>
 <body class="h-entry">
 <div class="head">


### PR DESCRIPTION
Remove the style loading the ED CSS.  It causes problems when viewing the WebAudio spec in dark mode.

This is the suggested fix from @tabatkins 

Fixes #1790