### PR TITLE
Retrieve the correct metadata boilerplate if "Status" is specified.

### DIFF
--- a/bikeshed/config/retrieve.py
+++ b/bikeshed/config/retrieve.py
@@ -69,8 +69,11 @@ def retrieveBoilerplateFile(doc, name, group=None, status=None, error=True):
     # Filenames must be of the format NAME.include or NAME-STATUS.include
     if group is None and doc.md.group is not None:
         group = doc.md.group.lower()
-    if status is None and doc.md.status is not None:
-        status = doc.md.status
+    if status is None:
+        if doc.md.status is not None:
+            status = doc.md.status
+        elif doc.md.rawStatus is not None:
+            status = doc.md.rawStatus
     megaGroup, status = splitStatus(status)
 
     searchLocally = doc.md.localBoilerplate[name]


### PR DESCRIPTION
In commit 9410d77, `config.retrieveBoilerplateFile` was changed to, among other things, use `doc.md.status` rather than `doc.md.rawStatus` as the default status specifier. However, when the `default` and `computed-metadata` boilerplates are retrieved, `doc.md.status` is set to `None` since the implicit metadata hasn't been computed yet, which causes the default boilerplate files to load rather than those for the specified status.

Fixes #1818 and fixes whatwg/whatwg.org#348.