### PR TITLE
Include all contents of wpt folder in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include semver.txt
 graft docs
 graft bikeshed/spec-data
 graft bikeshed/boilerplate
+graft bikeshed/wpt


### PR DESCRIPTION
It looks like the file `wptScript.js` is not included in the version of `bikeshed` available in PyPI, which results in the following error:

```
File "/home/jerivas/.virtualenvs/bike2/lib/python3.9/site-packages/bikeshed/wpt/wptElement.py", line 447, in getWptScript
    with open(config.scriptPath("wpt", "wptScript.js"), "r", encoding="utf-8") as fh:
FileNotFoundError: [Errno 2] No such file or directory: '/home/jerivas/.virtualenvs/bike2/lib/python3.9/site-packages/bikeshed/wpt/wptScript.js'
```

## Steps to reproduce

I found this problem when trying to process a CSS working group spec:

```
pip install bikeshed==3.3.1
curl https://raw.githubusercontent.com/w3c/csswg-drafts/main/cssom-1/Overview.bs
bikeshed
```