### PR TITLE
chore: Add Python 3.10 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
         os:
           - windows-latest
           - ubuntu-latest


### PR DESCRIPTION
Add the latest release line to the CI jobs