### PR TITLE
Remove unnecessary type attribute from <style> and <script>

### DIFF
--- a/bikeshed/spec-data/readonly/boilerplate/act-rules-format/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/act-rules-format/header.include
@@ -5,7 +5,7 @@
   <title>[TITLE] [LEVEL]</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/annotations.include
+++ b/bikeshed/spec-data/readonly/boilerplate/annotations.include
@@ -1,5 +1,4 @@
 <head>
   <script defer
-    src="[ANNOTATIONS]#![TESTSUITE]/[VSHORTNAME]"
-    type="text/javascript"></script>
+    src="[ANNOTATIONS]#![TESTSUITE]/[VSHORTNAME]"></script>
 </head>

--- a/bikeshed/spec-data/readonly/boilerplate/csswg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/csswg/header.include
@@ -7,9 +7,9 @@
   <meta name="csswg-work-status" content="[WORKSTATUS]">
   <meta name="w3c-status" content="[STATUS]">
   <meta name="abstract" content="[ABSTRACTATTR]">
-  <link href="../default.css" rel=stylesheet type="text/css">
+  <link href="../default.css" rel=stylesheet>
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/dap/header-ED.include
+++ b/bikeshed/spec-data/readonly/boilerplate/dap/header-ED.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/fxtf/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/fxtf/header.include
@@ -7,9 +7,9 @@
   <meta name="csswg-work-status" content="[WORKSTATUS]">
   <meta name="w3c-status" content="[STATUS]">
   <meta name="abstract" content="[ABSTRACTATTR]">
-  <link href="../default.css" rel=stylesheet type="text/css">
+  <link href="../default.css" rel=stylesheet>
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/html/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/html/header.include
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
   <title>[TITLE]</title>
-  <link href="styles/styles-html.css" rel="stylesheet" type="text/css">
-  <link href="[W3C-STYLESHEET-URL]" rel="stylesheet" type="text/css">
+  <link href="styles/styles-html.css" rel="stylesheet">
+  <link href="[W3C-STYLESHEET-URL]" rel="stylesheet">
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/i18n/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/i18n/header.include
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
   <meta name="abstract" content="[ABSTRACTATTR]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/immersivewebwg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/immersivewebwg/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/mediacapture/header-ED.include
+++ b/bikeshed/spec-data/readonly/boilerplate/mediacapture/header-ED.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/mediawg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/mediawg/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/secondscreenwg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/secondscreenwg/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/serviceworkers/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/serviceworkers/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/svg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/svg/header.include
@@ -4,8 +4,8 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="../default.css" rel=stylesheet type="text/css">
-  <link href="https://www.w3.org/StyleSheets/TR/W3C-[STATUS]" rel=stylesheet type="text/css">
+  <link href="../default.css" rel=stylesheet>
+  <link href="https://www.w3.org/StyleSheets/TR/W3C-[STATUS]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/texttracks/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/texttracks/header.include
@@ -34,7 +34,7 @@
      color: inherit;
    }
  </style>
- <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+ <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/uievents/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/uievents/header.include
@@ -5,10 +5,10 @@
   <title>[TITLE] [LEVEL]</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="w3c-status" content="[STATUS]">
-  <link href="../default.css" rel=stylesheet type="text/css">
+  <link href="../default.css" rel=stylesheet>
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="styles.css" rel=stylesheet type="text/css">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="styles.css" rel=stylesheet>
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/wasm/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wasm/header.include
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
   <meta name="abstract" content="[ABSTRACTATTR]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webappsec/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webappsec/header.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webauthn/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webauthn/header.include
@@ -5,7 +5,7 @@
   <title>[TITLE] [LEVEL]</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webmlwg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webmlwg/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webperf/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webperf/header.include
@@ -5,7 +5,7 @@
   <title>[TITLE] [LEVEL]</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webplatform/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webplatform/header.include
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webrtc/header-ED.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webrtc/header-ED.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/webtransport/header-ED.include
+++ b/bikeshed/spec-data/readonly/boilerplate/webtransport/header-ED.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <meta name="w3c-status" content="[STATUS]">
-  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
 </head>
 <body class="h-entry">
 <div class="head">

--- a/bikeshed/spec-data/readonly/boilerplate/wg14/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wg14/header.include
@@ -6,7 +6,7 @@
   <title>N[SHORTNAME]: [TITLE]</title>
   <style data-fill-with="stylesheet">
   </style>
-  <style type="text/css">
+  <style>
     table, th, td {
       border: 1px solid black;
       border-collapse: collapse;

--- a/bikeshed/spec-data/readonly/boilerplate/wg21/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wg21/header.include
@@ -6,7 +6,7 @@
   <title>[SHORTNAME]R[LEVEL]: [TITLE]</title>
   <style data-fill-with="stylesheet">
   </style>
-  <style type="text/css">
+  <style>
     table, th, td {
       border: 1px solid black;
       border-collapse: collapse;


### PR DESCRIPTION
The attributes are obsolete and are generating warnings in validator.w3.org/nu as per https://html.spec.whatwg.org/multipage/obsolete.html#warnings-for-obsolete-but-conforming-features

This is similar to https://github.com/tabatkins/bikeshed-boilerplate/pull/16