### PR TITLE
fixed IWWG header boilerplate with recent? change, like status to sotd

### DIFF
--- a/bikeshed/boilerplate/immersivewebwg/header.include
+++ b/bikeshed/boilerplate/immersivewebwg/header.include
@@ -4,7 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
+  <meta name="w3c-status" content="[STATUS]">
 </head>
 <body class="h-entry">
 <div class="head">
@@ -20,7 +21,7 @@
 
 <div class="p-summary" data-fill-with="abstract"></div>
 
-<h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
+<h2 class='no-num no-toc no-ref' id='sotd'>Status of this document</h2>
 <div data-fill-with="status"></div>
 <div data-fill-with="at-risk"></div>
 


### PR DESCRIPTION
fixes to match with pubrules rules.
seems forgot to push this when I've worked on manual publishing of IWWG spec to /TR/ last time... (was kept in local stash)

@AdaRoseCannon , do we want to include our favicon lines here, instead of having in each spec .bs??