### PR TITLE
Parse the content of the wpt element's title attribute as HTML

### DIFF
--- a/bikeshed/wpt/wptElement.py
+++ b/bikeshed/wpt/wptElement.py
@@ -7,6 +7,7 @@ from ..h import (
     removeNode,
     removeAttr,
     textContent,
+    parseHTML,
 )
 from ..messages import *
 
@@ -127,7 +128,7 @@ def appendTestList(
                 "lang": titleLang,
                 "dir": titleDir,
             },
-            title,
+            parseHTML(title),
         )
         appendChild(blockEl, titleEl)
     testListEl = E.ul({"class": "wpt-tests-list"})


### PR DESCRIPTION
In ordinary HTML, attributes don't contain markup, but as the content of
this particular attribute is going to be injected as an actual element
in the tree, actually treating it as HTML is useful. In particular, it
makes it possible to include links in that text.