### PR TITLE
Add NOTE-ED, NOTE-WD and NOTE-FPWD statuses

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -23,6 +23,9 @@ shortToLongStatus = {
     "w3c/WG-NOTE": "W3C Working Group Note",
     "w3c/IG-NOTE": "W3C Interest Group Note",
     "w3c/NOTE": "W3C Note",
+    "w3c/NOTE-ED": "Editor's Draft",
+    "w3c/NOTE-WD": "W3C Working Draft",
+    "w3c/NOTE-FPWD": "W3C First Public Working Draft",
     "w3c/MO": "W3C Member-only Draft",
     "w3c/UD": "Unofficial Proposal Draft",
     "w3c/CG-DRAFT": "Draft Community Group Report",
@@ -90,6 +93,8 @@ snapshotStatuses = [
     "w3c/WG-NOTE",
     "w3c/IG-NOTE",
     "w3c/NOTE",
+    "w3c/NOTE-WD",
+    "w3c/NOTE-FPWD",
     "w3c/MO",
 ]
 datedStatuses = [
@@ -104,6 +109,8 @@ datedStatuses = [
     "w3c/WG-NOTE",
     "w3c/IG-NOTE",
     "w3c/NOTE",
+    "w3c/NOTE-WD",
+    "w3c/NOTE-FPWD",
     "w3c/MO",
     "whatwg/RD",
 ]
@@ -138,7 +145,16 @@ noEDStatuses = [
 
 # These statuses are usable by any group operating under the W3C Process
 # Document. (So, not by Community and Business Groups.)
-w3cProcessDocumentStatuses = frozenset(["w3c/ED", "w3c/NOTE", "w3c/UD"])
+w3cProcessDocumentStatuses = frozenset(
+    [
+        "w3c/ED",
+        "w3c/NOTE",
+        "w3c/NOTE-ED",
+        "w3c/NOTE-WD",
+        "w3c/NOTE-FPWD",
+        "w3c/UD",
+    ]
+)
 
 # Interest Groups are limited to these statuses
 w3cIGStatuses = frozenset(["w3c/IG-NOTE"]).union(w3cProcessDocumentStatuses)

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -274,10 +274,12 @@ class MetadataManager:
             macros["longstatus"] = config.shortToLongStatus[self.status]
         else:
             macros["longstatus"] = ""
-        if self.status in ("w3c/LCWD", "w3c/FPWD"):
+        if self.status in ("w3c/LCWD", "w3c/FPWD", "w3c/NOTE-FPWD"):
             macros["status"] = "WD"
         elif self.status in ("w3c/WG-NOTE", "w3c/IG-NOTE"):
             macros["status"] = "NOTE"
+        elif self.status == "w3c/NOTE-ED":
+            macros["status"] = "ED"
         else:
             macros["status"] = self.rawStatus
         if self.workStatus:
@@ -339,7 +341,7 @@ class MetadataManager:
             macros["mailinglist"] = self.mailingList
         if self.mailingListArchives:
             macros["mailinglistarchives"] = self.mailingListArchives
-        if self.status == "w3c/FPWD":
+        if self.status in ("w3c/FPWD", "w3c/NOTE-FPWD", "w3c/NOTE-WD"):
             macros[
                 "w3c-stylesheet-url"
             ] = "https://www.w3.org/StyleSheets/TR/2016/W3C-WD"
@@ -355,6 +357,10 @@ class MetadataManager:
             macros[
                 "w3c-stylesheet-url"
             ] = "https://www.w3.org/StyleSheets/TR/2016/cg-final"
+        elif self.status == "w3c/NOTE-ED":
+            macros[
+                "w3c-stylesheet-url"
+            ] = "https://www.w3.org/StyleSheets/TR/2016/W3C-ED"
         else:
             shortStatus = (
                 self.rawStatus.partition("/")[2]

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -889,6 +889,9 @@ Several keys are required information, and will cause the processor to flag an e
 			* WG-NOTE: "W3C Working Group Note"
 			* IG-NOTE: "W3C Interest Group Note"
 			* NOTE: "W3C Note" ([unclear what this is used for](https://github.com/w3c/tr-design/issues/124))
+			* NOTE-ED: "Editor's Draft" of a Group Note
+			* NOTE-WD: "W3C Working Draft" of a Group Note
+			* NOTE-FPWD: "W3C First Public Working Draft" of a Group Note
 			* MO: "W3C Member-only Draft"
 			* UD: "Unofficial Proposal Draft"
 			* CG-DRAFT: "Draft Community Group Report"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1484,9 +1484,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version bf43dc5c8, updated Fri Apr 9 15:21:04 2021 +0900" name="generator">
+  <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="bf43dc5c895885430e3c49c7c36829ed53bc98fb" name="document-revision">
+  <meta content="60db2014790c98827b31f1006a36fef2ca122e84" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -2177,7 +2177,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-04-09">9 April 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-04-14">14 April 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2190,9 +2190,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
+   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 9 April 2021,
+In addition, as of 14 April 2021,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -3065,6 +3065,12 @@ and marked-up text in <a data-link-type="dfn" href="#metadata-h1" id="ref-for-me
         <p>IG-NOTE: "W3C Interest Group Note"</p>
        <li data-md>
         <p class="note" role="note"><span>NOTE:</span> "W3C Note" (<a href="https://github.com/w3c/tr-design/issues/124">unclear what this is used for</a>)</p>
+       <li data-md>
+        <p>NOTE-ED: "Editor’s Draft" of a Group Note</p>
+       <li data-md>
+        <p>NOTE-WD: "W3C Working Draft" of a Group Note</p>
+       <li data-md>
+        <p>NOTE-FPWD: "W3C First Public Working Draft" of a Group Note</p>
        <li data-md>
         <p>MO: "W3C Member-only Draft"</p>
        <li data-md>
@@ -5451,12 +5457,12 @@ to avoid getting in the way of reading the document,
 while "open" causes them to be expanded initially.
 In either case, the use can interactively collapse or expand each element.</p>
    <figure>
-     <img height="195" src="images/wpt-display-open.png" srcset="images/wpt-display-open.png 2x" width="600"> 
+     <img srcset="images/wpt-display-open.png 2x"> 
     <figcaption> When <code>WPT Display: open</code> is set,
 		the <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element①②">wpt</a></code> element turns into a "TESTS" block. </figcaption>
    </figure>
    <figure>
-     <img height="104" src="images/wpt-display-closed.png" srcset="images/wpt-display-closed.png 2x" width="600"> 
+     <img srcset="images/wpt-display-closed.png 2x"> 
     <figcaption> When <code>WPT Display: closed</code> is set,
 		the <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element①③">wpt</a></code> element also turns into a "TESTS" block,
 		but it is initially collapsed. </figcaption>
@@ -5498,7 +5504,7 @@ crash-002.html
 <c- p>&lt;/</c-><c- f>wpt</c-><c- p>></c->
 </pre>
     <p>The test block in the example above would be rendered as follows:</p>
-    <figure> <img alt="A WPT element with a list of tests, preceded by an introductory paragraph" height="168" src="images/tests-with-intro.png" srcset="images/tests-with-intro.png 2x" width="624"> </figure>
+    <figure> <img alt="A WPT element with a list of tests, preceded by an introductory paragraph" srcset="images/tests-with-intro.png 2x"> </figure>
    </div>
    <p>If multiple <code><a data-link-type="element" href="#wpt-element" id="ref-for-wpt-element①⑧">wpt</a></code> follow each other in the source,
 with nothing between them other than whitespace,


### PR DESCRIPTION
This creates additional statuses for Notes to be able to produce suitable SOTD sections for Editor's Drafts, First Public Working Drafts, and Working Drafts of specifications intended to become Notes.

See https://github.com/tabatkins/bikeshed/pull/1999#issuecomment-819130407

@tabatkins That's best effort on what I understand needs to change. I get results that look correct when I run it locally but there may be other places that need to be updated as well, and tests to add. In other words, I'll let you take it from there :)

I'll redo #1999 once new statuses are available.