### PR TITLE
Upgrade Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ html5lib==1.1
 isodate==0.6.0
 json-home-client==1.1.1
 lxml==4.6.3
-Pillow==8.1.1
+Pillow==9.0.0
 pygments==2.8.1
 requests==2.25.1
 result==0.6.0


### PR DESCRIPTION
The previously specified version of Pillow fails with recent version of
python. This fix allows "pip install -e ." to work on python 3.10

See #2181 and #2153

