### PR TITLE
DAS WG: Adjust the order of the text

### DIFF
--- a/bikeshed/boilerplate/dap/status-CRD.include
+++ b/bikeshed/boilerplate/dap/status-CRD.include
@@ -9,10 +9,7 @@
 <p>
   This document was published by the
   <a href="https://www.w3.org/das/">Devices and Sensors Working Group</a>
-  as a Candidate Recommendation Draft. A Candidate Recommendation Draft
-  integrates changes from the previous Candidate Recommendation that the Working
-  Group intends to include in a subsequent Candidate Recommendation Snapshot.
-  This document is intended to become a W3C Recommendation.
+  as a Candidate Recommendation Draft. This document is intended to become a W3C Recommendation.
 </p>
 
 <p>
@@ -28,10 +25,13 @@
 </p>
 
 <p>
-  Publication as a Candidate Recommendation Draft does not imply endorsement by the W3C
-  Membership. This is a draft document and may be updated, replaced or
-  obsoleted by other documents at any time. It is inappropriate to cite this
-  document as other than work in progress.
+  Publication as a Candidate Recommendation Draft does not imply endorsement by
+  the W3C Membership. A Candidate Recommendation Draft integrates changes from
+  the previous Candidate Recommendation that the Working Group intends to
+  include in a subsequent Candidate Recommendation Snapshot. This is a draft
+  document and may be updated, replaced or obsoleted by other documents at any
+  time. It is inappropriate to cite this document as other than work in
+  progress.
 </p>
 
 <p>


### PR DESCRIPTION
According to https://github.com/w3c/specberus/blob/2d79e706121ef49138927f9212a52ca7522568f2/lib/rules/sotd/stability.js#L19-L22 , the order of this text seems to be wrong.