### PR TITLE
Allow adding `assert` to a div tag.

### DIFF
--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1215,7 +1215,7 @@ def cleanupHTML(doc: "t.SpecType"):
             el.tag = "span"
             el.set("id", h.safeID(doc, "assert-" + h.hashContents(el)))
         # For any <div assert> elements, add a unique ID based on its contents.
-        if el.tag == "div" and "assert" in el.attrib:
+        if el.tag == "div" and el.get("assert") is not None:
             h.removeAttr(el, "assert")
             el.set("id", h.safeID(doc, "assert-" + h.hashContents(el)))
 

--- a/bikeshed/unsortedJunk.py
+++ b/bikeshed/unsortedJunk.py
@@ -1207,11 +1207,16 @@ def cleanupHTML(doc: "t.SpecType"):
             el.tag = "span"
             h.addClass(el, "css")
 
+        # Assert IDs are used to tag arbitrary sections with an ID so you can point tests at it.
+        # (The ID will be guaranteed stable across publications, but guaranteed to change when the text changes.)
+        #
         # Transform the <assert> fake tag into a span with a unique ID based on its contents.
-        # This is just used to tag arbitrary sections with an ID so you can point tests at it.
-        # (And the ID will be guaranteed stable across publications, but guaranteed to change when the text changes.)
         if el.tag == "assert":
             el.tag = "span"
+            el.set("id", h.safeID(doc, "assert-" + h.hashContents(el)))
+        # For any <div assert> elements, add a unique ID based on its contents.
+        if el.tag == "div" and "assert" in el.attrib:
+            h.removeAttr(el, "assert")
             el.set("id", h.safeID(doc, "assert-" + h.hashContents(el)))
 
         # Add ARIA role of "note" to class="note" elements

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1874,9 +1874,19 @@ This isn't very pretty,
 so if you want to avoid it,
 supply an ID yourself.
 
-Bikeshed recognizes a fake element named `<assert>` for marking "assertions" that tests can refer to.
-In the generated output, this is converted to a `<span>` with a unique ID generated from its contents,
-like issues (described above).
+
+Assertions {#id-assert}
+----------
+
+Bikeshed provides the ability to mark "assertions" that tests can refer to.
+The assertion can either be added with the fake element `<assert>` or by
+adding an `assert` attribute to a `div`. (e.g. `<div assert>`).
+
+For the `<assert>` tag, it will be replaced by a `<span>` tag in the generated
+source. The `<div>` tag will pass through but the `assert` attribute is removed.
+
+In both cases a unique ID is generated from the tags contents of the form "assert-###",
+where "###" is a substring of a hash of the assertions contents.
 This ensures that you have a unique ID that won't change arbitrarily,
 but *will* change **when the contents of the assertion change**,
 making it easier to tell when a test might no longer be testing the assertion it points to


### PR DESCRIPTION
This PR adds the ability to add `assert` to a div tag to generate the
unique assert hash for the contents of the div and then attach an
`id=assert-<hash>` to the div. This allows using the assert
functionality with larger block based pieces of spec.

Fixes #2268