### PR TITLE
Add a new "direct" biblio display style

### DIFF
--- a/bikeshed/constants.py
+++ b/bikeshed/constants.py
@@ -7,7 +7,7 @@ printMode = "console"
 quiet = True
 asciiOnly = False
 refStatus = StringEnum("current", "snapshot")
-biblioDisplay = StringEnum("index", "inline")
+biblioDisplay = StringEnum("index", "inline", "direct")
 specClass: t.Optional[t.Spec]
 specClass = None
 testAnnotationURL = "https://test.csswg.org/harness/annotate.js"

--- a/bikeshed/metadata.py
+++ b/bikeshed/metadata.py
@@ -618,7 +618,7 @@ def parseBiblioDisplay(key, val, lineNum):
     val = val.strip().lower()
     if val in constants.biblioDisplay:
         return val
-    die(f"'{key}' must be either 'inline' or 'index'. Got '{val}'", lineNum=lineNum)
+    die(f"'{key}' must be either 'inline', 'index', or 'direct'. Got '{val}'", lineNum=lineNum)
     return constants.biblioDisplay.index
 
 

--- a/bikeshed/shorthands/oldShorthands.py
+++ b/bikeshed/shorthands/oldShorthands.py
@@ -345,7 +345,7 @@ biblioRe = re.compile(
                         \[\[
                         (!)?
                         ([\w.+-]+)
-                        (\s+(?:current|snapshot|inline|index|obsolete)\s*)*
+                        (\s+(?:current|snapshot|inline|index|direct|obsolete)\s*)*
                         (?:\|([^\]]+))?
                         \]\]""",
     re.X,
@@ -380,10 +380,17 @@ def biblioReplacer(match):
 
     displayInline = "inline" in modifiers
     displayIndex = "index" in modifiers
-    if displayInline and displayIndex:
-        die(f"Biblio shorthand {match.group(0)} contains *both* 'inline' and 'index', please pick one.")
-    elif displayInline or displayIndex:
-        attrs["data-biblio-display"] = "inline" if displayInline else "index"
+    displayDirect = "direct" in modifiers
+    if (displayInline + displayIndex + displayDirect) > 1:
+        die(
+            f"Biblio shorthand {match.group(0)} contains more than one of 'inline', 'index' and 'direct', please pick one."
+        )
+    elif displayInline:
+        attrs["data-biblio-display"] = "inline"
+    elif displayIndex:
+        attrs["data-biblio-display"] = "index"
+    elif displayDirect:
+        attrs["data-biblio-display"] = "direct"
 
     if "obsolete" in modifiers:
         attrs["data-biblio-obsolete"] = ""

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -871,6 +871,7 @@ def processBiblioLinks(doc):
             ):  # False if it's already been replaced by an author supplied text using the [[FOOBAR inline|custom text]] syntax.
                 clearContents(el)
                 appendChild(el, E.cite(ref.title))
+        if biblioDisplay in ("inline", "direct"):
             if ref.url is not None:
                 el.set("href", ref.url)
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1070,10 +1070,11 @@ There are several additional optional keys:
 		and selects which URL you want to default to
 		for bibliography and autolinks entries that have both "current" and "snapshot" URLs.
 		(You can also specify this per-biblio entry or per-autolink.)
-	* <dfn>Default Biblio Display</dfn> takes the values "index" (default) or "inline",
+	* <dfn>Default Biblio Display</dfn> takes the values "index" (default), "inline", or "direct"
 		and selects whether biblio autolinks default to
-		displaying as their shortname and linking to the bibliography index,
-		or displaying as their title and linking straight to the referenced document.
+		displaying as their shortname and linking to the bibliography index ("index"),
+		displaying as their title and linking straight to the referenced document ("inline"), or
+		displaying as their shortname and linking to the referenced document ("direct").
 		(You can also specify this per-biblio entry.)
 	* <dfn>Markup Shorthands</dfn> lets you specify which categories of markup shorthands you want to use; for example, you can turn off CSS shorthands and reclaim use of single quotes in your spec.  You can still link to things with explicit markup even if the shorthand is turned off.  Its value is a comma-separated list of markup categories and <a>boolish</a> values, like `css no, biblio yes`.  The currently-recognized categories are:
 
@@ -2928,13 +2929,14 @@ after the biblio name.
 * By default, biblio autolinks are formatted like you typed, just with a single set of square brackets:
 	`[[FOO]]` will produce a link with the text "\[FOO]",
 	which links to the bibliography.
+	can make them display "direct", where they link straight to the document,
+	rather than going to the bibliography first.
+	(It still adds an entry to the bibliography index.)
 	Alternately, you can force them to display "inline",
 	where the link text is the actual title of the referenced document,
 	and the link goes straight to that document,
-	rather than going to the bibliography first.
-	(It still adds an entry to the bibliography index.)
 
-	You can control this by setting `inline` or `index` in the shorthand,
+	You can control this by setting `inline`, `direct`, or `index` in the shorthand,
 	like `[[FOO inline]]`,
 	or change the default for all biblio links in the document
 	by setting the [=metadata/Default Biblio Display=] metadata.

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
  *   - .toc for the Table of Contents (<ol class="toc">)
  *     + <span class="secno"> for the section numbers
  *   - #toc for the Table of Contents (<nav id="toc">)
- *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in § N.M</span>)
  *   - table.index for Index Tables (e.g. for properties or elements)
  *
  * Structural Markup
@@ -1487,9 +1487,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version a9882e4ba, updated Fri Jun 18 10:04:59 2021 -0700" name="generator">
+  <meta content="Bikeshed version 3c61bdda6, updated Wed Dec 15 05:21:07 2021 -0800" name="generator">
   <link href="https://tabatkins.github.io/bikeshed/" rel="canonical">
-  <meta content="a9882e4ba3ab3fb7f615ad02159a9652ccb7d629" name="document-revision">
+  <meta content="3c61bdda627d44d3aaa0e25963a0193046acb4c5" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1730,6 +1730,16 @@ figcaption:not(.no-marker)::before {
 }
 
 .dfn-paneled { cursor: pointer; }
+</style>
+<style>/* style-issues */
+
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
 </style>
 <style>/* style-line-highlighting */
 
@@ -2180,7 +2190,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Bikeshed Documentation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-06-19">19 June 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-12-15">15 December 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2195,7 +2205,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="https://licensebuttons.net/p/zero/1.0/80x15.png" width="80"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 19 June 2021,
+In addition, as of 15 December 2021,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -2682,7 +2692,7 @@ requires two things:</p>
 <pre>    docker run --rm -v $(pwd):/data &lt;organization>/bikeshed:&lt;date> bikeshed spec /data/&lt;some *.bs file> [/data/&lt;some output file>]
 </pre>
    <p>Example for a Windows host:</p>
-<pre>    docker run --rm --volume C:\mystuff\project1\:\data bikeshed spec \data\Index.bs \data\out\Index.html
+<pre>    docker run --rm --volume C:\mystuff\project1\:/data &lt;organization>/bikeshed:&lt;date> spec /data/Index.bs /data/out/Index.html
 </pre>
    <p>Note that the <a href="#cli-options">§ 3.2 Global Options</a> apply to running Bikeshed from a docker image.
 Since the Bikeshed docker image is read-only, it does not make sense to execute the Bikeshed <code>update</code> command from a docker image.</p>
@@ -3017,10 +3027,10 @@ Or if you’re adding multiple lines with the same key, you can just start the s
    <p>Several keys are required information, and will cause the processor to flag an error if you omit them:</p>
    <ul>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-title">Title</dfn> is the spec’s full title, used to generate both the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element" id="ref-for-the-title-element">title</a></code> and <code><a data-link-type="element">h1</a></code> of the document.
-This can alternately be specified by adding an <code><a data-link-type="element">h1</a></code> element as the first line of the spec.</p>
-     <p class="note" role="note"><span>Note:</span> The optional <a data-link-type="dfn" href="#metadata-h1" id="ref-for-metadata-h1">H1</a> metadata lets you specify the text you want for the document’s <code><a data-link-type="element">h1</a></code>,
-if for some reason you want the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element" id="ref-for-the-title-element①">title</a></code> and <code><a data-link-type="element">h1</a></code> to have different text.
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-title">Title</dfn> is the spec’s full title, used to generate both the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element" id="ref-for-the-title-element">title</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element">h1</a></code> of the document.
+This can alternately be specified by adding an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element①">h1</a></code> element as the first line of the spec.</p>
+     <p class="note" role="note"><span>Note:</span> The optional <a data-link-type="dfn" href="#metadata-h1" id="ref-for-metadata-h1">H1</a> metadata lets you specify the text you want for the document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element②">h1</a></code>,
+if for some reason you want the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element" id="ref-for-the-title-element①">title</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element③">h1</a></code> to have different text.
 For example, some browsers interpret markup as literal text in <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element" id="ref-for-the-title-element②">title</a></code>,
 so you may want to provide "plain text" in the <a data-link-type="dfn" href="#metadata-title" id="ref-for-metadata-title">Title</a> metadata
 and marked-up text in <a data-link-type="dfn" href="#metadata-h1" id="ref-for-metadata-h1①">H1</a>.</p>
@@ -3223,7 +3233,7 @@ Multiple Abstract lines can be used, representing multiple lines of content, as 
    <p>There are several additional optional keys:</p>
    <ul>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-h1">H1</dfn> contains the text/markup that goes into the document’s <code><a data-link-type="element">h1</a></code> element.
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-h1">H1</dfn> contains the text/markup that goes into the document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element④">h1</a></code> element.
 If omitted, this defaults to the value of the <a data-link-type="dfn" href="#metadata-title" id="ref-for-metadata-title①">Title</a> metadata,
 which is usually what you want.</p>
     <li data-md>
@@ -3326,10 +3336,11 @@ and selects which URL you want to default to
 for bibliography and autolinks entries that have both "current" and "snapshot" URLs.
 (You can also specify this per-biblio entry or per-autolink.)</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-default-biblio-display">Default Biblio Display</dfn> takes the values "index" (default) or "inline",
+     <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-default-biblio-display">Default Biblio Display</dfn> takes the values "index" (default), "inline", or "direct"
 and selects whether biblio autolinks default to
-displaying as their shortname and linking to the bibliography index,
-or displaying as their title and linking straight to the referenced document.
+displaying as their shortname and linking to the bibliography index ("index"),
+displaying as their title and linking straight to the referenced document ("inline"), or
+displaying as their shortname and linking to the referenced document ("direct").
 (You can also specify this per-biblio entry.)</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="metadata" data-dfn-type="dfn" data-export id="metadata-markup-shorthands">Markup Shorthands</dfn> lets you specify which categories of markup shorthands you want to use; for example, you can turn off CSS shorthands and reclaim use of single quotes in your spec.  You can still link to things with explicit markup even if the shorthand is turned off.  Its value is a comma-separated list of markup categories and <a data-link-type="dfn" href="#boolish" id="ref-for-boolish③">boolish</a> values, like <code>css no, biblio yes</code>.  The currently-recognized categories are:</p>
@@ -4486,7 +4497,7 @@ interoperate with the Bikeshed ecosystem, here’s the full definition data mode
 and how to properly expose it.</p>
    <ol>
     <li data-md>
-     <p>The defining element MUST be a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element⑦">dfn</a></code> or <code><a data-link-type="element">h2</a></code>...<code><a data-link-type="element">h6</a></code>.  No other element
+     <p>The defining element MUST be a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element" id="ref-for-the-dfn-element⑦">dfn</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h2-element" id="ref-for-the-h2-element">h2</a></code>...<code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h6-element" id="ref-for-the-h6-element">h6</a></code>.  No other element
 is recognized as defining a term.</p>
     <li data-md>
      <p>The element MUST have an <code>id</code> attribute.</p>
@@ -4934,12 +4945,13 @@ or specify the default url to choose for all your biblio refs with the <a data-l
     <li data-md>
      <p>By default, biblio autolinks are formatted like you typed, just with a single set of square brackets: <code>[[FOO]]</code> will produce a link with the text "[FOO]",
 which links to the bibliography.
+can make them display "direct", where they link straight to the document,
+rather than going to the bibliography first.
+(It still adds an entry to the bibliography index.)
 Alternately, you can force them to display "inline",
 where the link text is the actual title of the referenced document,
-and the link goes straight to that document,
-rather than going to the bibliography first.
-(It still adds an entry to the bibliography index.)</p>
-     <p>You can control this by setting <code>inline</code> or <code>index</code> in the shorthand,
+and the link goes straight to that document,</p>
+     <p>You can control this by setting <code>inline</code>, <code>direct</code>, or <code>index</code> in the shorthand,
 like <code>[[FOO inline]]</code>,
 or change the default for all biblio links in the document
 by setting the <a data-link-type="dfn" href="#metadata-default-biblio-display" id="ref-for-metadata-default-biblio-display">Default Biblio Display</a> metadata.</p>
@@ -5106,7 +5118,7 @@ they’re placed after all the built-in keys.</p>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>auto
      <tr>
-      <th>Applies to:
+      <th><a href="https://www.w3.org/TR/css-cascade/#applies-to">Applies to:</a>
       <td><a data-link-type="dfn" href="https://drafts.csswg.org/css-flexbox-1/#flex-item" id="ref-for-flex-item">flex items</a>
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#inherited-property">Inherited:</a>
@@ -5118,7 +5130,7 @@ they’re placed after all the built-in keys.</p>
       <th><a href="https://www.w3.org/TR/css-cascade/#computed">Computed value:</a>
       <td>as specified, with lengths made absolute
      <tr>
-      <th>Canonical order:
+      <th><a href="https://www.w3.org/TR/cssom/#serializing-css-values">Canonical order:</a>
       <td>per grammar
      <tr>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
@@ -5212,7 +5224,7 @@ and automatically contain its type, nullability, and optionality
 (determined from the IDL block),
 like:</p>
 <pre class="idl highlight def" style="display:none"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="foo"><code><c- g>Foo</c-></code><a class="self-link" href="#foo"></a></dfn> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Foo" data-dfn-type="method" data-export data-lt="bar(arg1, arg2)" id="dom-foo-bar"><code><c- g>bar</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long"><c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg1"></a></dfn>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>? <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg2"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Foo" data-dfn-type="method" data-export data-lt="bar(arg1, arg2)" id="dom-foo-bar"><code><c- g>bar</c-></code></dfn>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-long" id="ref-for-idl-long"><c- b>long</c-></a> <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg1"></a></dfn>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>? <dfn class="idl-code" data-dfn-for="Foo/bar(arg1, arg2)" data-dfn-type="argument" data-export id="dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code><a class="self-link" href="#dom-foo-bar-arg1-arg2-arg2"></a></dfn>);
 };
 </pre>
    <table class="argumentdef data">
@@ -5682,7 +5694,7 @@ each of which takes a comma-separated list of inclusion conditions.</p>
     <li data-md>
      <p>If an element has <code><a data-link-type="element-sub" href="#element-attrdef-global-include-if" id="ref-for-element-attrdef-global-include-if">include-if</a></code>, it will included only if it matches at least one of the conditions.</p>
     <li data-md>
-     <p>If an element has <code><a data-link-type="element-sub" href="#element-attrdef-global-exclude-if" id="ref-for-element-attrdef-global-exclude-if">exclude-if</a></code>, it will be included only it matches <em>none</em> of the conditions.</p>
+     <p>If an element has <code><a data-link-type="element-sub" href="#element-attrdef-global-exclude-if" id="ref-for-element-attrdef-global-exclude-if">exclude-if</a></code>, it will be included only if it matches <em>none</em> of the conditions.</p>
     <li data-md>
      <p>If an element has both, it will be included only if it passes the inclusion criteria for both.</p>
    </ul>
@@ -5803,7 +5815,7 @@ the element’s contents will be moved there.</p>
    <h3 class="heading settled" data-level="12.6" id="table-of-contents"><span class="secno">12.6. </span><span class="content">Table of Contents</span><a class="self-link" href="#table-of-contents"></a></h3>
    <p>The headings in the spec are automatically numbered,
 and a table of contents automatically generated.</p>
-   <p>Any heading <code><a data-link-type="element">h2</a></code> to <code><a data-link-type="element">h6</a></code> (that is, skipping only the document-titling <code><a data-link-type="element">h1</a></code>)
+   <p>Any heading <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h2-element" id="ref-for-the-h2-element①">h2</a></code> to <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h6-element" id="ref-for-the-h6-element①">h6</a></code> (that is, skipping only the document-titling <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element⑤">h1</a></code>)
 is automatically numbered by having a <code>&lt;span class='secno'>...&lt;/span></code> prepended to its contents.
 You can avoid this behavior for a heading and all of its subsequent subheadings
 by adding <code>class="no-num"</code> to the heading.</p>
@@ -5812,7 +5824,7 @@ Headings and their subheadings can be omitted from the ToC
 by adding <code>class="no-toc"</code> to them.</p>
    <p>The processor assumes that your headings are numbered correctly.
 It does not yet pay attention to the HTML outline algorithm,
-so using a bunch of <code><a data-link-type="element">h1</a></code>s nested in <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element" id="ref-for-the-section-element">section</a></code>s will have very wrong effects.</p>
+so using a bunch of <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element" id="ref-for-the-h1-element⑥">h1</a></code>s nested in <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element" id="ref-for-the-section-element">section</a></code>s will have very wrong effects.</p>
    <p>Headings also automatically gain a self-link pointing to themselves,
 to enable people to easily link to sections without having to return to the ToC.</p>
    <h3 class="heading settled" data-level="12.7" id="bp-include"><span class="secno">12.7. </span><span class="content">File-based Includes</span><a class="self-link" href="#bp-include"></a></h3>
@@ -6334,149 +6346,149 @@ in other words, empty entries get dropped, so you can put a final semicolon at t
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#macro-abstract">[ABSTRACT]</a><span>, in §12.3</span>
-   <li><a href="#metadata-abstract">Abstract</a><span>, in §4</span>
-   <li><a href="#macro-abstractattr">[ABSTRACTATTR]</a><span>, in §12.3</span>
-   <li><a href="#metadata-advisement-class">Advisement Class</a><span>, in §4</span>
-   <li><a href="#algorithms">Algorithms</a><span>, in §5.5</span>
-   <li><a href="#railroad-and">And</a><span>, in §13.1</span>
-   <li><a href="#metadata-assertion-class">Assertion Class</a><span>, in §4</span>
-   <li><a href="#metadata-assume-explicit-for">Assume Explicit For</a><span>, in §4</span>
-   <li><a href="#metadata-at-risk">At Risk</a><span>, in §4</span>
-   <li><a href="#dom-foo-bar">bar(arg1, arg2)</a><span>, in §9.4</span>
-   <li><a href="#biblio-autolink">biblio autolink</a><span>, in §7.2</span>
-   <li><a href="#metadata-block-elements">Block Elements</a><span>, in §4</span>
-   <li><a href="#metadata-boilerplate">Boilerplate</a><span>, in §4</span>
-   <li><a href="#boolish">boolish</a><span>, in §4</span>
-   <li><a href="#railroad-c">C</a><span>, in §13.1</span>
-   <li><a href="#metadata-can-i-use-url">Can I Use URL</a><span>, in §4</span>
-   <li><a href="#metadata-canonical-url">Canonical URL</a><span>, in §4</span>
-   <li><a href="#macro-cdate">[CDATE]</a><span>, in §12.3</span>
-   <li><a href="#railroad-choice">Choice</a><span>, in §13.1</span>
-   <li><a href="#railroad-comment">Comment</a><span>, in §13.1</span>
-   <li><a href="#metadata-complain-about">Complain About</a><span>, in §4</span>
-   <li><a href="#metadata-custom-warning-text">Custom Warning Text</a><span>, in §4</span>
-   <li><a href="#metadata-custom-warning-title">Custom Warning Title</a><span>, in §4</span>
-   <li><a href="#macro-date">[DATE]</a><span>, in §12.3</span>
-   <li><a href="#metadata-date">Date</a><span>, in §4</span>
-   <li><a href="#macro-date-dmmy">[DATE-DMMY]</a><span>, in §12.3</span>
-   <li><a href="#macro-date-mmy">[DATE-MMY]</a><span>, in §12.3</span>
-   <li><a href="#macro-date-my">[DATE-MY]</a><span>, in §12.3</span>
-   <li><a href="#macro-deadline">[DEADLINE]</a><span>, in §12.3</span>
-   <li><a href="#metadata-deadline">Deadline</a><span>, in §4</span>
-   <li><a href="#metadata-default-biblio-display">Default Biblio Display</a><span>, in §4</span>
-   <li><a href="#metadata-default-highlight">Default Highlight</a><span>, in §4</span>
-   <li><a href="#metadata-default-ref-status">Default Ref Status</a><span>, in §4</span>
-   <li><a href="#dfn-autolink">dfn autolink</a><span>, in §7.1</span>
-   <li><a href="#metadata-ed">ED</a><span>, in §4</span>
-   <li><a href="#metadata-editor">Editor</a><span>, in §4</span>
-   <li><a href="#metadata-editor-term">Editor Term</a><span>, in §4</span>
-   <li><a href="#element-attrdef-global-exclude-if">exclude-if</a><span>, in §12.4</span>
-   <li><a href="#metadata-expires">Expires</a><span>, in §4</span>
-   <li><a href="#metadata-external-infotrees">External Infotrees</a><span>, in §4</span>
-   <li><a href="#metadata-favicon">Favicon</a><span>, in §4</span>
-   <li><a href="#propdef-flex-basis">flex-basis</a><span>, in §9.1</span>
-   <li><a href="#foo">Foo</a><span>, in §9.4</span>
-   <li><a href="#metadata-force-crossorigin">Force Crossorigin</a><span>, in §4</span>
-   <li><a href="#metadata-former-editor">Former Editor</a><span>, in §4</span>
-   <li><a href="#metadata-group">Group</a><span>, in §4</span>
-   <li><a href="#macro-h1">[H1]</a><span>, in §12.3</span>
-   <li><a href="#metadata-h1">H1</a><span>, in §4</span>
-   <li><a href="#elementdef-if-wrapper">if-wrapper</a><span>, in §12.4</span>
-   <li><a href="#metadata-ignore-can-i-use-url-failure">Ignore Can I Use URL Failure</a><span>, in §4</span>
-   <li><a href="#metadata-ignored-terms">Ignored Terms</a><span>, in §4</span>
-   <li><a href="#metadata-ignored-vars">Ignored Vars</a><span>, in §4</span>
-   <li><a href="#metadata-image-auto-size">Image Auto Size</a><span>, in §4</span>
-   <li><a href="#metadata-include-can-i-use-panels">Include Can I Use Panels</a><span>, in §4</span>
-   <li><a href="#element-attrdef-global-include-if">include-if</a><span>, in §12.4</span>
-   <li><a href="#metadata-include-mdn-panels">Include MDN Panels</a><span>, in §4</span>
-   <li><a href="#metadata-indent">Indent</a><span>, in §4</span>
-   <li><a href="#metadata-infer-css-dfns">Infer CSS Dfns</a><span>, in §4</span>
-   <li><a href="#metadata-informative-classes">Informative Classes</a><span>, in §4</span>
-   <li><a href="#metadata-inline-github-issues">Inline Github Issues</a><span>, in §4</span>
-   <li><a href="#macro-isodate">[ISODATE]</a><span>, in §12.3</span>
-   <li><a href="#metadata-issue-class">Issue Class</a><span>, in §4</span>
-   <li><a href="#metadata-issue-tracker-template">Issue Tracker Template</a><span>, in §4</span>
-   <li><a href="#metadata-issue-tracking">Issue Tracking</a><span>, in §4</span>
-   <li><a href="#l-element">l</a><span>, in §5.4</span>
-   <li><a href="#macro-latest">[LATEST]</a><span>, in §12.3</span>
-   <li><a href="#metadata-level">Level</a><span>, in §4</span>
-   <li><a href="#metadata-line-numbers">Line Numbers</a><span>, in §4</span>
-   <li><a href="#metadata-link-defaults">Link Defaults</a><span>, in §4</span>
-   <li><a href="#metadata-local-boilerplate">Local Boilerplate</a><span>, in §4</span>
-   <li><a href="#macro-logo">[LOGO]</a><span>, in §12.3</span>
-   <li><a href="#metadata-logo">Logo</a><span>, in §4</span>
-   <li><a href="#macro-longstatus">[LONGSTATUS]</a><span>, in §12.3</span>
-   <li><a href="#metadata-mailing-list">Mailing List</a><span>, in §4</span>
-   <li><a href="#metadata-mailing-list-archives">Mailing List Archives</a><span>, in §4</span>
-   <li><a href="#manual-autolink">manual autolink</a><span>, in §7.3</span>
-   <li><a href="#metadata-markup-shorthands">Markup Shorthands</a><span>, in §4</span>
-   <li><a href="#metadata-max-toc-depth">Max ToC Depth</a><span>, in §4</span>
-   <li><a href="#metadata-metadata-include">Metadata Include</a><span>, in §4</span>
-   <li><a href="#metadata-metadata-order">Metadata Order</a><span>, in §4</span>
-   <li><a href="#railroad-n">N</a><span>, in §13.1</span>
-   <li><a href="#metadata-no-abstract">No Abstract</a><span>, in §4</span>
-   <li><a href="#element-attrdef-img-no-autosize">no-autosize</a><span>, in §5.12</span>
-   <li><a href="#metadata-no-editor">No Editor</a><span>, in §4</span>
-   <li><a href="#railroad-nonterminal">NonTerminal</a><span>, in §13.1</span>
-   <li><a href="#metadata-note-class">Note Class</a><span>, in §4</span>
-   <li><a href="#railroad-oneormore">OneOrMore</a><span>, in §13.1</span>
-   <li><a href="#metadata-opaque-elements">Opaque Elements</a><span>, in §4</span>
-   <li><a href="#railroad-opt">Opt</a><span>, in §13.1</span>
-   <li><a href="#railroad-optional">Optional</a><span>, in §13.1</span>
-   <li><a href="#railroad-or">Or</a><span>, in §13.1</span>
-   <li><a href="#element-attrdef-wpt-pathprefix">pathprefix</a><span>, in §11.1</span>
-   <li><a href="#railroad-plus">Plus</a><span>, in §13.1</span>
-   <li><a href="#metadata-prepare-for-tr">Prepare For TR</a><span>, in §4</span>
-   <li><a href="#metadata-previous-version">Previous Version</a><span>, in §4</span>
-   <li><a href="#metadata-remove-multiple-links">Remove Multiple Links</a><span>, in §4</span>
-   <li><a href="#macro-repository">[REPOSITORY]</a><span>, in §12.3</span>
-   <li><a href="#metadata-repository">Repository</a><span>, in §4</span>
-   <li><a href="#metadata-required-ids">Required IDs</a><span>, in §4</span>
-   <li><a href="#metadata-revision">Revision</a><span>, in §4</span>
-   <li><a href="#railroad-s">S</a><span>, in §13.1</span>
-   <li><a href="#railroad-seq">Seq</a><span>, in §13.1</span>
-   <li><a href="#railroad-sequence">Sequence</a><span>, in §13.1</span>
-   <li><a href="#macro-shortname">[SHORTNAME]</a><span>, in §12.3</span>
-   <li><a href="#metadata-shortname">Shortname</a><span>, in §4</span>
-   <li><a href="#railroad-skip">Skip</a><span>, in §13.1</span>
-   <li><a href="#metadata-slim-build-artifact">Slim Build Artifact</a><span>, in §4</span>
-   <li><a href="#soft-boolish">soft boolish</a><span>, in §4</span>
-   <li><a href="#railroad-stack">Stack</a><span>, in §13.1</span>
-   <li><a href="#railroad-star">Star</a><span>, in §13.1</span>
-   <li><a href="#macro-status">[STATUS]</a><span>, in §12.3</span>
-   <li><a href="#metadata-status">Status</a><span>, in §4</span>
-   <li><a href="#macro-statustext">[STATUSTEXT]</a><span>, in §12.3</span>
-   <li><a href="#metadata-status-text">Status Text</a><span>, in §4</span>
-   <li><a href="#railroad-t">T</a><span>, in §13.1</span>
-   <li><a href="#railroad-terminal">Terminal</a><span>, in §13.1</span>
-   <li><a href="#metadata-test-suite">Test Suite</a><span>, in §4</span>
-   <li><a href="#metadata-text-macro">Text Macro</a><span>, in §4</span>
-   <li><a href="#macro-title">[TITLE]</a><span>, in §12.3</span>
-   <li><a href="#metadata-title">Title</a><span>, in §4</span>
-   <li><a href="#metadata-toggle-diffs">Toggle Diffs</a><span>, in §4</span>
-   <li><a href="#metadata-tr">TR</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-alt-text">Tracking Vector Alt Text</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-class">Tracking Vector Class</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-image">Tracking Vector Image</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-image-height">Tracking Vector Image Height</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-image-width">Tracking Vector Image Width</a><span>, in §4</span>
-   <li><a href="#metadata-tracking-vector-title">Tracking Vector Title</a><span>, in §4</span>
-   <li><a href="#metadata-translate-ids">Translate IDs</a><span>, in §4</span>
-   <li><a href="#metadata-translation">Translation</a><span>, in §4</span>
-   <li><a href="#metadata-url">URL</a><span>, in §4</span>
-   <li><a href="#metadata-use-dfn-panels">Use Dfn Panels</a><span>, in §4</span>
-   <li><a href="#metadata-use-i-autolinks">Use &lt;i> Autolinks</a><span>, in §4</span>
-   <li><a href="#macro-version">[VERSION]</a><span>, in §12.3</span>
-   <li><a href="#macro-vshortname">[VSHORTNAME]</a><span>, in §12.3</span>
-   <li><a href="#metadata-warning">Warning</a><span>, in §4</span>
-   <li><a href="#metadata-work-status">Work Status</a><span>, in §4</span>
-   <li><a href="#wpt-element">wpt</a><span>, in §11</span>
-   <li><a href="#metadata-wpt-display">WPT Display</a><span>, in §4</span>
-   <li><a href="#metadata-wpt-path-prefix">WPT Path Prefix</a><span>, in §4</span>
-   <li><a href="#elementdef-wpt-rest">wpt-rest</a><span>, in §11.1</span>
-   <li><a href="#macro-year">[YEAR]</a><span>, in §12.3</span>
-   <li><a href="#railroad-zeroormore">ZeroOrMore</a><span>, in §13.1</span>
+   <li><a href="#macro-abstract">[ABSTRACT]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-abstract">Abstract</a><span>, in § 4</span>
+   <li><a href="#macro-abstractattr">[ABSTRACTATTR]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-advisement-class">Advisement Class</a><span>, in § 4</span>
+   <li><a href="#algorithms">Algorithms</a><span>, in § 5.5</span>
+   <li><a href="#railroad-and">And</a><span>, in § 13.1</span>
+   <li><a href="#metadata-assertion-class">Assertion Class</a><span>, in § 4</span>
+   <li><a href="#metadata-assume-explicit-for">Assume Explicit For</a><span>, in § 4</span>
+   <li><a href="#metadata-at-risk">At Risk</a><span>, in § 4</span>
+   <li><a href="#dom-foo-bar">bar(arg1, arg2)</a><span>, in § 9.4</span>
+   <li><a href="#biblio-autolink">biblio autolink</a><span>, in § 7.2</span>
+   <li><a href="#metadata-block-elements">Block Elements</a><span>, in § 4</span>
+   <li><a href="#metadata-boilerplate">Boilerplate</a><span>, in § 4</span>
+   <li><a href="#boolish">boolish</a><span>, in § 4</span>
+   <li><a href="#railroad-c">C</a><span>, in § 13.1</span>
+   <li><a href="#metadata-can-i-use-url">Can I Use URL</a><span>, in § 4</span>
+   <li><a href="#metadata-canonical-url">Canonical URL</a><span>, in § 4</span>
+   <li><a href="#macro-cdate">[CDATE]</a><span>, in § 12.3</span>
+   <li><a href="#railroad-choice">Choice</a><span>, in § 13.1</span>
+   <li><a href="#railroad-comment">Comment</a><span>, in § 13.1</span>
+   <li><a href="#metadata-complain-about">Complain About</a><span>, in § 4</span>
+   <li><a href="#metadata-custom-warning-text">Custom Warning Text</a><span>, in § 4</span>
+   <li><a href="#metadata-custom-warning-title">Custom Warning Title</a><span>, in § 4</span>
+   <li><a href="#macro-date">[DATE]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-date">Date</a><span>, in § 4</span>
+   <li><a href="#macro-date-dmmy">[DATE-DMMY]</a><span>, in § 12.3</span>
+   <li><a href="#macro-date-mmy">[DATE-MMY]</a><span>, in § 12.3</span>
+   <li><a href="#macro-date-my">[DATE-MY]</a><span>, in § 12.3</span>
+   <li><a href="#macro-deadline">[DEADLINE]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-deadline">Deadline</a><span>, in § 4</span>
+   <li><a href="#metadata-default-biblio-display">Default Biblio Display</a><span>, in § 4</span>
+   <li><a href="#metadata-default-highlight">Default Highlight</a><span>, in § 4</span>
+   <li><a href="#metadata-default-ref-status">Default Ref Status</a><span>, in § 4</span>
+   <li><a href="#dfn-autolink">dfn autolink</a><span>, in § 7.1</span>
+   <li><a href="#metadata-ed">ED</a><span>, in § 4</span>
+   <li><a href="#metadata-editor">Editor</a><span>, in § 4</span>
+   <li><a href="#metadata-editor-term">Editor Term</a><span>, in § 4</span>
+   <li><a href="#element-attrdef-global-exclude-if">exclude-if</a><span>, in § 12.4</span>
+   <li><a href="#metadata-expires">Expires</a><span>, in § 4</span>
+   <li><a href="#metadata-external-infotrees">External Infotrees</a><span>, in § 4</span>
+   <li><a href="#metadata-favicon">Favicon</a><span>, in § 4</span>
+   <li><a href="#propdef-flex-basis">flex-basis</a><span>, in § 9.1</span>
+   <li><a href="#foo">Foo</a><span>, in § 9.4</span>
+   <li><a href="#metadata-force-crossorigin">Force Crossorigin</a><span>, in § 4</span>
+   <li><a href="#metadata-former-editor">Former Editor</a><span>, in § 4</span>
+   <li><a href="#metadata-group">Group</a><span>, in § 4</span>
+   <li><a href="#macro-h1">[H1]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-h1">H1</a><span>, in § 4</span>
+   <li><a href="#elementdef-if-wrapper">if-wrapper</a><span>, in § 12.4</span>
+   <li><a href="#metadata-ignore-can-i-use-url-failure">Ignore Can I Use URL Failure</a><span>, in § 4</span>
+   <li><a href="#metadata-ignored-terms">Ignored Terms</a><span>, in § 4</span>
+   <li><a href="#metadata-ignored-vars">Ignored Vars</a><span>, in § 4</span>
+   <li><a href="#metadata-image-auto-size">Image Auto Size</a><span>, in § 4</span>
+   <li><a href="#metadata-include-can-i-use-panels">Include Can I Use Panels</a><span>, in § 4</span>
+   <li><a href="#element-attrdef-global-include-if">include-if</a><span>, in § 12.4</span>
+   <li><a href="#metadata-include-mdn-panels">Include MDN Panels</a><span>, in § 4</span>
+   <li><a href="#metadata-indent">Indent</a><span>, in § 4</span>
+   <li><a href="#metadata-infer-css-dfns">Infer CSS Dfns</a><span>, in § 4</span>
+   <li><a href="#metadata-informative-classes">Informative Classes</a><span>, in § 4</span>
+   <li><a href="#metadata-inline-github-issues">Inline Github Issues</a><span>, in § 4</span>
+   <li><a href="#macro-isodate">[ISODATE]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-issue-class">Issue Class</a><span>, in § 4</span>
+   <li><a href="#metadata-issue-tracker-template">Issue Tracker Template</a><span>, in § 4</span>
+   <li><a href="#metadata-issue-tracking">Issue Tracking</a><span>, in § 4</span>
+   <li><a href="#l-element">l</a><span>, in § 5.4</span>
+   <li><a href="#macro-latest">[LATEST]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-level">Level</a><span>, in § 4</span>
+   <li><a href="#metadata-line-numbers">Line Numbers</a><span>, in § 4</span>
+   <li><a href="#metadata-link-defaults">Link Defaults</a><span>, in § 4</span>
+   <li><a href="#metadata-local-boilerplate">Local Boilerplate</a><span>, in § 4</span>
+   <li><a href="#macro-logo">[LOGO]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-logo">Logo</a><span>, in § 4</span>
+   <li><a href="#macro-longstatus">[LONGSTATUS]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-mailing-list">Mailing List</a><span>, in § 4</span>
+   <li><a href="#metadata-mailing-list-archives">Mailing List Archives</a><span>, in § 4</span>
+   <li><a href="#manual-autolink">manual autolink</a><span>, in § 7.3</span>
+   <li><a href="#metadata-markup-shorthands">Markup Shorthands</a><span>, in § 4</span>
+   <li><a href="#metadata-max-toc-depth">Max ToC Depth</a><span>, in § 4</span>
+   <li><a href="#metadata-metadata-include">Metadata Include</a><span>, in § 4</span>
+   <li><a href="#metadata-metadata-order">Metadata Order</a><span>, in § 4</span>
+   <li><a href="#railroad-n">N</a><span>, in § 13.1</span>
+   <li><a href="#metadata-no-abstract">No Abstract</a><span>, in § 4</span>
+   <li><a href="#element-attrdef-img-no-autosize">no-autosize</a><span>, in § 5.12</span>
+   <li><a href="#metadata-no-editor">No Editor</a><span>, in § 4</span>
+   <li><a href="#railroad-nonterminal">NonTerminal</a><span>, in § 13.1</span>
+   <li><a href="#metadata-note-class">Note Class</a><span>, in § 4</span>
+   <li><a href="#railroad-oneormore">OneOrMore</a><span>, in § 13.1</span>
+   <li><a href="#metadata-opaque-elements">Opaque Elements</a><span>, in § 4</span>
+   <li><a href="#railroad-opt">Opt</a><span>, in § 13.1</span>
+   <li><a href="#railroad-optional">Optional</a><span>, in § 13.1</span>
+   <li><a href="#railroad-or">Or</a><span>, in § 13.1</span>
+   <li><a href="#element-attrdef-wpt-pathprefix">pathprefix</a><span>, in § 11.1</span>
+   <li><a href="#railroad-plus">Plus</a><span>, in § 13.1</span>
+   <li><a href="#metadata-prepare-for-tr">Prepare For TR</a><span>, in § 4</span>
+   <li><a href="#metadata-previous-version">Previous Version</a><span>, in § 4</span>
+   <li><a href="#metadata-remove-multiple-links">Remove Multiple Links</a><span>, in § 4</span>
+   <li><a href="#macro-repository">[REPOSITORY]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-repository">Repository</a><span>, in § 4</span>
+   <li><a href="#metadata-required-ids">Required IDs</a><span>, in § 4</span>
+   <li><a href="#metadata-revision">Revision</a><span>, in § 4</span>
+   <li><a href="#railroad-s">S</a><span>, in § 13.1</span>
+   <li><a href="#railroad-seq">Seq</a><span>, in § 13.1</span>
+   <li><a href="#railroad-sequence">Sequence</a><span>, in § 13.1</span>
+   <li><a href="#macro-shortname">[SHORTNAME]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-shortname">Shortname</a><span>, in § 4</span>
+   <li><a href="#railroad-skip">Skip</a><span>, in § 13.1</span>
+   <li><a href="#metadata-slim-build-artifact">Slim Build Artifact</a><span>, in § 4</span>
+   <li><a href="#soft-boolish">soft boolish</a><span>, in § 4</span>
+   <li><a href="#railroad-stack">Stack</a><span>, in § 13.1</span>
+   <li><a href="#railroad-star">Star</a><span>, in § 13.1</span>
+   <li><a href="#macro-status">[STATUS]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-status">Status</a><span>, in § 4</span>
+   <li><a href="#macro-statustext">[STATUSTEXT]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-status-text">Status Text</a><span>, in § 4</span>
+   <li><a href="#railroad-t">T</a><span>, in § 13.1</span>
+   <li><a href="#railroad-terminal">Terminal</a><span>, in § 13.1</span>
+   <li><a href="#metadata-test-suite">Test Suite</a><span>, in § 4</span>
+   <li><a href="#metadata-text-macro">Text Macro</a><span>, in § 4</span>
+   <li><a href="#macro-title">[TITLE]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-title">Title</a><span>, in § 4</span>
+   <li><a href="#metadata-toggle-diffs">Toggle Diffs</a><span>, in § 4</span>
+   <li><a href="#metadata-tr">TR</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-alt-text">Tracking Vector Alt Text</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-class">Tracking Vector Class</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-image">Tracking Vector Image</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-image-height">Tracking Vector Image Height</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-image-width">Tracking Vector Image Width</a><span>, in § 4</span>
+   <li><a href="#metadata-tracking-vector-title">Tracking Vector Title</a><span>, in § 4</span>
+   <li><a href="#metadata-translate-ids">Translate IDs</a><span>, in § 4</span>
+   <li><a href="#metadata-translation">Translation</a><span>, in § 4</span>
+   <li><a href="#metadata-url">URL</a><span>, in § 4</span>
+   <li><a href="#metadata-use-dfn-panels">Use Dfn Panels</a><span>, in § 4</span>
+   <li><a href="#metadata-use-i-autolinks">Use &lt;i> Autolinks</a><span>, in § 4</span>
+   <li><a href="#macro-version">[VERSION]</a><span>, in § 12.3</span>
+   <li><a href="#macro-vshortname">[VSHORTNAME]</a><span>, in § 12.3</span>
+   <li><a href="#metadata-warning">Warning</a><span>, in § 4</span>
+   <li><a href="#metadata-work-status">Work Status</a><span>, in § 4</span>
+   <li><a href="#wpt-element">wpt</a><span>, in § 11</span>
+   <li><a href="#metadata-wpt-display">WPT Display</a><span>, in § 4</span>
+   <li><a href="#metadata-wpt-path-prefix">WPT Path Prefix</a><span>, in § 4</span>
+   <li><a href="#elementdef-wpt-rest">wpt-rest</a><span>, in § 11.1</span>
+   <li><a href="#macro-year">[YEAR]</a><span>, in § 12.3</span>
+   <li><a href="#railroad-zeroormore">ZeroOrMore</a><span>, in § 13.1</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-flex-container">
    <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
@@ -6580,6 +6592,27 @@ Annotating Specs with Tests: the wpt element</a>
     <li><a href="#ref-for-the-dt-element">4. Metadata</a>
     <li><a href="#ref-for-the-dt-element①">10.1.1. Free Type/Etc Documentation on Attributes/Dict Members</a>
     <li><a href="#ref-for-the-dt-element②">12.2. Rearranging and Excluding "Spec Metadata"</a> <a href="#ref-for-the-dt-element③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-h1-element">
+   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element">https://html.spec.whatwg.org/multipage/sections.html#the-h1-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-h1-element">4. Metadata</a> <a href="#ref-for-the-h1-element①">(2)</a> <a href="#ref-for-the-h1-element②">(3)</a> <a href="#ref-for-the-h1-element③">(4)</a> <a href="#ref-for-the-h1-element④">(5)</a>
+    <li><a href="#ref-for-the-h1-element⑤">12.6. Table of Contents</a> <a href="#ref-for-the-h1-element⑥">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-h2-element">
+   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-h2-element">https://html.spec.whatwg.org/multipage/sections.html#the-h2-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-h2-element">6.9. Definitions data model</a>
+    <li><a href="#ref-for-the-h2-element①">12.6. Table of Contents</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-h6-element">
+   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-h6-element">https://html.spec.whatwg.org/multipage/sections.html#the-h6-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-h6-element">6.9. Definitions data model</a>
+    <li><a href="#ref-for-the-h6-element①">12.6. Table of Contents</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-head-element">
@@ -6753,19 +6786,19 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">9.4. IDL Method Argument Tables</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">9.4. IDL Method Argument Tables</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">9.4. IDL Method Argument Tables</a>
    </ul>
@@ -6792,6 +6825,9 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
      <li><span class="dfn-paneled" id="term-for-attr-dir">dir</span>
      <li><span class="dfn-paneled" id="term-for-the-dl-element">dl</span>
      <li><span class="dfn-paneled" id="term-for-the-dt-element">dt</span>
+     <li><span class="dfn-paneled" id="term-for-the-h1-element">h1</span>
+     <li><span class="dfn-paneled" id="term-for-the-h2-element">h2</span>
+     <li><span class="dfn-paneled" id="term-for-the-h6-element">h6</span>
      <li><span class="dfn-paneled" id="term-for-the-head-element">head</span>
      <li><span class="dfn-paneled" id="term-for-attr-dim-height">height</span>
      <li><span class="dfn-paneled" id="term-for-attr-hidden">hidden</span>
@@ -6832,7 +6868,7 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
      <li><span class="dfn-paneled" id="term-for-animation-type">animation type</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
      <li><span class="dfn-paneled" id="term-for-idl-long">long</span>
@@ -6843,19 +6879,19 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-css-flexbox-1">[CSS-FLEXBOX-1]
-   <dd>Tab Atkins Jr.; et al. <a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1</a>. 19 November 2018. CR. URL: <a href="https://www.w3.org/TR/css-flexbox-1/">https://www.w3.org/TR/css-flexbox-1/</a>
+   <dd>Tab Atkins Jr.; et al. <a href="https://www.w3.org/TR/css-flexbox-1/"><cite>CSS Flexible Box Layout Module Level 1</cite></a>. 19 November 2018. CR. URL: <a href="https://www.w3.org/TR/css-flexbox-1/">https://www.w3.org/TR/css-flexbox-1/</a>
    <dt id="biblio-html">[HTML]
-   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
-   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 4 October 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
+   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/"><cite>Scalable Vector Graphics (SVG) 2</cite></a>. 4 October 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
    <dt id="biblio-web-animations-1">[WEB-ANIMATIONS-1]
-   <dd>Brian Birtles; et al. <a href="https://www.w3.org/TR/web-animations-1/">Web Animations</a>. 18 May 2021. WD. URL: <a href="https://www.w3.org/TR/web-animations-1/">https://www.w3.org/TR/web-animations-1/</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Brian Birtles; et al. <a href="https://www.w3.org/TR/web-animations-1/"><cite>Web Animations</cite></a>. 18 May 2021. WD. URL: <a href="https://www.w3.org/TR/web-animations-1/">https://www.w3.org/TR/web-animations-1/</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="property-index"><span class="content">Property Index</span><a class="self-link" href="#property-index"></a></h2>
   <div class="big-element-wrapper">
@@ -6886,7 +6922,7 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
   </div>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>interface</c-> <a href="#foo"><code><c- g>Foo</c-></code></a> {
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined"><c- b>undefined</c-></a> <a href="#dom-foo-bar"><code><c- g>bar</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a> <a href="#dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>? <a href="#dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined"><c- b>undefined</c-></a> <a href="#dom-foo-bar"><code><c- g>bar</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-long"><c- b>long</c-></a> <a href="#dom-foo-bar-arg1-arg2-arg1"><code><c- g>arg1</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a>? <a href="#dom-foo-bar-arg1-arg2-arg2"><code><c- g>arg2</c-></code></a>);
 };
 
 </pre>
@@ -6894,7 +6930,7 @@ Annotating Specs with Tests: the wpt element</a> <a href="#ref-for-attr-title①
   <div style="counter-reset:issue">
    <div class="issue"> Define the issues-list format.
 The <code>-t</code> output is already more than enough to actually work with,
-but it would still be good to describe it more fully.<a href="#issue-9f3e2897"> ↵ </a></div>
+but it would still be good to describe it more fully. <a class="issue-return" href="#issue-9f3e2897" title="Jump to section">↵</a></div>
   </div>
   <aside class="dfn-panel" data-for="metadata-title">
    <b><a href="#metadata-title">#metadata-title</a></b><b>Referenced in:</b>

--- a/tests/biblio002.bs
+++ b/tests/biblio002.bs
@@ -5,7 +5,7 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing 'inline' vs 'index' biblio links.
+Abstract: Testing 'inline' vs 'index' vs 'direct' biblio links.
 Editor: Example Editor
 Date: 1970-01-01
 </pre>
@@ -15,3 +15,5 @@ Date: 1970-01-01
 [[RFC2119 inline]]
 
 [[RFC2119 index]]
+
+[[RFC2119 direct]]

--- a/tests/biblio002.html
+++ b/tests/biblio002.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing <a class="property" data-link-type="propdesc">inline</a> vs <a class="property" data-link-type="propdesc">index</a> biblio links.</p>
+   <p>Testing <a class="property" data-link-type="propdesc">inline</a> vs <a class="property" data-link-type="propdesc">index</a> vs <a class="property" data-link-type="propdesc">direct</a> biblio links.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -433,6 +433,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
    <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a></p>
    <p><a data-biblio-display="index" data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+   <p><a data-biblio-display="direct" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">[RFC2119]</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span></h3>

--- a/tests/biblio003.bs
+++ b/tests/biblio003.bs
@@ -5,7 +5,7 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing 'Default Biblio Index: index'.
+Abstract: Testing 'Default Biblio Display: index'.
 Editor: Example Editor
 Date: 1970-01-01
 Default Biblio Display: index

--- a/tests/biblio003.bs
+++ b/tests/biblio003.bs
@@ -16,3 +16,5 @@ Default Biblio Display: index
 [[RFC2119 inline]]
 
 [[RFC2119 index]]
+
+[[RFC2119 direct]]

--- a/tests/biblio003.html
+++ b/tests/biblio003.html
@@ -433,6 +433,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
    <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a></p>
    <p><a data-biblio-display="index" data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+   <p><a data-biblio-display="direct" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">[RFC2119]</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span></h3>

--- a/tests/biblio003.html
+++ b/tests/biblio003.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing 'Default Biblio Index: index'.</p>
+   <p>Testing 'Default Biblio Display: index'.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">

--- a/tests/biblio004.bs
+++ b/tests/biblio004.bs
@@ -16,3 +16,5 @@ Default Biblio Display: inline
 [[RFC2119 inline]]
 
 [[RFC2119 index]]
+
+[[RFC2119 direct]]

--- a/tests/biblio004.bs
+++ b/tests/biblio004.bs
@@ -5,7 +5,7 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing 'Default Biblio Index: inline'.
+Abstract: Testing 'Default Biblio Display: inline'.
 Editor: Example Editor
 Date: 1970-01-01
 Default Biblio Display: inline

--- a/tests/biblio004.html
+++ b/tests/biblio004.html
@@ -433,6 +433,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a></p>
    <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a></p>
    <p><a data-biblio-display="index" data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+   <p><a data-biblio-display="direct" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">[RFC2119]</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span></h3>

--- a/tests/biblio004.html
+++ b/tests/biblio004.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing 'Default Biblio Index: inline'.</p>
+   <p>Testing 'Default Biblio Display: inline'.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">

--- a/tests/biblio005.bs
+++ b/tests/biblio005.bs
@@ -5,7 +5,7 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing 'Default Biblio Index: direct'.
+Abstract: Testing 'Default Biblio Display: direct'.
 Editor: Example Editor
 Date: 1970-01-01
 Default Biblio Display: direct

--- a/tests/biblio005.bs
+++ b/tests/biblio005.bs
@@ -5,11 +5,16 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing obsolete biblio handling.
+Abstract: Testing 'Default Biblio Index: direct'.
 Editor: Example Editor
 Date: 1970-01-01
+Default Biblio Display: direct
 </pre>
 
-[[dom-level-2-style]]
+[[RFC2119]]
 
-[[dom-level-2-style obsolete]]
+[[RFC2119 inline]]
+
+[[RFC2119 index]]
+
+[[RFC2119 direct]]

--- a/tests/biblio005.html
+++ b/tests/biblio005.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing 'Default Biblio Index: direct'.</p>
+   <p>Testing 'Default Biblio Display: direct'.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">

--- a/tests/biblio006.bs
+++ b/tests/biblio006.bs
@@ -5,13 +5,11 @@ Shortname: foo
 Level: 1
 Status: LS
 ED: http://example.com/foo
-Abstract: Testing inline bibliography generation variations.
+Abstract: Testing obsolete biblio handling.
 Editor: Example Editor
 Date: 1970-01-01
 </pre>
 
-[[JIS4051 inline]] <!-- inline bibliography for documents without url might not be terribly useful, but should not crash-->
+[[dom-level-2-style]]
 
-[[RFC2119 inline|custom text here should work]]
-
-[[JIS4051 inline|not sure why inline is useful on a document without a URL, but hey, the syntax's there, so it might as well work]]
+[[dom-level-2-style obsolete]]

--- a/tests/biblio006.html
+++ b/tests/biblio006.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing inline bibliography generation variations.</p>
+   <p>Testing obsolete biblio handling.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -430,15 +430,12 @@ dfn > a.self-link::before      { content: "#"; }
    </ol>
   </nav>
   <main>
-   <p><a data-biblio-display="inline" data-link-type="biblio" href="#biblio-jis4051"><cite>Formatting rules for Japanese documents (『日本語文書の組版方法』).</cite></a></p>
-   <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">custom text here should work</a></p>
-   <p><a data-biblio-display="inline" data-link-type="biblio" href="#biblio-jis4051">not sure why inline is useful on a document without a URL, but hey, the syntax’s there, so it might as well work</a></p>
+   <p><a data-link-type="biblio" href="#biblio-dom-level-2-style">[dom-level-2-style]</a></p>
+   <p><a data-biblio-obsolete data-link-type="biblio" href="#biblio-dom-level-2-style">[dom-level-2-style]</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span></h3>
   <dl>
-   <dt id="biblio-jis4051">[JIS4051]
-   <dd><cite>Formatting rules for Japanese documents (『日本語文書の組版方法』).</cite> Japanese Standards Association. 2004. JIS X 4051:2004. In Japanese
-   <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
+   <dt id="biblio-dom-level-2-style">[DOM-LEVEL-2-STYLE]
+   <dd>Chris Wilson; Philippe Le Hégaret. <a href="https://www.w3.org/TR/DOM-Level-2-Style/"><cite>Document Object Model (DOM) Level 2 Style Specification</cite></a>. 3 November 2020. REC. URL: <a href="https://www.w3.org/TR/DOM-Level-2-Style/">https://www.w3.org/TR/DOM-Level-2-Style/</a>
   </dl>

--- a/tests/biblio007.bs
+++ b/tests/biblio007.bs
@@ -1,0 +1,17 @@
+<pre class=metadata>
+Title: Foo
+Group: test
+Shortname: foo
+Level: 1
+Status: LS
+ED: http://example.com/foo
+Abstract: Testing inline bibliography generation variations.
+Editor: Example Editor
+Date: 1970-01-01
+</pre>
+
+[[JIS4051 inline]] <!-- inline bibliography for documents without url might not be terribly useful, but should not crash-->
+
+[[RFC2119 inline|custom text here should work]]
+
+[[JIS4051 inline|not sure why inline is useful on a document without a URL, but hey, the syntax's there, so it might as well work]]

--- a/tests/biblio007.html
+++ b/tests/biblio007.html
@@ -416,7 +416,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Testing 'Default Biblio Index: direct'.</p>
+   <p>Testing inline bibliography generation variations.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -430,14 +430,15 @@ dfn > a.self-link::before      { content: "#"; }
    </ol>
   </nav>
   <main>
-   <p><a data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">[RFC2119]</a></p>
-   <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a></p>
-   <p><a data-biblio-display="index" data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
-   <p><a data-biblio-display="direct" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">[RFC2119]</a></p>
+   <p><a data-biblio-display="inline" data-link-type="biblio" href="#biblio-jis4051"><cite>Formatting rules for Japanese documents (『日本語文書の組版方法』).</cite></a></p>
+   <p><a data-biblio-display="inline" data-link-type="biblio" href="https://datatracker.ietf.org/doc/html/rfc2119">custom text here should work</a></p>
+   <p><a data-biblio-display="inline" data-link-type="biblio" href="#biblio-jis4051">not sure why inline is useful on a document without a URL, but hey, the syntax’s there, so it might as well work</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span></h2>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span></h3>
   <dl>
+   <dt id="biblio-jis4051">[JIS4051]
+   <dd><cite>Formatting rules for Japanese documents (『日本語文書の組版方法』).</cite> Japanese Standards Association. 2004. JIS X 4051:2004. In Japanese
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
   </dl>


### PR DESCRIPTION
Add a new biblio display style, "direct", which displays references by their shortname and links to the referenced document. Closes #2032.