### PR TITLE
Cater for ReSpec specs in headings extraction rules

### DIFF
--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -134,7 +134,7 @@ def update(path: str, dryRun: bool = False) -> set[str] | None:
                 continue
             if "section" in rawAnchor and rawAnchor["section"] is True:
                 addToHeadings(rawAnchor, specHeadings, spec=spec)
-            if rawAnchor["type"] not in ["heading"]:
+            else:
                 addToAnchors(rawAnchor, anchors, spec=spec)
 
     cleanSpecHeadings(headings)
@@ -219,7 +219,7 @@ def linearizeAnchorTree(multiTree: list, rawAnchors: list[dict[str, t.Any]] = No
         rawAnchors = []
     # Call with multiTree being a list of trees
     for item in multiTree:
-        if item["type"] in config.dfnTypes.union(["dfn", "heading"]):
+        if (item["type"] == "dfn") or ("section" in item and item["section"] is True):
             rawAnchors.append(item)
         if item.get("children"):
             linearizeAnchorTree(item["children"], rawAnchors)


### PR DESCRIPTION
Via https://github.com/tabatkins/bikeshed/issues/1664#issuecomment-1264307993

When a spec generated with ReSpec is added to Shepherd for cross-referencing purpose, definitions properly find their way onto bikeshed-data. Headings do not however (e.g. see [empty headings file of the Presentation API](https://github.com/tabatkins/bikeshed-data/blob/267f66ae75d7ed43852300a63b69ba05ef42bd2e/data/headings/headings-presentation-api-1.json)).

The code that deals with anchor data from Shepherd only considered entries that had both a `heading` type and a `section` flag. Problem is ReSpec wraps sections using `<section>` and adds an ID to both the `<section>` and the heading elements. This makes Shepherd end up with two entries:

- one for the `<section>` of type `other` with a `section` flag
- one for the heading element of type `heading` but without `section` flag

Both entries were skipped. This update makes Bikeshed consider that all entries with a `section` flag are to be added to the list of headings and ignore entries of type `heading` (unless they have a `section` flag too).

This makes Bikeshed select the more straightforward `<section>` ID in specs generated with ReSpec and not the less straightforward heading element ID (e.g. `introduction` instead of `x1-introduction`), which would be selected if Bikeshed only considered anchor entries with a `heading` type instead.

Testing locally, this seems to solve the problem for ReSpec specs referenced in Shepherd and does not seem to have bad consequences on Bikeshed specs, but note I did not run a complete re-generation of the anchor data, so there may exist cases where this update adds additional heading entries that should not be viewed as headings.