### PR TITLE
chore: Format MD files with Markdownlint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ when you're making small changes to an active project;
 you'll save yourself a lot of future pain
 if you follow those steps.
 
-
 Running Tests
 -------------
 
@@ -28,32 +27,32 @@ We need to keep the tests green,
 so running these before submitting a PR is important.
 
 * `bikeshed test` will run all of the tests,
-	giving you diffs where there's failures.
+ giving you diffs where there's failures.
 * `bikeshed test --rebase` will rebase all of the tests,
-	replacing the `.html` files with their new forms.
-	This can be useful as a general testing strategy;
-	git's diff can be easier to read than the simple one `bikeshed test` uses,
-	and you might be even an even better diff pager than the default.
-	(I highly recommend [using Delta](https://github.com/dandavison/delta)!)
+    replacing the `.html` files with their new forms.
+    This can be useful as a general testing strategy;
+    git's diff can be easier to read than the simple one `bikeshed test` uses,
+    and you might be even an even better diff pager than the default.
+    (I highly recommend [using Delta](https://github.com/dandavison/delta)!)
 
-	It's also necessary, however, to actually generate the new test expectations;
-	the tests are generated with some special options
-	that ensure they can be stably generated across different environments
-	(omitting today's date, etc),
-	and `bikeshed test --rebase` ensures these are all set up correctly.
+    It's also necessary, however, to actually generate the new test expectations;
+    the tests are generated with some special options
+    that ensure they can be stably generated across different environments
+    (omitting today's date, etc),
+    and `bikeshed test --rebase` ensures these are all set up correctly.
 
 * Both of these commands default to running all of the tests,
-	but you can run *particular* tests
-	by passing them as additional command-line positional args
-	(full path, starting below the `/tests/` directory,
-	so running the manual tests just requires giving their name, etc).
+    but you can run *particular* tests
+    by passing them as additional command-line positional args
+    (full path, starting below the `/tests/` directory,
+    so running the manual tests just requires giving their name, etc).
 
-	Alternately, the `--manual-only` flag
-	will run only the manually-written tests,
-	which are small and very fast,
-	skipping all the real-spec tests.
-	This can be worthwhile for a quick check,
-	as it takes less than 20s to run them,
-	versus several minutes for the full suite.
-	However, many code paths are not exercised by these,
-	so a full test run/rebase is required to ensure your change is actually fine.
+    Alternately, the `--manual-only` flag
+    will run only the manually-written tests,
+    which are small and very fast,
+    skipping all the real-spec tests.
+    This can be worthwhile for a quick check,
+    as it takes less than 20s to run them,
+    versus several minutes for the full suite.
+    However, many code paths are not exercised by these,
+    so a full test run/rebase is required to ensure your change is actually fine.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,8 +3,9 @@
 We love contributions from our users. As bikeshed is all about precise, clear specifications, there is no fix too small. If you would like to update or improve the documentation, we ask that you follow these quick rules:
 
 1. **Use [Semantic Linefeeds](http://rhodesmill.org/brandon/2012/one-sentence-per-line/)** to put one sentence or clause per line.
-    
+
     Do this:
+
     ```
     Indent tells Bikeshed how many spaces you prefer to use to indent your source code,⏎
     so it can properly parse your Markdown and data-blocks.⏎
@@ -13,12 +14,13 @@ We love contributions from our users. As bikeshed is all about precise, clear sp
     (Of course, using tabs avoids this entirely,⏎
     as one tab is always one indent.)
     ```
-    
+
     Don't do this:
+
     ```
     Indent tells Bikeshed how many spaces you prefer to use to indent your source code, so it can properly parse your Markdown and data-blocks. It takes a single integer, and defaults to 4 if unspecified. (Of course, using tabs avoids this entirely, as one tab is always one indent.)
     ```
 
 1. **Include an updated `index.html`** in your Pull Request.
-    
+
     The quickest way is to use [the Bikeshed API](https://api.csswg.org/bikeshed/) to pre-process your `index.bs` file.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -68,6 +68,7 @@ Definitions and autolinks have a few extra attributes that you can specify;
 check out the details in the [Autolinking](https://tabatkins.github.io/bikeshed/#autolinking) documentation.
 
 There are a few textual shortcuts to use as well:
+
 * `[[foo]]` is an autolink to a bibliography entry named "foo", and auto-generates an informative reference in the biblio section.
     Add a leading exclamation point to the value, like `[[!foo]]` for a normative reference.
 * A number of autolink types have corresponding textual shorthands: for example, `'foo'` is an autolink to the "foo" CSS property; `{{Foo}}` is an autolink to the WebIDL "Foo" interface.
@@ -86,7 +87,7 @@ Defining Properties and Descriptors
 
 If defining a property/descriptor, rather than writing out the table markup explicitly, just add a propdef or descdef block, like so:
 
-~~~~html
+```html
 <pre class='propdef'> (or 'descdef')
 Name: var-*
 Value: <<value>> | <<CDO>> | <<CDC>>
@@ -97,7 +98,7 @@ Media: all
 Computed value: specified value with variables substituted (but see prose for "invalid variables")
 Percentage: n/a
 </pre>
-~~~~
+```
 
 Common practice is to define all of the values for the property in a `<dl>` underneath the propdef table.
 If you do so, and you're only defining the values in there


### PR DESCRIPTION
If you look at the "smart diff" it doesn't actually change the end rendering, just removes some yellow squiglies if you use Markdownlint in your IDE