### PR TITLE
Update the name of the Process CG

### DIFF
--- a/bikeshed/boilerplate/processcg/status.include
+++ b/bikeshed/boilerplate/processcg/status.include
@@ -4,7 +4,7 @@
 
 	<p>
 	This document is developed by the Advisory Board's Process Task Force
-	working within the <a href="https://www.w3.org/community/w3process/">Revising W3C Process Community Group</a>
+	working within the <a href="https://www.w3.org/community/w3process/">W3C Process Community Group</a>
 	(which anyone can join).
 	This is the [DATE] [LONGSTATUS] for the proposed next version of the W3C Process Document.
 


### PR DESCRIPTION
It used to have a long and awkward name, but has been officially
renamed to match what everybody has always been calling it.