### PR TITLE
Fix "This version" link for NOTE-WD status

### DIFF
--- a/bikeshed/boilerplate/mediawg/status.include
+++ b/bikeshed/boilerplate/mediawg/status.include
@@ -70,7 +70,7 @@
 
 <p exclude-if="WG-NOTE">
   This document was produced by a group operating under the <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20170801/">W3C Patent Policy</a>.
-  <if-wrapper include-if="NOTE-ED, NOTE-FPWD, NOTE-WD">The group does not expect this document to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation. This document is informative only.</if-wrapper>
+  <if-wrapper include-if="NOTE-ED, NOTE-FPWD, NOTE-WD">The group does not expect this document to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.</if-wrapper>
   <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/115198/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
 </p>
 

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -274,7 +274,7 @@ class MetadataManager:
             macros["longstatus"] = config.shortToLongStatus[self.status]
         else:
             macros["longstatus"] = ""
-        if self.status in ("w3c/LCWD", "w3c/FPWD", "w3c/NOTE-FPWD"):
+        if self.status in ("w3c/LCWD", "w3c/FPWD", "w3c/NOTE-FPWD", "w3c/NOTE-WD"):
             macros["status"] = "WD"
         elif self.status in ("w3c/WG-NOTE", "w3c/IG-NOTE"):
             macros["status"] = "NOTE"


### PR DESCRIPTION
This was missed when the NOTE-WD status was introduced. The prefix part in the "This Version" link needs to remain "WD" in that case, and not "NOTE-WD".

Also, it turns out that pubrules does not require the sentence "This document is informative only." in the SoTD of documents that will become Notes. Adjusting the boilerplate for Media WG documents accordingly.