### PR TITLE
fix: Skip metadata blank lines for specific blocks

### DIFF
--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -1073,6 +1073,9 @@ def parse(lines):
             inMetadata = False
             continue
         if inMetadata:
+            # Skip newlines except for multiline blocks
+            if line.text.strip() == "" and lastKey not in ("Abstract", "Status Text"):
+                continue
             if lastKey and (line.text.strip() == "" or re.match(r"\s+", line.text)):
                 # empty lines, or lines that start with 1+ spaces, continue previous key
                 md.addData(lastKey, line.text, lineNum=line.i)

--- a/tests/github/WICG/encrypted-media-encryption-scheme/index.html
+++ b/tests/github/WICG/encrypted-media-encryption-scheme/index.html
@@ -570,9 +570,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/encrypted-media-encryption-scheme/">https://wicg.github.io/encrypted-media-encryption-scheme/</a>
-     <dt class="editor">Editors:
+     <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="105371"><span class="p-name fn">Joey Parrish</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/wicg/encrypted-media-encryption-scheme">Git Repository.</a>
      <dd><a href="https://github.com/wicg/encrypted-media-encryption-scheme/issues/new">File an issue.</a>

--- a/tests/github/WICG/hdcp-detection/index.html
+++ b/tests/github/WICG/hdcp-detection/index.html
@@ -573,7 +573,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="45389"><span class="p-name fn">Mounir Lamouri</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="105371"><span class="p-name fn">Joey Parrish</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/wicg/hdcp-detection">Git Repository.</a>
      <dd><a href="https://github.com/wicg/hdcp-detection/issues/new">File an issue.</a>

--- a/tests/github/WICG/permissions-request/index.html
+++ b/tests/github/WICG/permissions-request/index.html
@@ -574,7 +574,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="72192"><span class="p-name fn">Jeffrey Yasskin</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
      <dt>Tests:
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/permissions-request">web-platform-tests permissions-request/</a> (<a href="https://github.com/w3c/web-platform-tests/labels/permissions-request">ongoing work</a>)
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/WICG/permissions-revoke/index.html
+++ b/tests/github/WICG/permissions-revoke/index.html
@@ -574,7 +574,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="72192"><span class="p-name fn">Jeffrey Yasskin</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
      <dt>Tests:
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/permissions-revoke">web-platform-tests permissions-revoke/</a> (<a href="https://github.com/w3c/web-platform-tests/labels/permissions-revoke">ongoing work</a>)
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/WebBluetoothCG/web-bluetooth/index.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/index.html
@@ -696,7 +696,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://github.com/WebBluetoothCG/web-bluetooth">Fix the text through GitHub</a>
      <dd><a href="mailto:public-web-bluetooth@w3.org">public-web-bluetooth@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-web-bluetooth/" rel="discussion">archives</a>)
      <dd><a href="irc://irc.w3.org:6665/#web-bluetooth">IRC: #web-bluetooth on W3C’s IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
@@ -593,7 +593,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://github.com/WebBluetoothCG/web-bluetooth">Fix the text through GitHub</a>
      <dd><a href="mailto:public-web-bluetooth@w3.org">public-web-bluetooth@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-web-bluetooth/" rel="discussion">archives</a>)
      <dd><a href="irc://irc.w3.org:6665/#web-bluetooth">IRC: #web-bluetooth on W3C’s IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/WebBluetoothCG/web-bluetooth/use-cases.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/use-cases.html
@@ -404,7 +404,6 @@ dfn > a.self-link::before      { content: "#"; }
      <dd><a href="https://github.com/WebBluetoothCG/web-bluetooth">Fix the text through GitHub</a>
      <dd><a href="mailto:public-web-bluetooth@w3.org">public-web-bluetooth@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-web-bluetooth/" rel="discussion">archives</a>)
      <dd><a href="irc://irc.w3.org:6665/#web-bluetooth">IRC: #web-bluetooth on W3C’s IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/anchors/index.html
+++ b/tests/github/immersive-web/anchors/index.html
@@ -635,14 +635,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://immersive-web.github.io/anchors/">https://immersive-web.github.io/anchors/</a>
-     <dt class="editor">Editors:
+     <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="114482"><a class="p-name fn u-email email" href="mailto:bialpio@google.com">Piotr Bialecki</a> (<a class="p-org org" href="http://google.com/">Google</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/anchors/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/anchors/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/dom-overlays/index.html
+++ b/tests/github/immersive-web/dom-overlays/index.html
@@ -626,14 +626,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://immersive-web.github.io/dom-overlays/">https://immersive-web.github.io/dom-overlays/</a>
-     <dt class="editor">Editors:
+     <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="113597"><a class="p-name fn u-email email" href="mailto:klausw@google.com">Klaus Weidner</a> (<a class="p-org org" href="http://google.com/">Google</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/dom-overlays/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/dom-overlays/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning">

--- a/tests/github/immersive-web/hit-test/index.html
+++ b/tests/github/immersive-web/hit-test/index.html
@@ -637,14 +637,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://immersive-web.github.io/hit-test/">https://immersive-web.github.io/hit-test/</a>
-     <dt class="editor">Editors:
+     <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="114482"><a class="p-name fn u-email email" href="mailto:bialpio@google.com">Piotr Bialecki</a> (<a class="p-org org" href="http://google.com/">Google</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/hit-test/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/hit-test/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
+++ b/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
@@ -625,9 +625,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>Previous Versions:
      <dd><a href rel="prev"></a>
-     <dt class="editor">Editors:
+     <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:rcabanier@magicleap.com">Rik Cabanier</a> (<a class="p-org org" href="https://magicleap.com">Magic Leap</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/webvr/spec/1.1/index.html
+++ b/tests/github/immersive-web/webvr/spec/1.1/index.html
@@ -572,6 +572,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://immersive-web.github.io/webvr/">https://immersive-web.github.io/webvr/</a>
+     <dt>Feedback:
+     <dd><span><a href="mailto:public-webvr@mozilla.org?subject=%5Bwebvr%5D%20YOUR%20TOPIC%20HERE">public-webvr@mozilla.org</a> with subject line “<kbd>[webvr] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webvr/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:vladimir@mozilla.com">Vladimir Vukicevic</a> (<a class="p-org org" href="https://mozilla.org/">Mozilla</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bajones@google.com">Brandon Jones</a> (<a class="p-org org" href="http://google.com/">Google</a>)
@@ -581,7 +583,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://github.com/w3c/webvr/issues/new">File an issue</a> (<a href="https://github.com/w3c/webvr/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-webvr/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #webvr IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/webxr-ar-module/index.html
+++ b/tests/github/immersive-web/webxr-ar-module/index.html
@@ -690,12 +690,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="87824"><a class="p-name fn u-email email" href="mailto:bajones@google.com">Brandon Jones</a> (<a class="p-org org" href="http://google.com/">Google</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="93109"><a class="p-name fn u-email email" href="mailto:nhw@amazon.com">Nell Waliczek</a> (<a class="p-org org" href="https://amazon.com/">Amazon [Microsoft until 2018]</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="109489"><a class="p-name fn u-email email" href="mailto:manish@mozilla.com">Manish Goregaokar</a> (<a class="p-org org" href="http://mozilla.org/">Mozilla</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/webxr-ar-module/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr-ar-module/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning">

--- a/tests/github/immersive-web/webxr-gamepads-module/index.html
+++ b/tests/github/immersive-web/webxr-gamepads-module/index.html
@@ -633,12 +633,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="87824"><a class="p-name fn u-email email" href="mailto:bajones@google.com">Brandon Jones</a> (<a class="p-org org" href="http://google.com/">Google</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="93109"><a class="p-name fn u-email email" href="mailto:nhw@amazon.com">Nell Waliczek</a> (<a class="p-org org" href="https://amazon.com/">Amazon [Microsoft until 2018]</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/webxr-gamepads/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr-gamepads-module/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/immersive-web/webxr-test-api/index.html
+++ b/tests/github/immersive-web/webxr-test-api/index.html
@@ -641,7 +641,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="109489"><a class="p-name fn u-email email" href="mailto:manish@mozilla.com">Manish Goregaokar</a> (<a class="p-org org" href="http://mozilla.org/">Mozilla</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="114716"><a class="p-name fn u-email email" href="mailto:alcooper@google.com">Alex Cooper</a> (<a class="p-org org" href="http://google.com/">Google</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
     </dl>
    </div>
    <div data-fill-with="warning">

--- a/tests/github/immersive-web/webxr/index.html
+++ b/tests/github/immersive-web/webxr/index.html
@@ -705,12 +705,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="87824"><a class="p-name fn u-email email" href="mailto:bajones@google.com">Brandon Jones</a> (<a class="p-org org" href="http://google.com/">Google</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="93109"><a class="p-name fn u-email email" href="mailto:nhw@amazon.com">Nell Waliczek</a> (<a class="p-org org" href="https://amazon.com/">Amazon [Microsoft until 2018]</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/immersive-web/webxr/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr/issues">open issues</a>)
      <dd><a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
      <dd><a href="irc://irc.w3.org:6665/">W3C’s #immersive-web IRC</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
@@ -670,7 +670,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-animations-1/Overview.bs">GitHub Editor</a>
       <dt>Issues List:
       <dd><a href="https://www.w3.org/Bugs/Public/buglist.cgi?component=Animations&amp;list_id=36653&amp;product=CSS&amp;query_format=advanced&amp;resolution=---">In Bugzilla</a>
-      <dd>
      </dl>
     </div>
    </details>

--- a/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
@@ -603,7 +603,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-animations-2-2/Overview.bs">GitHub Editor</a>
       <dt>Issues List:
       <dd><a href="https://www.w3.org/Bugs/Public/buglist.cgi?component=Animations&amp;list_id=36653&amp;product=CSS&amp;query_format=advanced&amp;resolution=---">In Bugzilla</a>
-      <dd>
      </dl>
     </div>
    </details>

--- a/tests/github/w3c/csswg-drafts/css-easing-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-easing-1/Overview.html
@@ -641,9 +641,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dd class="editor p-author h-card vcard" data-editor-id="43194"><a class="p-name fn u-email email" href="mailto:bbirtles@mozilla.com">Brian Birtles</a> (<a class="p-org org" href="https://www.mozilla.org/">Mozilla</a>)
       <dd class="editor p-author h-card vcard" data-editor-id="42080"><a class="p-name fn u-email email" href="mailto:dino@apple.com">Dean Jackson</a> (<a class="p-org org" href="https://www.apple.com/">Apple Inc</a>)
       <dd class="editor p-author h-card vcard" data-editor-id="62267"><span class="p-name fn">Matt Rakow</span> (<span class="p-org org">Microsoft</span>)
-      <dt class="editor">Former Editors:
+      <dt class="editor">Former Editor:
       <dd class="editor p-author h-card vcard" data-editor-id="47691"><a class="p-name fn u-email email" href="mailto:shans@google.com">Shane Stephens</a> (<span class="p-org org">Google Inc</span>)
-      <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
       <dt>Suggest an Edit for this Spec:
       <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-easing-1/Overview.bs">GitHub Editor</a>
       <dt>Participate:

--- a/tests/github/w3c/csswg-drafts/css-overscroll-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overscroll-1/Overview.html
@@ -636,7 +636,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dt class="editor">Editors:
       <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bgirard@fb.com">Benoit Girard</a> (<span class="p-org org">Facebook</span>)
       <dd class="editor p-author h-card vcard" data-editor-id="81464"><a class="p-name fn u-email email" href="mailto:majidvp@google.com">Majid Valipour</a> (<span class="p-org org">Google</span>)
-      <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
       <dt>Suggest an Edit for this Spec:
       <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-overscroll-1/Overview.bs">GitHub Editor</a>
      </dl>

--- a/tests/github/w3c/csswg-drafts/scroll-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/scroll-animations-1/Overview.html
@@ -584,7 +584,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="51377"><a class="p-name fn u-email email" href="mailto:graouts@apple.com">Antoine Quint</a> (<span class="p-org org">Apple</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="81464"><a class="p-name fn u-email email" href="mailto:majidvp@google.com">Majid Valipour</a> (<span class="p-org org">Google</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:gerchiko@microsoft.com">Olga Gerchikov</a> (<span class="p-org org">Microsoft</span>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt class="editor">Former Editors:
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Mantaroh Yoshinaga</span>
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:smcgruer@google.com">Stephen McGruer</a> (<span class="p-org org">Google</span>)

--- a/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
@@ -713,7 +713,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dt>Version History:
       <dd><a href="https://github.com/w3c/csswg-drafts/commits/master/web-animations-1">https://github.com/w3c/csswg-drafts/commits/master/web-animations-1</a>
       <dt>Issue Tracking:
-      <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations-1">CSSWG Issues Repository</a>
+      <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations-1-1">CSSWG Issues Repository</a>
       <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations-1">GitHub</a>
       <dt class="editor">Editors:
       <dd class="editor p-author h-card vcard" data-editor-id="43194"><a class="p-name fn u-email email" href="mailto:bbirtles@mozilla.com">Brian Birtles</a> (<span class="p-org org">Mozilla</span>)
@@ -726,14 +726,13 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <dd class="editor p-author h-card vcard" data-editor-id="31960"><a class="p-name fn u-email email" href="mailto:adanilo@google.com">Alex Danilo</a> (<span class="p-org org">Google Inc</span>)
       <dd class="editor p-author h-card vcard" data-editor-id="42199"><a class="p-name fn u-email email" href="mailto:jackalmage@gmail.com">Tab Atkins</a> (<span class="p-org org">Google Inc</span>)
       <dt>Suggest an Edit for this Spec:
-      <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/web-animations-1/Overview.bs">GitHub Editor</a>
+      <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/web-animations-1-1/Overview.bs">GitHub Editor</a>
       <dt>Participate:
       <dd><a href="https://github.com/w3c/csswg-drafts/tree/master/web-animations-1">Fix the text through GitHub</a>
       <dd>Join the ‘waapi’ channel on the <a href="https://damp-lake-50659.herokuapp.com/">Animation at Work</a> slack
       <dd>IRC: <a href="ircs://irc.w3.org:6667/webanimations">#webanimations</a> on W3C’s IRC
       <dt>Tests:
       <dd><a href="https://github.com/web-platform-tests/wpt/tree/master/web-animations">web-platform-tests web-animations/</a> (<a href="https://github.com/web-platform-tests/wpt/labels/web-animations">ongoing work</a>)
-      <dd>
      </dl>
     </div>
    </details>

--- a/tests/github/w3c/csswg-drafts/web-animations-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/web-animations-2/Overview.html
@@ -588,15 +588,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>Version History:
      <dd><a href="https://github.com/w3c/csswg-drafts/commits/master/web-animations-1">https://github.com/w3c/csswg-drafts/commits/master/web-animations-1</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations">CSSWG Issues Repository</a>
+     <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations-2">CSSWG Issues Repository</a>
      <dd><a href="https://github.com/w3c/csswg-drafts/labels/web-animations-2">GitHub</a>
-     <dd>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="43194"><a class="p-name fn u-email email" href="mailto:bbirtles@mozilla.com">Brian Birtles</a> (<span class="p-org org">Mozilla</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="47691"><a class="p-name fn u-email email" href="mailto:shans@google.com">Shane Stephens</a> (<span class="p-org org">Google Inc</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:dstockwell@google.com">Douglas Stockwell</a> (<span class="p-org org">Google Inc</span>)
      <dt>Suggest an Edit for this Spec:
-     <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/web-animations/Overview.bs">GitHub Editor</a>
+     <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/web-animations-2/Overview.bs">GitHub Editor</a>
      <dt>Participate:
      <dd><a href="https://github.com/w3c/csswg-drafts/tree/master/web-animations-2">Fix the text through GitHub</a>
      <dd>Join the ‘waapi’ channel on the <a href="https://damp-lake-50659.herokuapp.com/">Animation at Work</a> slack

--- a/tests/github/w3c/media-capabilities/index.html
+++ b/tests/github/w3c/media-capabilities/index.html
@@ -574,7 +574,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="45389"><span class="p-name fn">Mounir Lamouri</span> (<a class="p-org org" href="https://www.google.com/">Google Inc.</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="114832"><span class="p-name fn">Chris Cunningham</span> (<a class="p-org org" href="https://www.google.com/">Google Inc.</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="116349"><span class="p-name fn">Vi Nguyen</span> (<a class="p-org org" href="https://www.microsoft.com/">Microsoft Corporation</a>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/w3c/media-capabilities">Git Repository.</a>
      <dd><a href="https://github.com/w3c/media-capabilities/issues/new">File an issue.</a>

--- a/tests/github/w3c/mediacapture-image/index.html
+++ b/tests/github/w3c/mediacapture-image/index.html
@@ -592,7 +592,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://www.w3.org/TR/image-capture/">https://www.w3.org/TR/image-capture/</a>
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/2017/WD-image-capture-20170104/" rel="prev">https://www.w3.org/TR/2017/WD-image-capture-20170104/</a>
-     <dd><a href rel="prev"></a>
      <dt>Feedback:
      <dd><span><a href="mailto:public-media-capture@w3.org?subject=%5Bimage-capture%5D%20YOUR%20TOPIC%20HERE">public-media-capture@w3.org</a> with subject line “<kbd>[image-capture] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-media-capture/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editors:
@@ -601,11 +600,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>Participate:
      <dd><a href="https://lists.w3.org/Archives/Public/public-webrtc/">Mailing list</a>
      <dd><a href="https://github.com/w3c/mediacapture-image">GitHub repo</a> (<a href="https://github.com/w3c/mediacapture-image/issues/new">new issue</a>, <a href="https://github.com/w3c/mediacapture-image/issues">open issues</a>)
-     <dd>
      <dt>Implementation:
      <dd><a href="https://github.com/w3c/mediacapture-image/blob/master/implementation-status.md">Implementation Status</a>
      <dd><a href="http://caniuse.com/#feat=imagecapture">Can I use Image Capture?</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/w3c/mediacapture-record/MediaRecorder.html
+++ b/tests/github/w3c/mediacapture-record/MediaRecorder.html
@@ -603,7 +603,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://www.w3.org/TR/mediastream-recording/">https://www.w3.org/TR/mediastream-recording/</a>
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/2017/WD-mediastream-recording-20170405/" rel="prev">https://www.w3.org/TR/2017/WD-mediastream-recording-20170405/</a>
-     <dd><a href rel="prev"></a>
      <dt>Feedback:
      <dd><span><a href="mailto:public-media-capture@w3.org?subject=%5Bmediastream-recording%5D%20YOUR%20TOPIC%20HERE">public-media-capture@w3.org</a> with subject line “<kbd>[mediastream-recording] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-media-capture/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editor:
@@ -614,7 +613,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>Participate:
      <dd><a href="https://lists.w3.org/Archives/Public/public-webrtc/">Mailing list</a>
      <dd><a href="https://github.com/w3c/mediacapture-record">GitHub repo</a> (<a href="https://github.com/w3c/mediacapture-record/issues/new">new issue</a>, <a href="https://github.com/w3c/mediacapture-record/issues">open issues</a>)
-     <dd>
      <dt>Implementation:
      <dd><a href="http://caniuse.com/#feat=mediarecorder">Can I use Media Recording?</a>
      <dd><a href="https://github.com/miguelao/mediacapture-record-implementation-status/blob/master/chromium.md">Chromium Encode Acceleration Support</a>

--- a/tests/github/w3c/mediasession/index.html
+++ b/tests/github/w3c/mediasession/index.html
@@ -599,7 +599,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Former Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:zqzhang@google.com">Zhiqiang Zhang</a> (<span class="p-org org">Google Inc.</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:richt@opera.com">Rich Tibbett</a> (<span class="p-org org">Opera</span>)
-     <dd class="editor p-author h-card vcard"><span class="p-name fn"></span>
      <dt>Participate:
      <dd><a href="https://github.com/w3c/mediasession/">We are on GitHub</a>
      <dd><a href="https://github.com/w3c/mediasession/issues/new">File an issue</a>

--- a/tests/github/w3c/permissions/index.html
+++ b/tests/github/w3c/permissions/index.html
@@ -641,9 +641,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://www.w3.org/TR/permissions/">https://www.w3.org/TR/permissions/</a>
      <dt>Previous Versions:
      <dd><a href="https://www.w3.org/TR/2015/WD-permissions-20150407/" rel="prev">https://www.w3.org/TR/2015/WD-permissions-20150407/</a>
-     <dd><a href rel="prev"></a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Bpermissions%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[permissions] <i data-lt>… message topic …</i></kbd>”</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5Bpermissions%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[permissions] <i data-lt>… message topic …</i></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard" data-editor-id="45389"><span class="p-name fn">Mounir Lamouri</span> (<a class="p-org org" href="https://google.com/">Google Inc.</a>)
      <dd class="editor p-author h-card vcard" data-editor-id="39125"><span class="p-name fn">Marcos Cáceres</span> (<a class="p-org org" href="https://mozilla.com/">Mozilla</a>)
@@ -655,7 +654,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>Implementation status:
      <dd><a href="https://code.google.com/p/chromium/issues/detail?id=437770">Blink/Chromium</a>
      <dd><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1105827">Gecko</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/w3c/webappsec-subresource-integrity/index.html
+++ b/tests/github/w3c/webappsec-subresource-integrity/index.html
@@ -587,7 +587,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://code.google.com/p/chromium/issues/detail?id=355467">Blink/Chromium</a><br><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=992096">Gecko</a>
      <dt>Implementation report:
      <dd><a href="https://github.com/w3c/webappsec-subresource-integrity/wiki/Links">https://github.com/w3c/webappsec-subresource-integrity/wiki/Links</a>
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/w3ctag/design-principles/index.html
+++ b/tests/github/w3ctag/design-principles/index.html
@@ -2058,7 +2058,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd><a href="https://www.w3.org/2001/tag/">Members of the TAG</a>, past and present
      <dt>Participate:
      <dd><a href="https://github.com/w3ctag/design-principles">GitHub w3ctag/design-principles</a> (<a href="https://github.com/w3ctag/design-principles/issues/new">file an issue</a>; <a href="https://github.com/w3ctag/design-principles/issues?state=open">open issues</a>)
-     <dd>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/tests/github/whatwg/loader/index.html
+++ b/tests/github/whatwg/loader/index.html
@@ -36,7 +36,6 @@
      <dd><a href="https://github.com/whatwg/loader">GitHub whatwg/loader</a> (<a href="https://github.com/whatwg/loader/issues/new">new issue</a>, <a href="https://github.com/whatwg/loader/issues">open issues</a>)
      <dd><a href="https://wiki.whatwg.org/wiki/IRC">IRC: #whatwg on Freenode</a>
      <dd><a href="https://github.com/whatwg/loader/issues/new">File an issue</a> (<a href="https://github.com/whatwg/loader/issues?state=open">open issues</a>)
-     <dd>
      <dt>Commits:
      <dd><a href="https://github.com/whatwg/loader/commits">GitHub whatwg/loader/commits</a>
      <dd><a href="/commit-snapshots/[COMMIT-SHA]/" id="commit-snapshot-link">Snapshot as of this commit</a>


### PR DESCRIPTION
Made empty list items and DDs in some cases