### PR TITLE
Move processing of wpt elements to be earlier in the chain

### DIFF
--- a/bikeshed/Spec.py
+++ b/bikeshed/Spec.py
@@ -226,6 +226,7 @@ class Spec:
         boilerplate.addAtRisk(self)
         addNoteHeaders(self)
         boilerplate.removeUnwantedBoilerplate(self)
+        wpt.processWptElements(self)
         shorthands.run(self)
         inlineTags.processTags(self)
         canonicalizeShortcuts(self)
@@ -236,7 +237,6 @@ class Spec:
         processIssuesAndExamples(self)
         idl.markupIDL(self)
         inlineRemoteIssues(self)
-        wpt.processWptElements(self)
         addImageSize(self)
 
         # Handle all the links

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
@@ -1682,8 +1682,8 @@ p <c- p>{</c->
      <li class="wpt-test"><a class="wpt-name" href="https://wpt.fyi/results/css/css-multicol/parsing/column-rule-valid.html">column-rule-valid.html</a> <a class="wpt-live" href="http://wpt.live/css/css-multicol/parsing/column-rule-valid.html" title="css/css-multicol/parsing/column-rule-valid.html"><small>(live test)</small></a> <a class="wpt-source" href="https://github.com/web-platform-tests/wpt/blob/master/css/css-multicol/parsing/column-rule-valid.html"><small>(source)</small></a>
     </ul>
    </details>
-   <div class="example" id="example-31902657">
-    <a class="self-link" href="#example-31902657"></a> In this example, the <a data-link-type="dfn" href="#column-rule" id="ref-for-column-rule⑤">column rule</a> and the <a data-link-type="dfn" href="#column-gap" id="ref-for-column-gap②">column gap</a> have the same width. 
+   <div class="example" id="example-840f1fa1">
+    <a class="self-link" href="#example-840f1fa1"></a> In this example, the <a data-link-type="dfn" href="#column-rule" id="ref-for-column-rule⑤">column rule</a> and the <a data-link-type="dfn" href="#column-gap" id="ref-for-column-gap②">column gap</a> have the same width. 
 		Therefore, they will occupy exactly the same space. 
 <pre class="highlight">body <c- p>{</c->
   <c- k>column-gap</c-><c- p>:</c-> <c- m>35</c-><c- k>px</c-><c- p>;</c->


### PR DESCRIPTION
That way, usual bikeshed syntax can be used in the title attribute of
wpt elements