### PR TITLE
Make warnings refer to the main branch

### DIFF
--- a/bikeshed/boilerplate/warning-branch.include
+++ b/bikeshed/boilerplate/warning-branch.include
@@ -2,7 +2,7 @@
   <summary>This is a branch snapshot of the standard</summary>
   <p>
     This document contains the contents of the standard as they were last seen in the <a href="[SNAPSHOTURL]">[SNAPSHOTID] branch</a>,
-    and do not reflect the state of the master branch and the living standard it embodies.
+    and do not reflect the state of the main branch and the living standard it embodies.
   <p>
     Do not attempt to implement this version of the standard.
     Do not reference this version as authoritative in any way.

--- a/bikeshed/boilerplate/warning-commit.include
+++ b/bikeshed/boilerplate/warning-commit.include
@@ -3,7 +3,7 @@
   <p>
     This document contains the contents of the standard as of the <a href="[SNAPSHOTURL]">[SNAPSHOTID] commit</a>,
     and should only be used as a historical reference.
-    This commit may not even have been merged into master.
+    This commit may not even have been merged into the main branch.
   <p>
     Do not attempt to implement this version of the standard.
     Do not reference this version as authoritative in any way.


### PR DESCRIPTION
This word occurs more often in Bikeshed, but I wasn't sure how to address each instance.