### PR TITLE
chore: Run lint before matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Not sure if this is a "good" optimization.
If you look at the runs, it now gates the lint in front of the full Python/OS matrix
![image](https://user-images.githubusercontent.com/1297909/106082951-a792e300-60e9-11eb-9f25-fd1689955624.png)

Don't think it happens much, but since there is a 5 parallel macOS job limit, this will stop early if it can't pass the lint. Downside is that this potentially adds 2 minutes waiting for the lint to finish to a happy run