### PR TITLE
`encoding` keyword removed from json.load in python 3.9

### DIFF
--- a/bikeshed/update/updateCanIUse.py
+++ b/bikeshed/update/updateCanIUse.py
@@ -16,7 +16,7 @@ def update(path, dryRun=False):
         return
 
     try:
-        data = response.json(encoding="utf-8", object_pairs_hook=OrderedDict)
+        data = response.json(object_pairs_hook=OrderedDict)
     except Exception as e:
         m.die(f"The Can I Use data wasn't valid JSON for some reason. Try downloading again?\n{e}")
         return

--- a/bikeshed/update/updateMdn.py
+++ b/bikeshed/update/updateMdn.py
@@ -17,7 +17,7 @@ def update(path, dryRun=False):
         return
 
     try:
-        data = response.json(encoding="utf-8", object_pairs_hook=OrderedDict)
+        data = response.json(object_pairs_hook=OrderedDict)
     except Exception as e:
         m.die(f"The MDN Spec Links data wasn't valid JSON for some reason. Try downloading again?\n{e}")
         return


### PR DESCRIPTION
It should fix https://github.com/tabatkins/bikeshed/issues/2320