### PR TITLE
chore: Ignore BS functions defined in includes

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -289,7 +289,8 @@ class Spec:
                     "http://lists.w3.org"
                 ):
                     el.text = "https" + text[4:]
-            extensions.BSPrepTR(self)
+            # Loaded from .include files
+            extensions.BSPrepTR(self)  # pylint: disable=no-member
 
         return self
 

--- a/bikeshed/publish.py
+++ b/bikeshed/publish.py
@@ -62,7 +62,10 @@ def prepareTar(doc, visibleTar=False, additionalDirectories=None):
         f = tempfile.NamedTemporaryFile(delete=False)
         tar = tarfile.open(fileobj=f, mode="w")
     tar.add(specOutput.name, arcname="Overview.html")
-    additionalFiles = extensions.BSPublishAdditionalFiles(additionalDirectories)
+    # Loaded from .include files
+    additionalFiles = extensions.BSPublishAdditionalFiles(  # pylint: disable=no-member
+        additionalDirectories
+    )
     for fname in additionalFiles:
         try:
             if isinstance(fname, str):


### PR DESCRIPTION
Refrenced in publish.py and Spec.py.
Copied placeholders from boilerplate/bs-extensions.include