### PR TITLE
Fix anchors processing

### DIFF
--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -219,7 +219,7 @@ def linearizeAnchorTree(multiTree: list, rawAnchors: list[dict[str, t.Any]] | No
         rawAnchors = []
     # Call with multiTree being a list of trees
     for item in multiTree:
-        if (item["type"] == "dfn") or ("section" in item and item["section"] is True):
+        if (item["type"] in config.dfnTypes.union(["dfn"])) or ("section" in item and item["section"] is True):
             rawAnchors.append(item)
         if item.get("children"):
             linearizeAnchorTree(item["children"], rawAnchors)


### PR DESCRIPTION
PR #2358 fixed headings but also excluded all non `dfn` terms from processing, resulting in many definitions missing from the anchors data. This update makes sure that all terms are taken into account.

(With my apologies for the hiccup. I completely overlooked `config.dfnTypes` when I removed `"heading"` types, and I was so focused on solving the headings problem that I didn't notice this would affect anchors generation)

Note I'm currently re-generating anchors locally to confirm that this works as intended. Will update once done.