### PR TITLE
CSSWG: fix FPWD boilerplate

### DIFF
--- a/bikeshed/boilerplate/csswg/status.include
+++ b/bikeshed/boilerplate/csswg/status.include
@@ -61,7 +61,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/Style/CSS/">CSS Working Group</a>
 	as a <strong>First Public Working Draft</strong>.
-	Publication as a Working Draft
+	Publication as a First Public Working Draft
 	does not imply endorsement by the W3C Membership.
 
 <p include-if="WD, FPWD, CRD">


### PR DESCRIPTION
See https://www.w3.org/TR/2021/WD-css-cascade-5-20210119/#status for an example.