### PR TITLE
Only count each WPT test once for the summary view

### DIFF
--- a/bikeshed/wpt/wptScript.js
+++ b/bikeshed/wpt/wptScript.js
@@ -23,7 +23,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
-    const seenTests = Set();
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];

--- a/bikeshed/wpt/wptScript.js
+++ b/bikeshed/wpt/wptScript.js
@@ -23,6 +23,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -31,10 +32,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -44,6 +41,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {

--- a/bikeshed/wpt/wptScript.js
+++ b/bikeshed/wpt/wptScript.js
@@ -42,15 +42,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/WICG/idle-detection/index.html
+++ b/tests/github/WICG/idle-detection/index.html
@@ -2132,6 +2132,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -2140,10 +2141,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -2153,6 +2150,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -2209,4 +2217,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/WICG/idle-detection/index.html
+++ b/tests/github/WICG/idle-detection/index.html
@@ -2151,15 +2151,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/WICG/portals/index.html
+++ b/tests/github/WICG/portals/index.html
@@ -3506,15 +3506,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/WICG/portals/index.html
+++ b/tests/github/WICG/portals/index.html
@@ -3487,6 +3487,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3495,10 +3496,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3508,6 +3505,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3564,4 +3572,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/WICG/scroll-to-text-fragment/index.html
+++ b/tests/github/WICG/scroll-to-text-fragment/index.html
@@ -3584,15 +3584,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/WICG/scroll-to-text-fragment/index.html
+++ b/tests/github/WICG/scroll-to-text-fragment/index.html
@@ -3565,6 +3565,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3573,10 +3574,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3586,6 +3583,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3642,4 +3650,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
@@ -2994,6 +2994,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3002,10 +3003,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3015,6 +3012,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3071,4 +3079,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
@@ -3013,15 +3013,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
@@ -8533,15 +8533,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
@@ -8514,6 +8514,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -8522,10 +8523,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -8535,6 +8532,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -8591,4 +8599,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
@@ -3096,15 +3096,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
@@ -3077,6 +3077,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3085,10 +3086,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3098,6 +3095,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3154,4 +3162,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
@@ -3846,15 +3846,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
@@ -3827,6 +3827,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3835,10 +3836,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3848,6 +3845,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3904,4 +3912,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
@@ -7901,15 +7901,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
@@ -7882,6 +7882,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -7890,10 +7891,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -7903,6 +7900,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -7959,4 +7967,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
@@ -9282,15 +9282,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
@@ -9263,6 +9263,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -9271,10 +9272,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -9284,6 +9281,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -9340,4 +9348,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
@@ -3548,15 +3548,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
@@ -3529,6 +3529,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3537,10 +3538,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3550,6 +3547,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3606,4 +3614,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
@@ -3187,15 +3187,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
@@ -3168,6 +3168,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -3176,10 +3177,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -3189,6 +3186,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -3245,4 +3253,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
@@ -9655,15 +9655,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
@@ -9636,6 +9636,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -9644,10 +9645,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -9657,6 +9654,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -9713,4 +9721,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
@@ -4916,6 +4916,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -4924,10 +4925,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -4937,6 +4934,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -4993,4 +5001,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
@@ -4935,15 +4935,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
@@ -4729,6 +4729,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -4737,10 +4738,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -4750,6 +4747,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -4806,4 +4814,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
@@ -4748,15 +4748,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
@@ -8051,6 +8051,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -8059,10 +8060,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -8072,6 +8069,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -8128,4 +8136,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
@@ -8070,15 +8070,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");

--- a/tests/github/w3c/csswg-drafts/css2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css2/Overview.html
@@ -20353,6 +20353,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         const passes = result.legacy_status.map(x=>[x.passes, x.total]);
         return [testPath, passes];
     }));
+    const seenTests = new Set();
     document.querySelectorAll(".wpt-name").forEach(nameEl=>{
         const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
         const numTests = passData[0][1];
@@ -20361,10 +20362,6 @@ document.addEventListener("DOMContentLoaded", async ()=>{
                 el("small", {}, ` (${numTests} tests)`));
         }
         if(passData == undefined) return;
-        passData.forEach((p,i) => {
-            browsers[i].passes += p[0];
-            browsers[i].total += p[1];
-        })
         const resultsEl = el("span",{"class":"wpt-results"},
             ...passData.map((p,i) => el("span",
             {
@@ -20374,6 +20371,17 @@ document.addEventListener("DOMContentLoaded", async ()=>{
             })),
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
+
+	// Only update the summary pass/total count if we haven't seen this
+	// test before, to support authors listing the same test multiple times
+	// in a spec.
+        if (!seenTests.has(nameEl.getAttribute("title"))) {
+          seenTests.add(nameEl.getAttribute("title"));
+          passData.forEach((p,i) => {
+              browsers[i].passes += p[0];
+              browsers[i].total += p[1];
+          });
+        }
     });
     const overview = document.querySelector(".wpt-overview");
     if(overview) {
@@ -20430,4 +20438,5 @@ function formatWptResult({name, version, passes, total}) {
         el('br', {}),
         el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
     );
-}</script>
+}
+</script>

--- a/tests/github/w3c/csswg-drafts/css2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css2/Overview.html
@@ -20372,15 +20372,15 @@ document.addEventListener("DOMContentLoaded", async ()=>{
         );
         nameEl.insertAdjacentElement("afterend", resultsEl);
 
-	// Only update the summary pass/total count if we haven't seen this
-	// test before, to support authors listing the same test multiple times
-	// in a spec.
+        // Only update the summary pass/total count if we haven't seen this
+        // test before, to support authors listing the same test multiple times
+        // in a spec.
         if (!seenTests.has(nameEl.getAttribute("title"))) {
-          seenTests.add(nameEl.getAttribute("title"));
-          passData.forEach((p,i) => {
-              browsers[i].passes += p[0];
-              browsers[i].total += p[1];
-          });
+            seenTests.add(nameEl.getAttribute("title"));
+            passData.forEach((p,i) => {
+                browsers[i].passes += p[0];
+                browsers[i].total += p[1];
+            });
         }
     });
     const overview = document.querySelector(".wpt-overview");


### PR DESCRIPTION
Previously, every .wpt-name was counted for calculating the pass/total summary,
even if it had previously been seen. This would cause inaccurate results for
specifications where authors list the same WPT test more than once (e.g., if
the test relates to multiple parts of the spec).

Fixes https://github.com/tabatkins/bikeshed/issues/2303