### PR TITLE
Use datatracker.ietf.org URLs for RFC 2119

### DIFF
--- a/bikeshed/refs/ReferenceManager.py
+++ b/bikeshed/refs/ReferenceManager.py
@@ -215,7 +215,7 @@ class ReferenceManager:
                 "date": "March 1997\n",
                 "status": "Best Current Practice\n",
                 "title": "Key words for use in RFCs to Indicate Requirement Levels\n",
-                "snapshot_url": "https://tools.ietf.org/html/rfc2119\n",
+                "snapshot_url": "https://www.rfc-editor.org/info/rfc2119\n",
                 "current_url": "\n",
                 "obsoletedBy": "\n",
                 "other": "\n",

--- a/bikeshed/refs/ReferenceManager.py
+++ b/bikeshed/refs/ReferenceManager.py
@@ -215,7 +215,7 @@ class ReferenceManager:
                 "date": "March 1997\n",
                 "status": "Best Current Practice\n",
                 "title": "Key words for use in RFCs to Indicate Requirement Levels\n",
-                "snapshot_url": "https://www.rfc-editor.org/info/rfc2119\n",
+                "snapshot_url": "https://datatracker.ietf.org/doc/html/rfc2119\n",
                 "current_url": "\n",
                 "obsoletedBy": "\n",
                 "other": "\n",


### PR DESCRIPTION
tools.ietf.org is no longer to be relied on per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/
