### PR TITLE
Don't make things into relpos unless they actually contain a self-link

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -802,7 +802,7 @@ styleSelflinks = """
     --selflink-bg: gray;
     --selflink-hover-text: black;
 }
-.heading, .issue, .note, .example, li, dt {
+.heading[id], .issue[id], .note[id], .example[id], li[id], dt[id] {
     position: relative;
 }
 a.self-link {


### PR DESCRIPTION
position:relative changes the containing block for absolutely positioned
descendants. If there is a self-link, that's desired. If not, it's at
best useless, and can interfere with other intended uses of absolute
positioning.