### PR TITLE
Add an ID to the example example

### DIFF
--- a/bikeshed/boilerplate/w3c/footer.include
+++ b/bikeshed/boilerplate/w3c/footer.include
@@ -21,7 +21,7 @@
     with <code>class="example"</code>,
     like this:
 
-    <div class="example">
+    <div class="example" id="example-example">
         <p>This is an example of an informative example.
     </div>
 


### PR DESCRIPTION
This allows usage of "Complain About: missing-example-ids yes" in W3C specs