### PR TITLE
Bump python version

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -221,7 +221,7 @@ To use bikeshed on [Travis CI](https://travis-ci.org/)'s github integration, you
 ```
 language: python
 python:
-  - "3.8"
+  - "3.10"
 install:
   - pip install bikeshed
   - bikeshed update


### PR DESCRIPTION
Bikeshed no longer seems to run fine a python 3.8, so don't advertise that it does.

See for example https://github.com/w3c/w3process/actions/runs/3243873384/jobs/5319223498 This bug goes away by using python 3.10