### PR TITLE
fix: run pyupgrade --py37-plus on *.py

### DIFF
--- a/bikeshed/DefaultOrderedDict.py
+++ b/bikeshed/DefaultOrderedDict.py
@@ -39,7 +39,7 @@ class DefaultOrderedDict(OrderedDict):
         return type(self)(self.default_factory, copy.deepcopy(list(self.items())))
 
     def __repr__(self):
-        return "OrderedDefaultDict(%s, %s)" % (
+        return "OrderedDefaultDict({}, {})".format(
             self.default_factory,
             OrderedDict.__repr__(self),
         )

--- a/bikeshed/InputSource.py
+++ b/bikeshed/InputSource.py
@@ -161,7 +161,7 @@ class FileInputSource(InputSource):
         return self.sourceName
 
     def read(self) -> InputContent:
-        with io.open(self.sourceName, "r", encoding="utf-8") as f:
+        with open(self.sourceName, encoding="utf-8") as f:
             return InputContent(
                 f.readlines(),
                 datetime.fromtimestamp(os.path.getmtime(self.sourceName)).date(),

--- a/bikeshed/InputSource.py
+++ b/bikeshed/InputSource.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import attr
 import email.utils
 import errno
-import io
 import os
 import requests
 import sys

--- a/bikeshed/Line.py
+++ b/bikeshed/Line.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
-
-
 import attr
 
 
 @attr.s(slots=True)
-class Line(object):
+class Line:
     i = attr.ib(validator=[attr.validators.instance_of(int)])
     text = attr.ib(validator=[attr.validators.instance_of(str)])
 

--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -1,5 +1,4 @@
 import glob
-import io
 import os
 import sys
 from collections import defaultdict

--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import glob
 import io
 import os
@@ -38,7 +35,7 @@ from .refs import ReferenceManager
 from .unsortedJunk import *
 
 
-class Spec(object):
+class Spec:
     def __init__(
         self,
         inputFilename,
@@ -111,7 +108,7 @@ class Spec(object):
                 self.inputSource,
             )
             return False
-        except IOError:
+        except OSError:
             die("Couldn't open the input file '{0}'.", self.inputSource)
             return False
 
@@ -327,7 +324,7 @@ class Spec(object):
                 if outputFilename == "-":
                     sys.stdout.write(rendered)
                 else:
-                    with io.open(
+                    with open(
                         outputFilename, "w", encoding="utf-8", newline=newline
                     ) as f:
                         f.write(rendered)
@@ -360,7 +357,7 @@ class Spec(object):
 
         outputFilename = self.fixMissingOutputFilename(outputFilename)
         if self.inputSource.mtime() is None:
-            die("Watch mode doesn't support {}".format(self.inputSource))
+            die(f"Watch mode doesn't support {self.inputSource}")
         if outputFilename == "-":
             die("Watch mode doesn't support streaming to STDOUT.")
             return
@@ -380,7 +377,7 @@ class Spec(object):
                 ("localhost" if localhost else "", port), SilentServer
             )
 
-            print("Serving at port {0}".format(port))
+            print(f"Serving at port {port}")
             thread = threading.Thread(target=server.serve_forever)
             thread.daemon = True
             thread.start()

--- a/bikeshed/__init__.py
+++ b/bikeshed/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 def verify_python_version():
     import sys
     import platform
@@ -39,7 +36,7 @@ def verify_requirements():
     )
     if os.path.exists(requirements_file_path):
         requirements_met = True
-        with open(requirements_file_path, "r") as requirements_file:
+        with open(requirements_file_path) as requirements_file:
             requirements = [
                 line
                 for line in requirements_file.read().split("\n")
@@ -59,7 +56,7 @@ def verify_requirements():
                         requirements_met = False
                 except Exception:
                     print(
-                        "Package {} is not installed.".format(requirement.project_name)
+                        f"Package {requirement.project_name} is not installed."
                     )
                     requirements_met = False
         if not requirements_met:

--- a/bikeshed/biblio.py
+++ b/bikeshed/biblio.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import re
 from collections import defaultdict
 
@@ -12,7 +9,7 @@ from .messages import *
 
 
 @attr.s(slots=True)
-class BiblioEntry(object):
+class BiblioEntry:
     linkText = attr.ib(default=None)
     originalLinkText = attr.ib(default=None)
     title = attr.ib(default=None)
@@ -60,9 +57,9 @@ class BiblioEntry(object):
             str += "; et al. " if etAl else ". "
 
         if self.url:
-            str += "<a href='{0}'>{1}</a>. ".format(self.url, self.title)
+            str += f"<a href='{self.url}'>{self.title}</a>. "
         else:
-            str += "{0}. ".format(self.title)
+            str += f"{self.title}. "
 
         if self.preferredURL == "current" and self.current_url:
             pass
@@ -134,7 +131,7 @@ class SpecBasedBiblioEntry(BiblioEntry):
     """
 
     def __init__(self, spec, preferredURL=None):
-        super(SpecBasedBiblioEntry, self).__init__()
+        super().__init__()
         if preferredURL is None:
             preferredURL = constants.refStatus.snapshot
         self.spec = spec

--- a/bikeshed/boilerplate.py
+++ b/bikeshed/boilerplate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import copy
 import os
 import re
@@ -334,14 +332,14 @@ def addIndexOfLocallyDefinedTerms(doc, container):
             # Don't generate index entries for arguments.
             continue
         if el.get("data-dfn-for") is not None:
-            disambiguator = "{0} for {1}".format(
+            disambiguator = "{} for {}".format(
                 el.get("data-dfn-type"),
                 ", ".join(config.splitForValues(el.get("data-dfn-for"))),
             )
         elif type == "dfn":
             disambiguator = "definition of"
         else:
-            disambiguator = "({0})".format(el.get("data-dfn-type"))
+            disambiguator = "({})".format(el.get("data-dfn-type"))
 
         id = el.get("id")
         for linkText in linkTexts:
@@ -373,11 +371,11 @@ def addExplicitIndexes(doc):
             continue
 
         if el.get("type"):
-            types = set(x.strip() for x in el.get("type").split(","))
+            types = {x.strip() for x in el.get("type").split(",")}
             for t in types:
                 if t not in config.dfnTypes:
                     die(
-                        "Unknown type value '{0}' on {1}".format(t, outerHTML(el)),
+                        "Unknown type value '{}' on {}".format(t, outerHTML(el)),
                         el=el,
                     )
                     types.remove(t)
@@ -386,18 +384,18 @@ def addExplicitIndexes(doc):
 
         if el.get("data-link-spec"):
             # Yes, this is dumb. Accidental over-firing of a shortcut attribute. >_<
-            specs = set(x.strip() for x in el.get("data-link-spec").split(","))
+            specs = {x.strip() for x in el.get("data-link-spec").split(",")}
             for s in list(specs):
                 if s not in doc.refs.specs:
                     die(
-                        "Unknown spec name '{0}' on {1}".format(s, outerHTML(el)), el=el
+                        "Unknown spec name '{}' on {}".format(s, outerHTML(el)), el=el
                     )
                     specs.remove(s)
         else:
             specs = None
 
         if el.get("for"):
-            fors = set(x.strip() for x in el.get("for").split(","))
+            fors = {x.strip() for x in el.get("for").split(",")}
         else:
             fors = None
 
@@ -409,7 +407,7 @@ def addExplicitIndexes(doc):
                 export = False
             else:
                 die(
-                    "Unknown export value '{0}' (should be boolish) on {1}".format(
+                    "Unknown export value '{}' (should be boolish) on {}".format(
                         exportVal, outerHTML(el)
                     ),
                     el=el,
@@ -427,7 +425,7 @@ def addExplicitIndexes(doc):
             if ref.for_:
                 try:
                     disambInfo.append(
-                        "for {0}".format(", ".join(x.strip() for x in ref.for_))
+                        "for {}".format(", ".join(x.strip() for x in ref.for_))
                     )
                 except:
                     # todo: The TR version of Position triggers this
@@ -590,7 +588,7 @@ def addIndexOfExternallyDefinedTerms(doc, container):
                 for key, ref in sorted(refs.items(), key=lambda x: x[0]):
                     if key:
                         link = makeLink(
-                            ref.text, " ", E.small({}, "(for {0})".format(key))
+                            ref.text, " ", E.small({}, f"(for {key})")
                         )
                     else:
                         link = makeLink(ref.text)

--- a/bikeshed/caniuse.py
+++ b/bikeshed/caniuse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 from collections import OrderedDict
 from datetime import datetime
@@ -218,7 +216,7 @@ def validateCanIUseURLs(doc, elements):
         )
 
 
-class CanIUseManager(object):
+class CanIUseManager:
     def __init__(self, dataFile):
         self.dataFile = dataFile
         data = json.loads(
@@ -240,7 +238,7 @@ class CanIUseManager(object):
             return
         data = json.loads(
             self.dataFile.fetch(
-                "caniuse", "feature-{0}.json".format(featureName), str=True
+                "caniuse", f"feature-{featureName}.json", str=True
             ),
             object_pairs_hook=OrderedDict,
         )

--- a/bikeshed/cli.py
+++ b/bikeshed/cli.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import argparse
 import os
 import sys
@@ -17,7 +14,7 @@ def main():
         sys.argv.append("spec")
 
     try:
-        with open(config.scriptPath("..", "semver.txt"), "r") as fh:
+        with open(config.scriptPath("..", "semver.txt")) as fh:
             semver = fh.read().strip()
             semverText = f"Bikeshed v{semver}: "
     except:
@@ -587,7 +584,7 @@ def handleDebug(options, extras):
         refs = doc.refs.refs[options.linkText] + doc.refs.refs[options.linkText + "\n"]
         constants.quiet = options.quiet
         if not constants.quiet:
-            p("Refs for '{0}':".format(options.linkText))
+            p(f"Refs for '{options.linkText}':")
         # Get ready for JSONing
         for ref in refs:
             ref["level"] = str(ref["level"])
@@ -670,8 +667,8 @@ def handleTest(options, extras):
 def handleProfile(options, extras):
     import os
 
-    root = '--root="{0}"'.format(options.root) if options.root else ""
-    leaf = '--leaf="{0}"'.format(options.leaf) if options.leaf else ""
+    root = f'--root="{options.root}"' if options.root else ""
+    leaf = f'--leaf="{options.leaf}"' if options.leaf else ""
     if options.svgFile:
         os.system(
             "time python -m cProfile -o stat.prof -m bikeshed -f spec && gprof2dot -f pstats --skew=.0001 {root} {leaf} stat.prof | dot -Tsvg -o {svg} && rm stat.prof".format(

--- a/bikeshed/conditional.py
+++ b/bikeshed/conditional.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 from . import config

--- a/bikeshed/config/BoolSet.py
+++ b/bikeshed/config/BoolSet.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import collections
 
 
@@ -54,4 +51,4 @@ class BoolSet(collections.MutableMapping):
         else:
             falseVals = [k for k, v in self._internal.items() if v is False]
             vrepr = "{" + ", ".join(repr(x) + ":False" for x in falseVals) + "}"
-        return "BoolSet({0}, default={1})".format(vrepr, self.default)
+        return f"BoolSet({vrepr}, default={self.default})"

--- a/bikeshed/config/Nil.py
+++ b/bikeshed/config/Nil.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class Nil(object):
+class Nil:
     """Super-None, falsey and returns itself from every method/attribute/etc"""
 
     def __repr__(self):

--- a/bikeshed/config/__init__.py
+++ b/bikeshed/config/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .BoolSet import BoolSet
 from .dfnTypes import *
 from .main import *

--- a/bikeshed/config/dfnTypes.py
+++ b/bikeshed/config/dfnTypes.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import re
 from collections import defaultdict
 

--- a/bikeshed/config/main.py
+++ b/bikeshed/config/main.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import collections
 import lxml
 import os
@@ -106,9 +104,7 @@ class DuplicatedLinkText(Exception):
         self.el = el
 
     def __unicode__(self):
-        return "<Text '{0}' shows up in both lt and local-lt>".format(
-            self.offendingText
-        )
+        return f"<Text '{self.offendingText}' shows up in both lt and local-lt>"
 
 
 def firstLinkTextFromElement(el):
@@ -163,8 +159,7 @@ def flatten(arr):
             and not isinstance(el, str)
             and not lxml.etree.iselement(el)
         ):
-            for sub in flatten(el):
-                yield sub
+            yield from flatten(el)
         else:
             yield el
 

--- a/bikeshed/config/printjson.py
+++ b/bikeshed/config/printjson.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from ..messages import printColor
 from ..h import outerHTML, isElement
 

--- a/bikeshed/config/retrieve.py
+++ b/bikeshed/config/retrieve.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import io
 import os
 
@@ -10,7 +7,7 @@ from .main import scriptPath
 from .status import splitStatus
 
 
-class DataFileRequester(object):
+class DataFileRequester:
     def __init__(self, type=None, fallback=None):
         self.type = type
         if self.type not in ("readonly", "latest"):
@@ -25,23 +22,22 @@ class DataFileRequester(object):
         location = self._buildPath(segs=segs, fileType=fileType)
         try:
             if str:
-                with io.open(location, "r", encoding="utf-8") as fh:
+                with open(location, encoding="utf-8") as fh:
                     return fh.read()
             else:
-                return io.open(location, "r", encoding="utf-8")
-        except IOError:
+                return open(location, encoding="utf-8")
+        except OSError:
             if self.fallback:
                 try:
                     return self.fallback.fetch(*segs, str=str, okayToFail=okayToFail)
-                except IOError:
+                except OSError:
                     return self._fail(location, str, okayToFail)
             return self._fail(location, str, okayToFail)
 
     def walkFiles(self, *segs, **kwargs):
         fileType = kwargs.get("type", self.type)
         for root, dirs, files in os.walk(self._buildPath(segs, fileType=fileType)):
-            for file in files:
-                yield file
+            yield from files
 
     def _buildPath(self, segs, fileType=None):
         if fileType is None:
@@ -57,7 +53,7 @@ class DataFileRequester(object):
                 return ""
             else:
                 return io.StringIO("")
-        raise IOError("Couldn't find file '{0}'".format(location))
+        raise OSError(f"Couldn't find file '{location}'")
 
 
 defaultRequester = DataFileRequester(
@@ -84,8 +80,8 @@ def retrieveBoilerplateFile(doc, name, group=None, status=None, error=True):
     def boilerplatePath(*segs):
         return scriptPath("boilerplate", *segs)
 
-    statusFile = "{0}-{1}.include".format(name, status)
-    genericFile = "{0}.include".format(name)
+    statusFile = f"{name}-{status}.include"
+    genericFile = f"{name}.include"
     sources = []
     if searchLocally:
         sources.append(doc.inputSource.relative(statusFile))  # Can be None.
@@ -119,7 +115,7 @@ def retrieveBoilerplateFile(doc, name, group=None, status=None, error=True):
         if source is not None:
             try:
                 return source.read().content
-            except IOError:
+            except OSError:
                 # That input doesn't exist.
                 pass
     else:

--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .main import englishFromList
 from ..messages import *
 
@@ -276,7 +273,7 @@ def canonicalizeStatus(rawStatus, group):
 
         def formatStatusSet(statuses):
             return ", ".join(
-                sorted(set([status.split("/")[-1] for status in statuses]))
+                sorted({status.split("/")[-1] for status in statuses})
             )
 
         msg = "You used Status: {0}, but {1} limited to these statuses: {2}."
@@ -342,23 +339,17 @@ def canonicalizeStatus(rawStatus, group):
         # Was the error because the megagroup doesn't exist?
         if possibleMgs:
             if megaGroup not in megaGroups:
-                msg = "Status metadata specified an unrecognized '{0}' organization.".format(
-                    megaGroup
-                )
+                msg = f"Status metadata specified an unrecognized '{megaGroup}' organization."
             else:
-                msg = "Status '{0}' can't be used with the org '{1}'.".format(
-                    status, megaGroup
-                )
+                msg = f"Status '{status}' can't be used with the org '{megaGroup}'."
             if "" in possibleMgs:
                 if len(possibleMgs) == 1:
-                    msg += " That status must be used without an org at all, like `Status: {0}`".format(
-                        status
-                    )
+                    msg += f" That status must be used without an org at all, like `Status: {status}`"
                 else:
-                    msg += " That status can only be used with the org{0} {1}, or without an org at all.".format(
+                    msg += " That status can only be used with the org{} {}, or without an org at all.".format(
                         "s" if len(possibleMgs) > 1 else "",
                         englishFromList(
-                            "'{0}'".format(x) for x in possibleMgs if x != ""
+                            f"'{x}'" for x in possibleMgs if x != ""
                         ),
                     )
             else:
@@ -367,19 +358,15 @@ def canonicalizeStatus(rawStatus, group):
                         possibleMgs[0], status
                     )
                 else:
-                    msg += " That status can only be used with the orgs {0}.".format(
-                        englishFromList("'{0}'".format(x) for x in possibleMgs)
+                    msg += " That status can only be used with the orgs {}.".format(
+                        englishFromList(f"'{x}'" for x in possibleMgs)
                     )
 
         else:
             if megaGroup not in megaGroups:
-                msg = "Unknown Status metadata '{0}'. Check the docs for valid Status values.".format(
-                    canonStatus
-                )
+                msg = f"Unknown Status metadata '{canonStatus}'. Check the docs for valid Status values."
             else:
-                msg = "Status '{0}' can't be used with the org '{1}'. Check the docs for valid Status values.".format(
-                    status, megaGroup
-                )
+                msg = f"Status '{status}' can't be used with the org '{megaGroup}'. Check the docs for valid Status values."
         die("{0}", msg)
         return canonStatus
 
@@ -399,23 +386,21 @@ def canonicalizeStatus(rawStatus, group):
 
     # Group isn't in any compatible org, so suggest prefixing.
     if possibleMgs:
-        msg = "You used Status: {0}, but that's limited to the {1} org{2}".format(
+        msg = "You used Status: {}, but that's limited to the {} org{}".format(
             rawStatus,
-            englishFromList("'{0}'".format(mg) for mg in possibleMgs),
+            englishFromList(f"'{mg}'" for mg in possibleMgs),
             "s" if len(possibleMgs) > 1 else "",
         )
         if group:
-            msg += ", and your group '{0}' isn't recognized as being in {1}.".format(
+            msg += ", and your group '{}' isn't recognized as being in {}.".format(
                 group, "any of those orgs" if len(possibleMgs) > 1 else "that org"
             )
             msg += " If this is wrong, please file a Bikeshed issue to categorize your group properly, and/or try:\n"
-            msg += "\n".join("Status: {0}/{1}".format(mg, status) for mg in possibleMgs)
+            msg += "\n".join(f"Status: {mg}/{status}" for mg in possibleMgs)
         else:
             msg += ", and you don't have a Group metadata. Please declare your Group, or check the docs for statuses that can be used by anyone."
     else:
-        msg = "Unknown Status metadata '{0}'. Check the docs for valid Status values.".format(
-            canonStatus
-        )
+        msg = f"Unknown Status metadata '{canonStatus}'. Check the docs for valid Status values."
     die("{0}", msg)
     return canonStatus
 

--- a/bikeshed/constants.py
+++ b/bikeshed/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .stringEnum import StringEnum
 
 dryRun = False

--- a/bikeshed/datablocks.py
+++ b/bikeshed/datablocks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from collections import OrderedDict, defaultdict
 
@@ -75,7 +73,7 @@ def transformDataBlocks(doc, lines):
                 die(
                     "Found {0} classes on the <{1}>, so can't tell which to process the block as. Please use only one.",
                     config.englishFromList(
-                        ("'{0}'".format(x) for x in seenClasses), "and"
+                        (f"'{x}'" for x in seenClasses), "and"
                     ),
                     tagName,
                     lineNum=line.i,
@@ -197,13 +195,13 @@ def transformPre(lines, tagName, firstLine, **kwargs):
     # which'll mess up the indent finding.
     # Instead, specially handle this case.
     if len(lines) == 0:
-        return [firstLine, "</{0}>".format(tagName)]
+        return [firstLine, f"</{tagName}>"]
 
     if re.match(r"\s*</code>\s*$", lines[-1]):
-        lastLine = "</code></{0}>".format(tagName)
+        lastLine = f"</code></{tagName}>"
         lines = lines[:-1]
     else:
-        lastLine = "</{0}>".format(tagName)
+        lastLine = f"</{tagName}>"
 
     if len(lines) == 0:
         return [firstLine, lastLine]
@@ -245,12 +243,12 @@ def transformPropdef(lines, doc, firstLine, lineNum=None, **kwargs):
     # attrs with any other value are optional, and use the specified value if not present in parsedAttrs
     forHint = ""
     if "Name" in parsedAttrs:
-        forHint = " data-link-for-hint='{0}'".format(
+        forHint = " data-link-for-hint='{}'".format(
             parsedAttrs["Name"].split(",")[0].strip()
         )
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     if "partial" in firstLine or "New values" in parsedAttrs:
         attrs["Name"] = None
         attrs["New values"] = None
@@ -323,34 +321,22 @@ def transformPropdef(lines, doc, firstLine, lineNum=None, **kwargs):
 
     for key, val in attrsToPrint:
         tr = "<tr>"
-        th = "<th>{0}:".format(key)
-        td = "<td>{0}".format(val)
+        th = f"<th>{key}:"
+        td = f"<td>{val}"
         if key in ("Value", "New values"):
             tr = "<tr class=value>"
-            th = "<th><a href='https://www.w3.org/TR/css-values/#value-defs'>{0}:</a>".format(
-                key
-            )
-            td = "<td class=prod>{0}".format(val)
+            th = f"<th><a href='https://www.w3.org/TR/css-values/#value-defs'>{key}:</a>"
+            td = f"<td class=prod>{val}"
         elif key == "Initial":
-            th = "<th><a href='https://www.w3.org/TR/css-cascade/#initial-values'>{0}:</a>".format(
-                key
-            )
+            th = f"<th><a href='https://www.w3.org/TR/css-cascade/#initial-values'>{key}:</a>"
         elif key == "Inherited":
-            th = "<th><a href='https://www.w3.org/TR/css-cascade/#inherited-property'>{0}:</a>".format(
-                key
-            )
+            th = f"<th><a href='https://www.w3.org/TR/css-cascade/#inherited-property'>{key}:</a>"
         elif key == "Percentages":
-            th = "<th><a href='https://www.w3.org/TR/css-values/#percentages'>{0}:</a>".format(
-                key
-            )
+            th = f"<th><a href='https://www.w3.org/TR/css-values/#percentages'>{key}:</a>"
         elif key == "Computed value":
-            th = "<th><a href='https://www.w3.org/TR/css-cascade/#computed'>{0}:</a>".format(
-                key
-            )
+            th = f"<th><a href='https://www.w3.org/TR/css-cascade/#computed'>{key}:</a>"
         elif key in ("Animatable", "Animation type"):
-            th = "<th><a href='https://www.w3.org/TR/web-animations/#animation-type'>{0}:</a>".format(
-                key
-            )
+            th = f"<th><a href='https://www.w3.org/TR/web-animations/#animation-type'>{key}:</a>"
         elif key == "Applies to" and val.lower() == "all elements":
             td = "<td><a href='https://www.w3.org/TR/css-pseudo/#generated-content' title='Includes ::before and ::after pseudo-elements.'>all elements</a>"
         ret.append(tr + th + td)
@@ -368,7 +354,7 @@ def transformPropdef(lines, doc, firstLine, lineNum=None, **kwargs):
 def transformDescdef(lines, doc, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     vals = parseDefBlock(lines, "descdef")
     if "partial" in firstLine or "New values" in vals:
         requiredKeys = ["Name", "For"]
@@ -394,14 +380,14 @@ def transformDescdef(lines, doc, firstLine, lineNum=None, **kwargs):
     for key in requiredKeys:
         if key == "For":
             ret.append(
-                "<tr><th>{0}:<td><a at-rule>{1}</a>".format(key, vals.get(key, ""))
+                "<tr><th>{}:<td><a at-rule>{}</a>".format(key, vals.get(key, ""))
             )
         elif key == "Value":
             ret.append(
-                "<tr><th>{0}:<td class='prod'>{1}".format(key, vals.get(key, ""))
+                "<tr><th>{}:<td class='prod'>{}".format(key, vals.get(key, ""))
             )
         elif key in vals:
-            ret.append("<tr><th>{0}:<td>{1}".format(key, vals.get(key, "")))
+            ret.append("<tr><th>{}:<td>{}".format(key, vals.get(key, "")))
         else:
             die(
                 "The descdef for '{0}' is missing a '{1}' line.",
@@ -413,7 +399,7 @@ def transformDescdef(lines, doc, firstLine, lineNum=None, **kwargs):
     for key, val in vals.items():
         if key in requiredKeys:
             continue
-        ret.append("<tr><th>{0}:<td>{1}".format(key, vals[key]))
+        ret.append("<tr><th>{}:<td>{}".format(key, vals[key]))
     ret.append("</table>")
 
     indent = getWsPrefix(firstLine)
@@ -425,7 +411,7 @@ def transformDescdef(lines, doc, firstLine, lineNum=None, **kwargs):
 def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     attrs = OrderedDict()
     parsedAttrs = parseDefBlock(lines, "elementdef")
     if "Attribute groups" in parsedAttrs or "Attributes" in parsedAttrs:
@@ -460,7 +446,7 @@ def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
     attrs["Attributes"] = None
     attrs["Dom interfaces"] = None
     ret = [
-        "<table class='def elementdef'{lineNumAttr}>".format(lineNumAttr=lineNumAttr)
+        f"<table class='def elementdef'{lineNumAttr}>"
     ]
     for key, val in attrs.items():
         if key in parsedAttrs or val is not None:
@@ -477,7 +463,7 @@ def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
                     )
                 )
             elif key == "Content model":
-                ret.append("<tr><th>{0}:<td>".format(key))
+                ret.append(f"<tr><th>{key}:<td>")
                 ret.extend(val.split("\n"))
             elif key == "Categories":
                 ret.append("<tr><th>Categories:<td>")
@@ -500,7 +486,7 @@ def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
                     )
                 )
             else:
-                ret.append("<tr><th>{0}:<td>{1}".format(key, val))
+                ret.append(f"<tr><th>{key}:<td>{val}")
         else:
             die(
                 "The elementdef for '{0}' is missing a '{1}' line.",
@@ -512,7 +498,7 @@ def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
     for key, val in parsedAttrs.items():
         if key in attrs:
             continue
-        ret.append("<tr><th>{0}:<td>{1}".format(key, val))
+        ret.append(f"<tr><th>{key}:<td>{val}")
     ret.append("</table>")
 
     indent = getWsPrefix(firstLine)
@@ -524,7 +510,7 @@ def transformElementdef(lines, doc, firstLine, lineNum=None, **kwargs):
 def transformArgumentdef(lines, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     attrs = parseDefBlock(lines, "argumentdef", capitalizeKeys=False, lineNum=lineNum)
     el = parseHTML(firstLine + "</pre>")[0]
     if "for" in el.attrib:
@@ -548,7 +534,7 @@ def transformArgumentdef(lines, firstLine, lineNum=None, **kwargs):
         return []
     addClass(el, "data")
     rootAttrs = " ".join(
-        "{0}='{1}'".format(k, escapeAttr(v)) for k, v in el.attrib.items()
+        "{}='{}'".format(k, escapeAttr(v)) for k, v in el.attrib.items()
     )
     text = (
         """
@@ -743,7 +729,7 @@ def processAnchors(anchors, doc, lineNum=None):
         spec = anchor["spec"][0] if "spec" in anchor else None
         if shortname and not spec:
             if level:
-                spec = "{0}-{1}".format(shortname, level)
+                spec = f"{shortname}-{level}"
             else:
                 spec = shortname
         elif spec and not shortname:
@@ -903,7 +889,7 @@ def processInfo(infos, doc, lineNum=None):
 def transformInclude(lines, doc, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     infos = parseInfoTree(lines, doc.md.indent, lineNum)
     path = None
     macros = {}
@@ -928,10 +914,10 @@ def transformInclude(lines, doc, firstLine, lineNum=None, **kwargs):
                         lineNum=lineNum,
                     )
     if path:
-        el = "<pre class=include path='{0}'".format(escapeAttr(path))
+        el = "<pre class=include path='{}'".format(escapeAttr(path))
         for i, (k, v) in enumerate(macros.items()):
-            el += " macro-{0}='{1} {2}'".format(i, k, escapeAttr(v))
-        el += "{lineNumAttr}></pre>".format(lineNumAttr=lineNumAttr)
+            el += " macro-{}='{} {}'".format(i, k, escapeAttr(v))
+        el += f"{lineNumAttr}></pre>"
 
         indent = getWsPrefix(firstLine)
         return [indent + el]
@@ -942,7 +928,7 @@ def transformInclude(lines, doc, firstLine, lineNum=None, **kwargs):
 def transformIncludeCode(lines, doc, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     infos = parseInfoTree(lines, doc.md.indent, lineNum)
     path = None
     highlight = None
@@ -986,18 +972,18 @@ def transformIncludeCode(lines, doc, firstLine, lineNum=None, **kwargs):
 
     if path:
         attrs = lineNumAttr
-        attrs += " path='{0}'".format(escapeAttr(path))
+        attrs += " path='{}'".format(escapeAttr(path))
         if highlight:
-            attrs += " highlight='{0}'".format(escapeAttr(highlight))
+            attrs += " highlight='{}'".format(escapeAttr(highlight))
         if lineStart:
-            attrs += " line-start='{0}'".format(escapeAttr(lineStart))
+            attrs += " line-start='{}'".format(escapeAttr(lineStart))
         if show:
-            attrs += " data-code-show='{0}'".format(escapeAttr(",".join(show)))
+            attrs += " data-code-show='{}'".format(escapeAttr(",".join(show)))
         if lineHighlight:
-            attrs += " line-highlight='{0}'".format(escapeAttr(",".join(lineHighlight)))
+            attrs += " line-highlight='{}'".format(escapeAttr(",".join(lineHighlight)))
         if lineNumbers:
             attrs += " line-numbers"
-        el = "<pre class=include-code{0}></pre>".format(attrs)
+        el = f"<pre class=include-code{attrs}></pre>"
         indent = getWsPrefix(firstLine)
         return [indent + el]
     else:
@@ -1007,7 +993,7 @@ def transformIncludeCode(lines, doc, firstLine, lineNum=None, **kwargs):
 def transformIncludeRaw(lines, doc, firstLine, lineNum=None, **kwargs):
     lineNumAttr = ""
     if lineNum is not None:
-        lineNumAttr = " line-number={0}".format(lineNum)
+        lineNumAttr = f" line-number={lineNum}"
     infos = parseInfoTree(lines, doc.md.indent, lineNum)
     path = None
     for info in infos:
@@ -1022,8 +1008,8 @@ def transformIncludeRaw(lines, doc, firstLine, lineNum=None, **kwargs):
 
     if path:
         attrs = lineNumAttr
-        attrs += " path='{0}'".format(escapeAttr(path))
-        el = "<pre class=include-raw{0}></pre>".format(attrs)
+        attrs += " path='{}'".format(escapeAttr(path))
+        el = f"<pre class=include-raw{attrs}></pre>"
         indent = getWsPrefix(firstLine)
         return [indent + el]
     else:
@@ -1130,7 +1116,7 @@ def classesFromLine(line):
 
 
 @attr.s(slots=True)
-class StartTag(object):
+class StartTag:
     tag = attr.ib()
     attrs = attr.ib(default=attr.Factory(dict))
 

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .DefaultOrderedDict import DefaultOrderedDict
 from .h import *
 
@@ -48,7 +45,7 @@ def addDfnPanels(doc, dfns):
             for i, el in enumerate(els):
                 refID = el.get("id")
                 if refID is None:
-                    refID = "ref-for-{0}".format(id)
+                    refID = f"ref-for-{id}"
                     el.set("id", safeID(doc, refID))
                 if i == 0:
                     appendChild(
@@ -89,7 +86,7 @@ def addExternalDfnPanel(termEl, ref, elsFromHref, doc):
     if len(refs):
         addClass(termEl, "dfn-paneled")
         _, _, refID = ref.url.partition("#")
-        termID = "term-for-{0}".format(refID)
+        termID = f"term-for-{refID}"
         termEl.set("id", termID)
         termEl.set("data-silently-dedup", "")
         panel = E.aside(

--- a/bikeshed/dfns/attributeInfo.py
+++ b/bikeshed/dfns/attributeInfo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 from .. import config
@@ -74,7 +72,7 @@ def getTargetInfo(doc, el):
         )
     else:
         targets = h.findAll(
-            'a[data-link-type={1}][data-lt="{0}"]'.format(referencedAttribute, refType),
+            f'a[data-link-type={refType}][data-lt="{referencedAttribute}"]',
             doc,
         )
 

--- a/bikeshed/extensions.py
+++ b/bikeshed/extensions.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from . import config
 from .h import *  # noqa: F401
 from .messages import *  # noqa: F401

--- a/bikeshed/fingerprinting.py
+++ b/bikeshed/fingerprinting.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .h import *
 
 trackingVectorId = "b732b3fe"  # hashlib.md5("tracking-vector").hexdigest()[0:8], to minimize chance of collision

--- a/bikeshed/fonts.py
+++ b/bikeshed/fonts.py
@@ -1,4 +1,3 @@
-import io
 import re
 from itertools import *
 

--- a/bikeshed/fonts.py
+++ b/bikeshed/fonts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import re
 from itertools import *
@@ -63,10 +61,10 @@ This defines a font capable of rendering text composed of "A", "B", "a", "b", an
 """
 
 
-class Font(object):
+class Font:
     def __init__(self, fontfilename=config.scriptPath("bigblocks.bsfont")):
         try:
-            lines = io.open(fontfilename, "r", encoding="utf-8").readlines()
+            lines = open(fontfilename, encoding="utf-8").readlines()
         except Exception as e:
             die("Couldn't find font file “{0}”:\n{1}", fontfilename, e)
         self.metadata, lines = parseMetadata(lines)
@@ -174,14 +172,14 @@ def getInputLines(inputFilename):
         if inputFilename == "-":
             lines = list(sys.stdin.readlines())
         else:
-            lines = io.open(inputFilename, "r", encoding="utf-8").readlines()
+            lines = open(inputFilename, encoding="utf-8").readlines()
     except OSError:
         die(
             "Couldn't find the input file at the specified location '{0}'.",
             inputFilename,
         )
         return []
-    except IOError:
+    except OSError:
         die("Couldn't open the input file '{0}'.", inputFilename)
         return []
     return lines, inputFilename
@@ -194,7 +192,7 @@ def writeOutputLines(outputFilename, inputFilename, lines):
         if outputFilename == "-":
             sys.stdout.write("".join(lines))
         else:
-            with io.open(outputFilename, "w", encoding="utf-8") as f:
+            with open(outputFilename, "w", encoding="utf-8") as f:
                 f.write("".join(lines))
     except Exception as e:
         die(

--- a/bikeshed/func.py
+++ b/bikeshed/func.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class Functor(object):
+class Functor:
     # Pointed and Co-Pointed by default;
     # override these yourself if you need to.
     def __init__(self, val):

--- a/bikeshed/h/__init__.py
+++ b/bikeshed/h/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .serializer import Serializer
 
 from .dom import addClass

--- a/bikeshed/h/dom.py
+++ b/bikeshed/h/dom.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import hashlib
 import html5lib
 import re
@@ -54,7 +52,7 @@ def escapeCSSIdent(val):
             or (i == 0 and 0x30 <= code <= 0x39)
             or (i == 1 and 0x30 <= code <= 0x39 and firstCode == 0x2D)
         ):
-            ident += r"\{0:x} ".format(code)
+            ident += fr"\{code:x} "
         elif (
             code >= 0x80
             or code == 0x2D
@@ -65,7 +63,7 @@ def escapeCSSIdent(val):
         ):
             ident += chr(code)
         else:
-            ident += r"\{0}".format(chr(code))
+            ident += r"\{}".format(chr(code))
     return ident
 
 
@@ -76,7 +74,7 @@ def escapeUrlFrag(val):
             result += char
         else:
             for b in char.encode("utf-8"):
-                result += "%{:0>2x}".format(b)
+                result += f"%{b:0>2x}"
     return result
 
 
@@ -451,8 +449,7 @@ def nodeIter(el, clear=False, skipOddNodes=True):
         if skipOddNodes and isOddNode(c):
             continue
         # yield from nodeIter(c, clear=clear, skipOddNodes=skipOddNodes)
-        for grandChild in nodeIter(c, clear=clear, skipOddNodes=skipOddNodes):
-            yield grandChild
+        yield from nodeIter(c, clear=clear, skipOddNodes=skipOddNodes)
     if tail is not None:
         yield tail
 
@@ -526,7 +523,7 @@ def addClass(el, cls):
     elif hasClass(el, cls):
         pass
     else:
-        el.set("class", "{0} {1}".format(el.get("class"), cls))
+        el.set("class", "{} {}".format(el.get("class"), cls))
 
 
 _classMap = {}
@@ -724,9 +721,7 @@ def replaceAwkwardCSSShorthands(text):
         escape, text = match.groups()
         if escape:
             return escapeHTML(match.group(0)[1:])
-        return "<fake-production-placeholder class=production bs-autolink-syntax='{0}'>{1}</fake-production-placeholder>".format(
-            syntaxAttr, text
-        )
+        return f"<fake-production-placeholder class=production bs-autolink-syntax='{syntaxAttr}'>{text}</fake-production-placeholder>"
 
     text = re.sub(r"(\\)?<<([^>\n]+)>>", replaceProduction, text)
 
@@ -739,9 +734,7 @@ def replaceAwkwardCSSShorthands(text):
         escape, text = match.groups()
         if escape:
             return escapeHTML(match.group(0)[1:])
-        return "<fake-maybe-placeholder bs-autolink-syntax='{0}'>{1}</fake-maybe-placeholder>".format(
-            syntaxAttr, text
-        )
+        return f"<fake-maybe-placeholder bs-autolink-syntax='{syntaxAttr}'>{text}</fake-maybe-placeholder>"
 
     text = re.sub(r"(\\)?''([^=\n]+?)''", replaceMaybe, text)
     return text
@@ -810,7 +803,7 @@ def dedupIDs(doc):
                     el=el,
                 )
             for x in ints:
-                altId = "{0}{1}".format(dupeId, circledDigits(x))
+                altId = "{}{}".format(dupeId, circledDigits(x))
                 if altId not in ids:
                     el.set("id", safeID(doc, altId))
                     ids[altId].append(el)

--- a/bikeshed/h/serializer.py
+++ b/bikeshed/h/serializer.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
-
-
 import io
 from . import dom
 
 
-class Serializer(object):
+class Serializer:
     inlineEls = frozenset(
         [
             "a",

--- a/bikeshed/headings.py
+++ b/bikeshed/headings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import config
 from .config import simplifyText
 from .h import *

--- a/bikeshed/highlight.py
+++ b/bikeshed/highlight.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import collections
 import itertools
 import re
@@ -169,11 +167,11 @@ def highlightWithWebIDL(text, el):
     All other text is colored with the attr currently on top of the stack.
     """
 
-    class IDLUI(object):
+    class IDLUI:
         def warn(self, msg):
             die("{0}", msg.rstrip())
 
-    class HighlightMarker(object):
+    class HighlightMarker:
         # Just applies highlighting classes to IDL stuff.
         def markup_type_name(self, text, construct):
             return ("\1n\2", "\3")

--- a/bikeshed/idl.py
+++ b/bikeshed/idl.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import re
 
 from widlparser import parser
@@ -10,17 +7,17 @@ from .messages import *
 from .unsortedJunk import classifyDfns
 
 
-class IDLUI(object):
+class IDLUI:
     def warn(self, msg):
         die("{0}", msg.rstrip())
 
 
-class IDLSilent(object):
+class IDLSilent:
     def warn(self, msg):
         pass
 
 
-class DebugMarker(object):
+class DebugMarker:
     # Debugging tool for IDL markup
 
     def markup_construct(self, text, construct):
@@ -72,7 +69,7 @@ class DebugMarker(object):
         return ('<ENUM-VALUE for="' + construct.name + '">', "</ENUM-VALUE>")
 
 
-class IDLMarker(object):
+class IDLMarker:
     def markup_construct(self, text, construct):
         # Fires for every 'construct' in the WebIDL.
         # Some things are "productions", not "constructs".
@@ -121,7 +118,7 @@ class IDLMarker(object):
             if typeName.endswith("?"):
                 typeName = typeName[:-1]
             return (
-                '<a data-link-type=attribute data-link-for="{0}">'.format(typeName),
+                f'<a data-link-type=attribute data-link-for="{typeName}">',
                 "</a>",
             )
 
@@ -132,7 +129,7 @@ class IDLMarker(object):
             and construct.name == "LegacyWindowAlias"
         ):
             return (
-                '<idl data-idl-type=interface data-lt="{0}">'.format(text),
+                f'<idl data-idl-type=interface data-lt="{text}">',
                 "</idl>",
             )
 
@@ -152,7 +149,7 @@ class IDLMarker(object):
             if construct.name is None:
                 # If no name was defined, you're required to define stringification behavior.
                 return (
-                    "<a dfn for='{0}' data-lt='stringification behavior'>".format(
+                    "<a dfn for='{}' data-lt='stringification behavior'>".format(
                         construct.parent.full_name
                     ),
                     "</a>",
@@ -222,18 +219,18 @@ class IDLMarker(object):
                 readonly = "data-readonly"
             else:
                 readonly = ""
-            extraParameters = '{0} data-type="{1}"'.format(
+            extraParameters = '{} data-type="{}"'.format(
                 readonly, str(rest.type).strip()
             )
         elif idlType == "dict-member":
-            extraParameters = 'data-type="{0}"'.format(construct.type)
+            extraParameters = f'data-type="{construct.type}"'
             if construct.default is not None:
                 value = str(construct.default).split("=", 1)[1].strip()
                 if value.startswith("["):
                     value = "[]"
                 elif value.startswith("}"):
                     value = "{}"
-                extraParameters += ' data-default="{0}"'.format(escapeAttr(value))
+                extraParameters += ' data-default="{}"'.format(escapeAttr(value))
         elif idlType in ["interface", "namespace", "dictionary"]:
             if construct.partial:
                 refType = "link"
@@ -247,12 +244,12 @@ class IDLMarker(object):
             if idlType == "argument" and construct.parent.idl_type == "method":
                 interfaceName = construct.parent.parent.name
                 methodNames = [
-                    "{0}/{1}".format(interfaceName, m)
+                    f"{interfaceName}/{m}"
                     for m in self.methodLinkingTexts(construct.parent)
                 ]
-                idlFor = "data-idl-for='{0}'".format(", ".join(methodNames))
+                idlFor = "data-idl-for='{}'".format(", ".join(methodNames))
             else:
-                idlFor = "data-idl-for='{0}'".format(construct.parent.full_name)
+                idlFor = f"data-idl-for='{construct.parent.full_name}'"
         else:
             idlFor = ""
         return (
@@ -264,12 +261,12 @@ class IDLMarker(object):
                 name=elementName,
                 refType=refType,
             ),
-            "</{0}>".format(elementName),
+            f"</{elementName}>",
         )
 
     def markup_enum_value(self, text, construct):
         return (
-            "<idl data-idl-type=enum-value data-idl-for='{0}' data-lt='{1}'>".format(
+            "<idl data-idl-type=enum-value data-idl-for='{}' data-lt='{}'>".format(
                 escapeAttr(construct.name), escapeAttr(text)
             ),
             "</idl>",

--- a/bikeshed/includes.py
+++ b/bikeshed/includes.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import hashlib
 import itertools
 import re

--- a/bikeshed/inlineTags/__init__.py
+++ b/bikeshed/inlineTags/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from subprocess import Popen, PIPE
 
 from ..h import *

--- a/bikeshed/issuelist.py
+++ b/bikeshed/issuelist.py
@@ -1,5 +1,4 @@
 import glob
-import io
 import re
 import sys
 from .messages import *

--- a/bikeshed/issuelist.py
+++ b/bikeshed/issuelist.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import glob
 import io
 import re
@@ -28,7 +26,7 @@ def printIssueList(infilename=None, outfilename=None):
     else:
         for suffix in [".txt", "txt", ""]:
             try:
-                infile = io.open(infilename + suffix, "r", encoding="utf-8")
+                infile = open(infilename + suffix, encoding="utf-8")
                 infilename += suffix
                 break
             except Exception:
@@ -51,7 +49,7 @@ def printIssueList(infilename=None, outfilename=None):
         outfile = sys.stdout
     else:
         try:
-            outfile = io.open(outfilename, "w", encoding="utf-8")
+            outfile = open(outfilename, "w", encoding="utf-8")
         except Exception as e:
             die("Couldn't write to outfile:\n{0}", str(e))
             return
@@ -136,10 +134,10 @@ def extractHeaderInfo(lines, infilename):
                 status = "LCWD"
         if ed is None:
             shortname = match.group(2)
-            ed = "http://dev.w3.org/csswg/{}/".format(shortname)
+            ed = f"http://dev.w3.org/csswg/{shortname}/"
         if date is None:
             cdate = match.group(3)
-            date = "{0}-{1}-{2}".format(
+            date = "{}-{}-{}".format(
                 *re.match(r"(\d{4})(\d\d)(\d\d)", cdate).groups()
             )
     else:
@@ -275,7 +273,7 @@ def printIssues(outfile, lines):
         issue = re.sub(r"((http|https):\S+)", r"<a href='\1'>\1</a>", issue)
 
         # And print it
-        outfile.write("<pre class='{0}' id='issue-{1}'>\n".format(code, index))
+        outfile.write(f"<pre class='{code}' id='issue-{index}'>\n")
         outfile.write(issue)
         outfile.write("</pre>\n")
 

--- a/bikeshed/lexers.py
+++ b/bikeshed/lexers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from pygments.lexer import *
 from pygments.token import *

--- a/bikeshed/lint/__init__.py
+++ b/bikeshed/lint/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .accidental2119 import accidental2119
 from .brokenLinks import brokenLinks
 from .exampleIDs import exampleIDs

--- a/bikeshed/lint/accidental2119.py
+++ b/bikeshed/lint/accidental2119.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from ..h import *
 from ..messages import *

--- a/bikeshed/lint/brokenLinks.py
+++ b/bikeshed/lint/brokenLinks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 from ..h import *
 from ..messages import *

--- a/bikeshed/lint/exampleIDs.py
+++ b/bikeshed/lint/exampleIDs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..h import *
 from ..messages import *
 

--- a/bikeshed/lint/missingExposed.py
+++ b/bikeshed/lint/missingExposed.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..h import *
 from ..messages import *
 

--- a/bikeshed/lint/requiredIDs.py
+++ b/bikeshed/lint/requiredIDs.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from ..h import *
 from ..messages import *
 

--- a/bikeshed/lint/unusedInternalDfns.py
+++ b/bikeshed/lint/unusedInternalDfns.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from ..h import *
 from ..messages import *
 from ..config import dfnElementsSelector

--- a/bikeshed/markdown/__init__.py
+++ b/bikeshed/markdown/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from .markdown import stripComments, parse

--- a/bikeshed/mdnspeclinks.py
+++ b/bikeshed/mdnspeclinks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from collections import OrderedDict
 from .h import *  # noqa
@@ -12,11 +11,11 @@ def addMdnPanels(doc):
     try:
         filename = doc.md.vshortname + ".json"
         datafile = doc.dataFile.fetch("mdn", filename, str=True)
-    except IOError:
+    except OSError:
         try:
             filename = doc.md.shortname + ".json"
             datafile = doc.dataFile.fetch("mdn", filename, str=True)
-        except IOError:
+        except OSError:
             if doc.md.includeMdnPanels == "maybe":
                 # if "maybe", failure is fine, don't complain
                 pass

--- a/bikeshed/messages.py
+++ b/bikeshed/messages.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys
 from collections import Counter
 import lxml.html
@@ -60,9 +58,9 @@ def linkerror(msg, *formatArgs, **namedArgs):
             lineNum = el.get("line-number")
         else:
             if el.get("bs-autolink-syntax"):
-                suffix = "\n{0}".format(el.get("bs-autolink-syntax"))
+                suffix = "\n{}".format(el.get("bs-autolink-syntax"))
             else:
-                suffix = "\n{0}".format(
+                suffix = "\n{}".format(
                     lxml.html.tostring(
                         namedArgs["el"], with_tail=False, encoding="unicode"
                     )
@@ -158,7 +156,7 @@ def printColor(text, color="white", *styles):
 
         colorNum = colorsConverter[color.lower()]
         styleNum = ";".join(str(stylesConverter[style.lower()]) for style in styles)
-        return "\033[{0};{1}m{text}\033[0m".format(styleNum, colorNum, text=text)
+        return f"\033[{styleNum};{colorNum}m{text}\033[0m"
     else:
         return text
 
@@ -167,17 +165,17 @@ def formatMessage(type, text, lineNum=None):
     if constants.printMode == "markup":
         text = text.replace("<", "&lt;")
         if type == "fatal":
-            return "<fatal>{0}</fatal>".format(text)
+            return f"<fatal>{text}</fatal>"
         elif type == "link":
-            return "<linkerror>{0}</linkerror>".format(text)
+            return f"<linkerror>{text}</linkerror>"
         elif type == "warning":
-            return "<warning>{0}</warning>".format(text)
+            return f"<warning>{text}</warning>"
         elif type == "message":
-            return "<message>{0}</message>".format(text)
+            return f"<message>{text}</message>"
         elif type == "success":
-            return "<final-success>{0}</final-success>".format(text)
+            return f"<final-success>{text}</final-success>"
         elif type == "failure":
-            return "<final-failure>{0}</final-failure>".format(text)
+            return f"<final-failure>{text}</final-failure>"
     else:
         if type == "message":
             return text
@@ -201,7 +199,7 @@ def formatMessage(type, text, lineNum=None):
             headingText = "WARNING"
             color = "light cyan"
         if lineNum is not None:
-            headingText = "LINE {0}".format(lineNum)
+            headingText = f"LINE {lineNum}"
         return printColor(headingText + ":", color, "bold") + " " + text
 
 

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import copy
 import json
 import os
@@ -27,13 +24,13 @@ class MetadataManager:
     @property
     def vshortname(self):
         if self.level:
-            return "{0}-{1}".format(self.shortname, self.level)
+            return f"{self.shortname}-{self.level}"
         return self.shortname
 
     @property
     def displayVshortname(self):
         if self.level:
-            return "{0}-{1}".format(self.displayShortname, self.level)
+            return f"{self.displayShortname}-{self.level}"
         return self.displayShortname
 
     def __init__(self):
@@ -244,15 +241,15 @@ class MetadataManager:
         warnings = []
         for attrName, name in requiredSingularKeys.items():
             if getattr(self, attrName) is None:
-                errors.append("    Missing a '{0}' entry.".format(name))
+                errors.append(f"    Missing a '{name}' entry.")
         for attrName, name in recommendedSingularKeys.items():
             if getattr(self, attrName) is None:
                 warnings.append(
-                    "    You probably want to provide a '{0}' entry.".format(name)
+                    f"    You probably want to provide a '{name}' entry."
                 )
         for attrName, name in requiredMultiKeys.items():
             if len(getattr(self, attrName)) == 0:
-                errors.append("    Must provide at least one '{0}' entry.".format(name))
+                errors.append(f"    Must provide at least one '{name}' entry.")
         if warnings:
             warn("Some recommended metadata is missing:\n{0}", "\n".join(warnings))
         if errors:
@@ -276,7 +273,7 @@ class MetadataManager:
         macros["level"] = str(self.level)
         macros["vshortname"] = self.displayVshortname
         if self.status == "FINDING" and self.group:
-            macros["longstatus"] = "Finding of the {0}".format(self.group)
+            macros["longstatus"] = f"Finding of the {self.group}"
         elif self.status in config.shortToLongStatus:
             macros["longstatus"] = config.shortToLongStatus[self.status]
         else:
@@ -301,9 +298,9 @@ class MetadataManager:
             macros["abstract"] = ""
             macros["abstractattr"] = ""
         macros["year"] = self.date.year
-        macros["date"] = self.date.strftime("{0} %B %Y".format(self.date.day))
+        macros["date"] = self.date.strftime(f"{self.date.day} %B %Y")
         macros["date-dmmy"] = self.date.strftime(
-            "{0} %B %Y".format(self.date.day)
+            f"{self.date.day} %B %Y"
         )  # same as plain 'date'
         macros["cdate"] = self.date.strftime("%Y%m%d")
         macros["isodate"] = self.date.strftime("%Y-%m-%d")
@@ -311,10 +308,10 @@ class MetadataManager:
         macros["date-mmy"] = self.date.strftime("%B %Y")
         if isinstance(self.expires, date):
             macros["expires"] = self.expires.strftime(
-                "{0} %B %Y".format(self.expires.day)
+                f"{self.expires.day} %B %Y"
             )
             macros["expires-dmmy"] = self.expires.strftime(
-                "{0} %B %Y".format(self.expires.day)
+                f"{self.expires.day} %B %Y"
             )  # same as plain 'expires'
             macros["cexpires"] = self.expires.strftime("%Y%m%d")
             macros["isoexpires"] = self.expires.strftime("%Y-%m-%d")
@@ -322,7 +319,7 @@ class MetadataManager:
             macros["expires-mmy"] = self.expires.strftime("%B %Y")
         if self.deadline:
             macros["deadline"] = self.deadline.strftime(
-                "{0} %B %Y".format(self.deadline.day)
+                f"{self.deadline.day} %B %Y"
             )
             macros["isodeadline"] = self.deadline.strftime("%Y-%m-%d")
         if self.status in config.snapshotStatuses:
@@ -374,7 +371,7 @@ class MetadataManager:
             )
             macros[
                 "w3c-stylesheet-url"
-            ] = "https://www.w3.org/StyleSheets/TR/2016/W3C-{0}".format(shortStatus)
+            ] = f"https://www.w3.org/StyleSheets/TR/2016/W3C-{shortStatus}"
         if self.customWarningText is not None:
             macros["customwarningtext"] = "\n".join(
                 markdown.parse(self.customWarningText, self.indent)
@@ -619,7 +616,7 @@ def parseLinkDefaults(key, val, lineNum):
     defaultSpecs = defaultdict(list)
     for default in val.split(","):
         match = re.match(
-            r"^([\w\d-]+)  (?:\s+\( ({0}) (?:\s+(snapshot|current))? \) )  \s+(.*)$".format(
+            r"^([\w\d-]+)  (?:\s+\( ({}) (?:\s+(snapshot|current))? \) )  \s+(.*)$".format(
                 "|".join(config.dfnTypes.union(["dfn"]))
             ),
             default.strip(),
@@ -1238,7 +1235,7 @@ def join(*sources):
 
 
 @attr.s(slots=True, frozen=True)
-class Metadata(object):
+class Metadata:
     humanName = attr.ib()
     attrName = attr.ib()
     join = attr.ib()

--- a/bikeshed/publish.py
+++ b/bikeshed/publish.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import logging
 import os
 import tarfile

--- a/bikeshed/railroaddiagrams.py
+++ b/bikeshed/railroaddiagrams.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 # Display constants
 VERTICAL_SEPARATION = 8
 ARC_RADIUS = 10
@@ -38,7 +36,7 @@ def doubleenumerate(seq):
         yield i, i - length, item
 
 
-class DiagramItem(object):
+class DiagramItem:
     def __init__(self, name, attrs=None, text=None):
         self.name = name
         # up = distance it projects above the entry line
@@ -296,7 +294,7 @@ class OptionalSequence(DiagramItem):
         if len(items) <= 1:
             return Sequence(*items)
         else:
-            return super(OptionalSequence, cls).__new__(cls, *items)
+            return super().__new__(cls, *items)
 
     def __init__(self, *items):
         DiagramItem.__init__(self, "g")

--- a/bikeshed/railroadparser.py
+++ b/bikeshed/railroadparser.py
@@ -63,7 +63,7 @@ def parse(string):
             )
             return rr.Diagram()
         lastIndent = indent
-        if re.match(r"\s*({0})\W".format(blockNames), line):
+        if re.match(fr"\s*({blockNames})\W", line):
             match = re.match(r"\s*(\w+)\s*:\s*(.*)", line)
             if not match:
                 die(
@@ -75,7 +75,7 @@ def parse(string):
             command = match.group(1)
             prelude = match.group(2).strip()
             node = {"command": command, "prelude": prelude, "children": [], "line": i}
-        elif re.match(r"\s*({0})\W".format(textNames), line):
+        elif re.match(fr"\s*({textNames})\W", line):
             match = re.match(r"\s*(\w+)(\s[\w\s]+)?:\s*(.*)", line)
             if not match:
                 die(

--- a/bikeshed/refs/RefSource.py
+++ b/bikeshed/refs/RefSource.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import copy
 import re
 from collections import defaultdict
@@ -12,7 +9,7 @@ from .utils import *
 from ..messages import linkerror
 
 
-class RefSource(object):
+class RefSource:
 
     __slots__ = [
         "dataFile",
@@ -69,7 +66,7 @@ class RefSource(object):
             return []
         # Otherwise, load the group file.
         with self.dataFile.fetch(
-            "anchors", "anchors-{0}.data".format(group), okayToFail=True
+            "anchors", f"anchors-{group}.data", okayToFail=True
         ) as fh:
             self._refs.update(decodeAnchors(fh))
             self._loadedAnchorGroups.add(group)

--- a/bikeshed/refs/RefWrapper.py
+++ b/bikeshed/refs/RefWrapper.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import copy
 
 import attr
@@ -9,7 +6,7 @@ from .utils import stripLineBreaks
 
 
 @attr.s(slots=True)
-class RefWrapper(object):
+class RefWrapper:
     # Refs don't contain their own name, so I don't have to copy as much when there are multiple linkTexts
     # This wraps that, producing an object that looks like it has a text property.
     # It also makes all the ref dict keys look like object attributes.

--- a/bikeshed/refs/ReferenceManager.py
+++ b/bikeshed/refs/ReferenceManager.py
@@ -1,4 +1,3 @@
-import io
 import json
 import random
 import re

--- a/bikeshed/refs/ReferenceManager.py
+++ b/bikeshed/refs/ReferenceManager.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import io
 import json
 import random
@@ -18,7 +15,7 @@ from ..h import *
 from ..messages import *
 
 
-class ReferenceManager(object):
+class ReferenceManager:
 
     __slots__ = [
         "dataFile",
@@ -144,7 +141,7 @@ class ReferenceManager(object):
                     datablocks.transformAnchors(
                         doc.inputSource.relative("anchors.bsdata").read().rawLines, doc
                     )
-                except IOError:
+                except OSError:
                     warn(
                         "anchors.bsdata not found despite being listed in the External Infotrees metadata."
                     )
@@ -171,7 +168,7 @@ class ReferenceManager(object):
                         .rawLines,
                         doc,
                     )
-                except IOError:
+                except OSError:
                     warn(
                         "link-defaults.infotree not found despite being listed in the External Infotrees metadata."
                     )
@@ -180,7 +177,7 @@ class ReferenceManager(object):
         if spec in self.headings:
             return self.headings[spec]
         with self.dataFile.fetch(
-            "headings", "headings-{0}.json".format(spec), okayToFail=True
+            "headings", f"headings-{spec}.json", okayToFail=True
         ) as fh:
             try:
                 data = json.load(fh)
@@ -201,9 +198,9 @@ class ReferenceManager(object):
         # Get local bibliography data
         try:
             storage = defaultdict(list)
-            with io.open("biblio.json", "r", encoding="utf-8") as fh:
+            with open("biblio.json", encoding="utf-8") as fh:
                 biblio.processSpecrefBiblioFile(fh.read(), storage, order=2)
-        except IOError:
+        except OSError:
             # Missing file is fine
             pass
         for k, vs in storage.items():
@@ -861,7 +858,7 @@ class ReferenceManager(object):
             group = key[0:2]
             if group not in self.loadedBiblioGroups:
                 with self.dataFile.fetch(
-                    "biblio", "biblio-{0}.data".format(group), okayToFail=True
+                    "biblio", f"biblio-{group}.data", okayToFail=True
                 ) as lines:
                     biblio.loadBiblioDataFile(lines, self.biblios)
             self.loadedBiblioGroups.add(group)
@@ -964,12 +961,12 @@ def reportMultiplePossibleRefs(
             mergedRefs.append(refs)
 
     if linkFor:
-        error = "Multiple possible '{0}' {1} refs for '{2}'.".format(
+        error = "Multiple possible '{}' {} refs for '{}'.".format(
             linkText, linkType, linkFor
         )
     else:
-        error = "Multiple possible '{0}' {1} refs.".format(linkText, linkType)
-    error += "\nArbitrarily chose {0}".format(defaultRef.url)
+        error = f"Multiple possible '{linkText}' {linkType} refs."
+    error += f"\nArbitrarily chose {defaultRef.url}"
     if uniqueRefs:
         error += "\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\n"
         error += "\n".join(refToText(r) for r in uniqueRefs)

--- a/bikeshed/refs/__init__.py
+++ b/bikeshed/refs/__init__.py
@@ -1,4 +1,1 @@
-# -*- coding: utf-8 -*-
-
-
 from .ReferenceManager import ReferenceManager

--- a/bikeshed/refs/utils.py
+++ b/bikeshed/refs/utils.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from collections import defaultdict
 from .. import config
 
@@ -9,7 +6,7 @@ def filterObsoletes(
     refs, replacedSpecs, ignoredSpecs, localShortname=None, localSpec=None
 ):
     # Remove any ignored or obsoleted specs
-    possibleSpecs = set(ref.spec for ref in refs)
+    possibleSpecs = {ref.spec for ref in refs}
     if localSpec:
         possibleSpecs.add(localSpec)
     moreIgnores = set()

--- a/bikeshed/repository.py
+++ b/bikeshed/repository.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class Repository(object):
+class Repository:
     """
     A class for representing spec repositories.
     """
@@ -28,9 +25,9 @@ class Repository(object):
 
 class GithubRepository(Repository):
     def __init__(self, ns, user, repo):
-        super(GithubRepository, self).__init__(
-            "https://github.{0}/{1}/{2}".format(ns, user, repo),
-            "{0}/{1}".format(user, repo),
+        super().__init__(
+            f"https://github.{ns}/{user}/{repo}",
+            f"{user}/{repo}",
         )
         self.ns = ns
         self.user = user
@@ -39,16 +36,16 @@ class GithubRepository(Repository):
         if ns == "com":
             self.api = "https://api.github.com"
         else:
-            self.api = "https://github.{0}/api/v3".format(ns)
+            self.api = f"https://github.{ns}/api/v3"
 
     def formatIssueUrl(self, id=None):
         if id is None:
-            return "https://github.{0}/{1}/{2}/issues/".format(
+            return "https://github.{}/{}/{}/issues/".format(
                 self.ns, self.user, self.repo
             )
-        return "https://github.{0}/{1}/{2}/issues/{3}".format(
+        return "https://github.{}/{}/{}/issues/{}".format(
             self.ns, self.user, self.repo, id
         )
 
     def __str__(self):
-        return "{0}/{1}".format(self.user, self.repo)
+        return f"{self.user}/{self.repo}"

--- a/bikeshed/shorthands/biblio.py
+++ b/bikeshed/shorthands/biblio.py
@@ -48,7 +48,7 @@ class BiblioShorthand:
         self.bsAutolink += "]]"
 
         if not self.linkText:
-            self.linkText = "[{0}]".format(self.term)
+            self.linkText = f"[{self.term}]"
 
         attrs = {
             "data-lt": self.term,

--- a/bikeshed/shorthands/oldShorthands.py
+++ b/bikeshed/shorthands/oldShorthands.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from .. import config
 from ..h import *
@@ -92,9 +90,9 @@ def transformProductionPlaceholders(doc):
                 except:
                     print(text)
                     raise
-                interior += " [{0},{1}]".format(rangeStart, rangeEnd)
-                el.set("data-lt", "<{0}>".format(term))
-            el.text = "<{0}>".format(interior)
+                interior += f" [{rangeStart},{rangeEnd}]"
+                el.set("data-lt", f"<{term}>")
+            el.text = f"<{interior}>"
             continue
         die(
             "Shorthand <<{0}>> does not match any recognized shorthand grammar.",
@@ -382,7 +380,7 @@ def biblioReplacer(match):
     else:
         type = "informative"
     if linkText is None:
-        linkText = "[{0}]".format(term)
+        linkText = f"[{term}]"
     attrs = {
         "data-lt": term,
         "data-link-type": "biblio",

--- a/bikeshed/stringEnum/StringEnum.py
+++ b/bikeshed/stringEnum/StringEnum.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class StringEnum(object):
+class StringEnum:
     """
     Simple Enum class.
 

--- a/bikeshed/stringEnum/__init__.py
+++ b/bikeshed/stringEnum/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from .StringEnum import StringEnum

--- a/bikeshed/test.py
+++ b/bikeshed/test.py
@@ -1,6 +1,5 @@
 import difflib
 import glob
-import io
 import os
 import re
 from itertools import *

--- a/bikeshed/test.py
+++ b/bikeshed/test.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import difflib
 import glob
 import io
@@ -66,7 +63,7 @@ def runAllTests(patterns=None, manualOnly=False, md=None):
         total += 1
         doc = processTest(path, md)
         outputText = doc.serialize()
-        with io.open(path[:-2] + "html", encoding="utf-8") as golden:
+        with open(path[:-2] + "html", encoding="utf-8") as golden:
             goldenText = golden.read()
         if compare(outputText, goldenText):
             numPassed += 1
@@ -76,7 +73,7 @@ def runAllTests(patterns=None, manualOnly=False, md=None):
         p(printColor("✔ All tests passed.", color="green"))
         return True
     else:
-        p(printColor("✘ {0}/{1} tests passed.".format(numPassed, total), color="red"))
+        p(printColor(f"✘ {numPassed}/{total} tests passed.", color="red"))
         p(printColor("Failed Tests:", color="red"))
         for fail in fails:
             p("* " + fail)

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1,4 +1,3 @@
-import io
 import json
 import logging
 import re

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import io
 import json
 import logging
@@ -190,7 +187,7 @@ def canonicalizeShortcuts(doc):
         "algorithm": "data-algorithm",
         "ignore": "data-var-ignore",
     }
-    for el in findAll(",".join("[{0}]".format(attr) for attr in attrFixup.keys()), doc):
+    for el in findAll(",".join(f"[{attr}]" for attr in attrFixup.keys()), doc):
         for attr, fixedAttr in attrFixup.items():
             if el.get(attr) is not None:
                 el.set(fixedAttr, el.get(attr))
@@ -497,7 +494,7 @@ def fixInterDocumentReferences(doc):
                         + "but that spec is versioned as {1}. "
                         + "Please choose a versioned spec name.",
                         spec,
-                        config.englishFromList("'{0}'".format(x) for x in vNames),
+                        config.englishFromList(f"'{x}'" for x in vNames),
                         outerHTML(el),
                         el=el,
                     )
@@ -539,7 +536,7 @@ def fillInterDocumentReferenceFromShepherd(doc, el, spec, section):
                 "Multiple headings with id '{0}' for spec '{1}'. Please specify:\n{2}",
                 section,
                 spec,
-                "\n".join("  [[{0}]]".format(spec + x) for x in heading),
+                "\n".join("  [[{}]]".format(spec + x) for x in heading),
                 el=el,
             )
             return
@@ -743,7 +740,7 @@ def classifyDfns(doc, dfns):
                 el.set(
                     "data-alternate-id",
                     config.simplifyText(
-                        "dom-{_for}-{id}".format(_for=singleFor, id=primaryDfnText)
+                        f"dom-{singleFor}-{primaryDfnText}"
                     ),
                 )
                 if primaryDfnText.startswith("[["):
@@ -752,12 +749,12 @@ def classifyDfns(doc, dfns):
                     id += "-slot"
                     el.set(
                         "data-alternate-id",
-                        "{0}-slot".format(el.get("data-alternate-id")),
+                        "{}-slot".format(el.get("data-alternate-id")),
                     )
             else:
                 if dfnFor:
                     id = config.simplifyText(
-                        "{_for}-{id}".format(_for=singleFor, id=primaryDfnText)
+                        f"{singleFor}-{primaryDfnText}"
                     )
                 else:
                     id = config.simplifyText(primaryDfnText)
@@ -955,10 +952,10 @@ def verifyUsageOfAllLocalBiblios(doc):
     were used in the spec,
     so you can remove entries when they're no longer necessary.
     """
-    usedBiblioKeys = set(
+    usedBiblioKeys = {
         x.lower()
         for x in list(doc.normativeRefs.keys()) + list(doc.informativeRefs.keys())
-    )
+    }
     localBiblios = [
         b["linkText"].lower()
         for bs in doc.refs.biblios.values()
@@ -972,7 +969,7 @@ def verifyUsageOfAllLocalBiblios(doc):
     if unusedBiblioKeys:
         warn(
             "The following locally-defined biblio entries are unused and can be removed:\n{0}",
-            "\n".join("  * {0}".format(b) for b in unusedBiblioKeys),
+            "\n".join(f"  * {b}" for b in unusedBiblioKeys),
         )
 
 
@@ -1081,7 +1078,7 @@ def decorateAutolink(doc, el, linkType, linkText, ref):
     if el.get("id") is None:
         _, _, id = ref.url.partition("#")
         if id:
-            el.set("id", "ref-for-{0}".format(id))
+            el.set("id", f"ref-for-{id}")
             el.set("data-silently-dedup", "")
 
     # Get all the values that the type expands to, add it as a title.
@@ -1132,20 +1129,20 @@ def processIssuesAndExamples(doc):
             numberMatch = re.match(r"\s*(\d+)\s*$", remoteIssueID)
             remoteIssueURL = None
             if githubMatch:
-                remoteIssueURL = "https://github.com/{0}/{1}/issues/{2}".format(
+                remoteIssueURL = "https://github.com/{}/{}/issues/{}".format(
                     *githubMatch.groups()
                 )
                 if doc.md.inlineGithubIssues:
                     el.set(
                         "data-inline-github",
-                        "{0} {1} {2}".format(*githubMatch.groups()),
+                        "{} {} {}".format(*githubMatch.groups()),
                     )
             elif numberMatch and doc.md.repository.type == "github":
                 remoteIssueURL = doc.md.repository.formatIssueUrl(numberMatch.group(1))
                 if doc.md.inlineGithubIssues:
                     el.set(
                         "data-inline-github",
-                        "{0} {1} {2}".format(
+                        "{} {} {}".format(
                             doc.md.repository.user,
                             doc.md.repository.repo,
                             numberMatch.group(1),
@@ -1425,7 +1422,7 @@ def hackyLineNumbers(lines):
     for line in lines:
         line.text = re.sub(
             r"(^|[^<])(<[\w-]+)([ >])",
-            r"\1\2 line-number={0}\3".format(line.i),
+            fr"\1\2 line-number={line.i}\3",
             line.text,
         )
     return lines
@@ -1537,12 +1534,12 @@ def inlineRemoteIssues(doc):
 
     responses = json.loads(doc.dataFile.fetch("github-issues.json", str=True))
     for i, issue in enumerate(inlineIssues):
-        issueUserRepo = "{0}/{1}".format(*issue)
-        key = "{0}/{1}".format(issueUserRepo, issue.num)
-        href = "https://github.{0}/{1}/issues/{2}".format(
+        issueUserRepo = "{}/{}".format(*issue)
+        key = f"{issueUserRepo}/{issue.num}"
+        href = "https://github.{}/{}/issues/{}".format(
             doc.md.repository.ns, issueUserRepo, issue.num
         )
-        url = "{0}/repos/{1}/issues/{2}".format(
+        url = "{}/repos/{}/issues/{}".format(
             doc.md.repository.api, issueUserRepo, issue.num
         )
         say("Fetching issue {:-3d}/{:d}: {:s}".format(i + 1, len(inlineIssues), key))
@@ -1627,7 +1624,7 @@ def inlineRemoteIssues(doc):
                 el,
                 E.a(
                     {"href": href, "class": "marker"},
-                    "Issue #{0} on GitHub: “{1}”".format(data["number"], data["title"]),
+                    "Issue #{} on GitHub: “{}”".format(data["number"], data["title"]),
                 ),
                 *parseHTML(data["body_html"]),
             )
@@ -1636,7 +1633,7 @@ def inlineRemoteIssues(doc):
             el.tag = "div"
     # Save the cache for later
     try:
-        with io.open(
+        with open(
             config.scriptPath("spec-data", "github-issues.json"), "w", encoding="utf-8"
         ) as f:
             f.write(json.dumps(responses, ensure_ascii=False, indent=2, sort_keys=True))

--- a/bikeshed/update/__init__.py
+++ b/bikeshed/update/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from .main import fixupDataFiles, update, updateReadonlyDataFiles
 from .manifest import createManifest
 

--- a/bikeshed/update/main.py
+++ b/bikeshed/update/main.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import os
 
 from . import updateBackRefs
@@ -68,12 +65,12 @@ def fixupDataFiles():
     using the legacy files with the new code is quite bad!
     """
     try:
-        localVersion = int(open(localPath("version.txt"), "r").read())
-    except IOError:
+        localVersion = int(open(localPath("version.txt")).read())
+    except OSError:
         localVersion = None
     try:
-        remoteVersion = int(open(remotePath("version.txt"), "r").read())
-    except IOError as err:
+        remoteVersion = int(open(remotePath("version.txt")).read())
+    except OSError as err:
         warn("Couldn't check the datafile version. Bikeshed may be unstable.\n{0}", err)
         return
 
@@ -144,7 +141,7 @@ def cleanupFiles(root, touchedPaths, dryRun=False):
             os.remove(absPath)
             oldPaths.append(relPath)
     if oldPaths:
-        say("Success! Deleted {0} old files.".format(len(oldPaths)))
+        say("Success! Deleted {} old files.".format(len(oldPaths)))
     else:
         say("Success! Nothing to delete.")
 

--- a/bikeshed/update/manifest.py
+++ b/bikeshed/update/manifest.py
@@ -2,7 +2,6 @@ import asyncio
 import aiofiles
 import aiohttp
 import hashlib
-import io
 import os
 import requests
 import tenacity

--- a/bikeshed/update/manifest.py
+++ b/bikeshed/update/manifest.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import asyncio
 import aiofiles
 import aiohttp
@@ -53,7 +50,7 @@ def createManifest(path, dryRun=False):
                 pass
             else:
                 continue
-            with io.open(absPath, "r", encoding="utf-8") as fh:
+            with open(absPath, encoding="utf-8") as fh:
                 manifests.append((relPath, hashFile(fh)))
     except Exception:
         raise
@@ -64,7 +61,7 @@ def createManifest(path, dryRun=False):
 
     if not dryRun:
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "manifest.txt"), "w", encoding="utf-8"
             ) as fh:
                 fh.write(manifest)
@@ -109,7 +106,7 @@ def updateByManifest(path, dryRun=False):
     say("Gathering local manifest data...")
     # Get the last-update time from the local manifest
     try:
-        with io.open(os.path.join(path, "manifest.txt"), "r", encoding="utf-8") as fh:
+        with open(os.path.join(path, "manifest.txt"), encoding="utf-8") as fh:
             localDt = dtFromManifest(fh.readlines())
     except Exception as e:
         localDt = "error"
@@ -183,7 +180,7 @@ def updateByManifest(path, dryRun=False):
                 deletedPaths.append(filePath)
         if deletedPaths:
             print(
-                "Deleted {0} old data file{1}.".format(
+                "Deleted {} old data file{}.".format(
                     len(deletedPaths), "s" if len(deletedPaths) > 1 else ""
                 )
             )
@@ -197,7 +194,7 @@ def updateByManifest(path, dryRun=False):
             )
         goodPaths, badPaths = asyncio.run(updateFiles(path, newPaths))
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "manifest.txt"), "w", encoding="utf-8"
             ) as fh:
                 fh.write(createFinishedManifest(remoteManifest, goodPaths, badPaths))

--- a/bikeshed/update/updateBackRefs.py
+++ b/bikeshed/update/updateBackRefs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import urllib.parse
 from collections import defaultdict
@@ -48,11 +46,11 @@ def update(path, dryRun=False):
                 _, _, referencedID = ref.url.partition("#")
                 referencedID = urllib.parse.unquote(referencedID)
                 referencedShortname = ref.spec
-                referencingLinks = findAll("[href='{0}']".format(ref.url), doc)
+                referencingLinks = findAll(f"[href='{ref.url}']", doc)
                 referencingIDs = [
                     link.get("id") for link in referencingLinks if link.get("id")
                 ]
-                referencingURLs = ["{0}#{1}".format(url, id) for id in referencingIDs]
+                referencingURLs = [f"{url}#{id}" for id in referencingIDs]
                 backrefs[referencedShortname][referencedID].append(
                     {"shortname": referencingShortname, "urls": referencingURLs}
                 )

--- a/bikeshed/update/updateBiblio.py
+++ b/bikeshed/update/updateBiblio.py
@@ -1,4 +1,3 @@
-import io
 import json
 import re
 import os

--- a/bikeshed/update/updateBiblio.py
+++ b/bikeshed/update/updateBiblio.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import json
 import re
@@ -24,9 +22,9 @@ def update(path, dryRun=False):
         # Save each group to a file
         for group, biblios in groupedBiblios.items():
             try:
-                p = os.path.join(path, "biblio", "biblio-{0}.data".format(group))
+                p = os.path.join(path, "biblio", f"biblio-{group}.data")
                 writtenPaths.add(p)
-                with io.open(p, "w", encoding="utf-8") as fh:
+                with open(p, "w", encoding="utf-8") as fh:
                     writeBiblioFile(fh, biblios)
             except Exception as e:
                 die("Couldn't save biblio database to disk.\n{0}", e)
@@ -73,7 +71,7 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "biblio-keys.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write(
                     str(
                         json.dumps(
@@ -90,7 +88,7 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "biblio-numeric-suffixes.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write(
                     str(
                         json.dumps(

--- a/bikeshed/update/updateCanIUse.py
+++ b/bikeshed/update/updateCanIUse.py
@@ -1,4 +1,3 @@
-import io
 import json
 import os
 import requests

--- a/bikeshed/update/updateCanIUse.py
+++ b/bikeshed/update/updateCanIUse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import json
 import os
@@ -91,7 +89,7 @@ def update(path, dryRun=False):
                         version = simplifyVersion(v)
                     else:
                         break
-            browserData[codeNames[browser]] = "{0} {1}".format(status, version)
+            browserData[codeNames[browser]] = f"{status} {version}"
         featureData[featureName] = {"notes": notes, "url": url, "support": browserData}
 
     writtenPaths = set()
@@ -99,17 +97,17 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "caniuse", "data.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write(
                     json.dumps(basicData, indent=1, ensure_ascii=False, sort_keys=True)
                 )
 
             for featureName, feature in featureData.items():
                 p = os.path.join(
-                    path, "caniuse", "feature-{0}.json".format(featureName)
+                    path, "caniuse", f"feature-{featureName}.json"
                 )
                 writtenPaths.add(p)
-                with io.open(p, "w", encoding="utf-8") as fh:
+                with open(p, "w", encoding="utf-8") as fh:
                     fh.write(
                         json.dumps(
                             feature, indent=1, ensure_ascii=False, sort_keys=True

--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -1,5 +1,4 @@
 import certifi
-import io
 import json
 import re
 import tenacity

--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import certifi
 import io
 import json
@@ -76,16 +74,16 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "specs.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as f:
+            with open(p, "w", encoding="utf-8") as f:
                 f.write(json.dumps(specs, ensure_ascii=False, indent=2, sort_keys=True))
         except Exception as e:
             die("Couldn't save spec database to disk.\n{0}", e)
             return
         try:
             for spec, specHeadings in headings.items():
-                p = os.path.join(path, "headings", "headings-{0}.json".format(spec))
+                p = os.path.join(path, "headings", f"headings-{spec}.json")
                 writtenPaths.add(p)
-                with io.open(p, "w", encoding="utf-8") as f:
+                with open(p, "w", encoding="utf-8") as f:
                     f.write(
                         json.dumps(
                             specHeadings, ensure_ascii=False, indent=2, sort_keys=True
@@ -102,7 +100,7 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "methods.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as f:
+            with open(p, "w", encoding="utf-8") as f:
                 f.write(
                     json.dumps(methods, ensure_ascii=False, indent=2, sort_keys=True)
                 )
@@ -112,7 +110,7 @@ def update(path, dryRun=False):
         try:
             p = os.path.join(path, "fors.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as f:
+            with open(p, "w", encoding="utf-8") as f:
                 f.write(json.dumps(fors, ensure_ascii=False, indent=2, sort_keys=True))
         except Exception as e:
             die("Couldn't save fors database to disk.\n{0}", e)
@@ -241,7 +239,7 @@ def addToHeadings(rawAnchor, specHeadings, spec):
     if uri[0] == "#":
         # Either single-page spec, or link on the top page of a multi-page spec
         heading = {
-            "url": spec["{0}_url".format(rawAnchor["status"])] + uri,
+            "url": spec["{}_url".format(rawAnchor["status"])] + uri,
             "number": rawAnchor["name"]
             if re.match(r"[\d.]+$", rawAnchor["name"])
             else "",
@@ -271,7 +269,7 @@ def addToHeadings(rawAnchor, specHeadings, spec):
             fragment = "#"
         shorthand = page + fragment
         heading = {
-            "url": spec["{0}_url".format(rawAnchor["status"])] + uri,
+            "url": spec["{}_url".format(rawAnchor["status"])] + uri,
             "number": rawAnchor["name"]
             if re.match(r"[\d.]+$", rawAnchor["name"])
             else "",
@@ -309,7 +307,7 @@ def addToAnchors(rawAnchor, anchors, spec):
         "level": int(spec["level"]),
         "export": rawAnchor.get("export", False),
         "normative": rawAnchor.get("normative", False),
-        "url": spec["{0}_url".format(rawAnchor["status"])] + rawAnchor["uri"],
+        "url": spec["{}_url".format(rawAnchor["status"])] + rawAnchor["uri"],
         "for": rawAnchor.get("for", []),
     }
     for text in rawAnchor["linking_text"]:
@@ -387,9 +385,9 @@ def writeAnchorsFile(anchors, path):
         group = config.groupFromKey(key)
         groupedEntries[group][key] = entries
     for group, anchors in groupedEntries.items():
-        p = os.path.join(path, "anchors", "anchors-{0}.data".format(group))
+        p = os.path.join(path, "anchors", f"anchors-{group}.data")
         writtenPaths.add(p)
-        with io.open(p, "w", encoding="utf-8") as fh:
+        with open(p, "w", encoding="utf-8") as fh:
             for key, entries in sorted(anchors.items(), key=lambda x: x[0]):
                 for e in entries:
                     fh.write(key + "\n")

--- a/bikeshed/update/updateLanguages.py
+++ b/bikeshed/update/updateLanguages.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import os
 import requests
@@ -19,7 +17,7 @@ def update(path, dryRun=False):
 
     if not dryRun:
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "languages.json"), "w", encoding="utf-8"
             ) as f:
                 f.write(data)

--- a/bikeshed/update/updateLanguages.py
+++ b/bikeshed/update/updateLanguages.py
@@ -1,4 +1,3 @@
-import io
 import os
 import requests
 

--- a/bikeshed/update/updateLinkDefaults.py
+++ b/bikeshed/update/updateLinkDefaults.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import os
 import requests
@@ -19,7 +17,7 @@ def update(path, dryRun=False):
 
     if not dryRun:
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "link-defaults.infotree"), "w", encoding="utf-8"
             ) as f:
                 f.write(data)

--- a/bikeshed/update/updateLinkDefaults.py
+++ b/bikeshed/update/updateLinkDefaults.py
@@ -1,4 +1,3 @@
-import io
 import os
 import requests
 

--- a/bikeshed/update/updateMdn.py
+++ b/bikeshed/update/updateMdn.py
@@ -1,4 +1,3 @@
-import io
 import json
 import os
 import requests

--- a/bikeshed/update/updateMdn.py
+++ b/bikeshed/update/updateMdn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 import json
 import os
@@ -34,7 +33,7 @@ def update(path, dryRun=False):
                 os.makedirs(mdnSpecLinksDir)
             p = os.path.join(path, "mdn.json")
             writtenPaths.add(p)
-            with io.open(p, "w", encoding="utf-8") as fh:
+            with open(p, "w", encoding="utf-8") as fh:
                 fh.write(
                     json.dumps(data, indent=1, ensure_ascii=False, sort_keys=False)
                 )
@@ -59,7 +58,7 @@ def update(path, dryRun=False):
                         e,
                     )
                     return
-                with io.open(p, "w", encoding="utf-8") as fh:
+                with open(p, "w", encoding="utf-8") as fh:
                     fh.write(fileContents)
         except Exception as e:
             die("Couldn't save MDN Spec Links data to disk.\n{0}", e)

--- a/bikeshed/update/updateTestSuites.py
+++ b/bikeshed/update/updateTestSuites.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import certifi
 import io
 import json
@@ -54,7 +52,7 @@ def update(path, dryRun=False):
 
     if not dryRun:
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "test-suites.json"), "w", encoding="utf-8"
             ) as f:
                 f.write(

--- a/bikeshed/update/updateTestSuites.py
+++ b/bikeshed/update/updateTestSuites.py
@@ -1,5 +1,4 @@
 import certifi
-import io
 import json
 import os
 from json_home_client import Client as APIClient

--- a/bikeshed/update/updateWpt.py
+++ b/bikeshed/update/updateWpt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import os
 import requests
@@ -44,10 +42,10 @@ def update(path, dryRun=False):
             collectPaths(paths, typePaths, testType + " ")
     if not dryRun:
         try:
-            with io.open(
+            with open(
                 os.path.join(path, "wpt-tests.txt"), "w", encoding="utf-8"
             ) as f:
-                f.write("sha: {0}\n".format(sha))
+                f.write(f"sha: {sha}\n")
                 for path in sorted(paths):
                     f.write(path + "\n")
         except Exception as e:
@@ -59,7 +57,7 @@ def update(path, dryRun=False):
 def collectPaths(pathListSoFar, pathTrie, pathPrefix):
     for k, v in pathTrie.items():
         if isinstance(v, dict):
-            collectPaths(pathListSoFar, v, "{0}{1}/".format(pathPrefix, k))
+            collectPaths(pathListSoFar, v, f"{pathPrefix}{k}/")
         else:
             pathListSoFar.append(pathPrefix + k)
     return pathListSoFar

--- a/bikeshed/update/updateWpt.py
+++ b/bikeshed/update/updateWpt.py
@@ -1,4 +1,3 @@
-import io
 import os
 import requests
 

--- a/bikeshed/wpt/__init__.py
+++ b/bikeshed/wpt/__init__.py
@@ -1,4 +1,1 @@
-# -*- coding: utf-8 -*-
-
-
 from .wptElement import processWptElements

--- a/bikeshed/wpt/wptElement.py
+++ b/bikeshed/wpt/wptElement.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from ..h import (
     findAll,
     textContent,
@@ -108,9 +105,7 @@ def createHTML(doc, blockEl, testNames, testData):
                     E.a(
                         {
                             "title": testName,
-                            "href": "{0}://web-platform-tests.live/{1}".format(
-                                liveTestScheme, testName
-                            ),
+                            "href": f"{liveTestScheme}://web-platform-tests.live/{testName}",
                             "class": "wpt-live",
                         },
                         E.small("(live test)"),

--- a/release.py
+++ b/release.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import argparse
 import json
 import os
@@ -22,14 +20,14 @@ def createRelease():
         )
         sys.exit(1)
 
-    with open("semver.txt", "r") as fh:
+    with open("semver.txt") as fh:
         currentVersion = fh.read().strip()
         semver = parseSemver(currentVersion)
 
     try:
-        with open("secrets.json", "r") as fh:
+        with open("secrets.json") as fh:
             secrets = json.load(fh)
-    except IOError:
+    except OSError:
         print("Error trying to load the secrets.json file.")
         raise
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     long_description = fh.read()
-with open("semver.txt", "r") as fh:
+with open("semver.txt") as fh:
     semver = fh.read().strip()
-with open("requirements.txt", "r") as fh:
+with open("requirements.txt") as fh:
     install_requires = [x.strip() for x in fh.read().strip().split("\n")]
 
 setup(


### PR DESCRIPTION
- ran `find . -path "*.py" -exec pyupgrade --py37-plus {} \;`
- Manually removed fonts.py call shebang to py 2.7
- Fixed "termref-for-" not passing refID to old .format
- Second pass seems to catch the previous io.open and fix default read