### PR TITLE
Add WinterCG group templates

### DIFF
--- a/bikeshed/config/status.py
+++ b/bikeshed/config/status.py
@@ -254,6 +254,7 @@ megaGroups = {
             "webvr",
             "wecg",
             "wicg",
+            "wintercg",
         ]
     ),
     "whatwg": frozenset(["whatwg"]),
@@ -299,6 +300,7 @@ w3cCgs = frozenset(
         "web-bluetooth-cg",
         "wecg",
         "wicg",
+        "wintercg",
     ]
 )
 assert w3cCgs.issubset(megaGroups["w3c"])

--- a/bikeshed/spec-data/readonly/boilerplate/wintercg/copyright.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wintercg/copyright.include
@@ -1,0 +1,2 @@
+<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification, published by the <a href="https://www.w3.org/community/wintercg/">Web-interoperable Runtimes Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.

--- a/bikeshed/spec-data/readonly/boilerplate/wintercg/defaults.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wintercg/defaults.include
@@ -1,0 +1,3 @@
+{
+	"Include Mdn Panels": "if possible"
+}

--- a/bikeshed/spec-data/readonly/boilerplate/wintercg/header.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wintercg/header.include
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>[TITLE]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div class="p-summary" data-fill-with="abstract"></div>
+<div data-fill-with="at-risk"></div>
+
+<h2 class='no-num no-toc no-ref' id='status'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>

--- a/bikeshed/spec-data/readonly/boilerplate/wintercg/status.include
+++ b/bikeshed/spec-data/readonly/boilerplate/wintercg/status.include
@@ -1,0 +1,14 @@
+<p>
+  This specification was published by the <a href="https://www.w3.org/community/wintercg/">Web-interoperable Runtimes Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the
+  <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
+  there is a limited opt-out and other conditions apply.
+
+  Learn more about
+  <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
+</p>
+
+<p>
+	[STATUSTEXT]


### PR DESCRIPTION
WinterCG is a new W3C community group working on interoperability of web
APIs between non-browser runtimes (see https://wintercg.org).

We want to use Bikeshed for our work product documents. As such it'd be
great if Bikeshed had templates for WinterCG built in :)

This commit adds those templates (copied mostly from WICG) with the correct
copyright info for this group.