### PR TITLE
Support balanced top-level parens, escaped parens, missing url

### DIFF
--- a/bikeshed/shorthands/oldShorthands.py
+++ b/bikeshed/shorthands/oldShorthands.py
@@ -678,18 +678,28 @@ def varReplacer(match: re.Match) -> t.NodeT:
 
 inlineLinkRe = re.compile(
     r"""
-                            (\\)?
-                            \[([^\]]*)\]
-                            \(\s*
-                            ([^\s)]+)
-                            \s*(?:"([^"]*)")?\s*
-                            \)""",
+                    (\\)?
+                    \[([^\]]+)\]
+                    \(\s*
+                    (
+                        (?:\\[()]|[^\s"()])*
+                        (?:
+                            # Optional top-level paren group
+                            (?:\((?:\\[()]|[^\s"()])*\))
+                            (?:\\[()]|[^\s"()])*
+                        )*
+                    )
+                    \s*(?:"([^"]*)")?\s*
+                    \)""",
     re.X,
 )
 
 
 def inlineLinkReplacer(match: re.Match) -> t.NodeT:
     _, text, href, title = match.groups()
+    # Remove escapes from parens.
+    href = re.sub(r"\\\(", "(", href)
+    href = re.sub(r"\\\)", ")", href)
     if title:
         attrs = {"href": href, "title": title}
     else:

--- a/tests/markdown012.bs
+++ b/tests/markdown012.bs
@@ -15,9 +15,15 @@ Markup Shorthands: markdown on
 Fragment {#fragment}
 ========
 
-[link]() this is fine
+[link]() missing link and title is fine
 
 [link](/uri) this is normal
+
+[link](/url "title") link and title
+
+[link]("title") missing link, only title is OK
+
+[link] (/uri) is not a proper link, you monster
 
 [link](#fragment) cool too
 
@@ -25,14 +31,27 @@ Fragment {#fragment}
 
 [link](http://example.com?foo=3#frag) nice nice
 
+[link](http://example.com?foo=3#frag); nice and tidy
+
+[link](http://example.com?foo=3#frag)
+
 [link](foo\bar) leave as-is
 
 [link](foo%20b&auml;) also leave as-is
-
-[link](/url "title") fancy
 
 [link](   /uri  ) is OK, albeit spacy
 
 [link](   /uri  "title"  ) is OK
 
-[link] (/uri) is not OK, you monster
+[link](https://en.wikipedia.org/wiki/Sandbox_&lpar;computer_security&rpar;) - html entities for '(' and ')'
+
+[link](https://en.wikipedia.org/wiki/Sandbox_(computer_security)and(Other)(Tricks)) - balanced parens
+
+[link](https://en.wikipedia.org/wiki/Sandbox_\(computer_security\)and\(Other\)\(Tricks) - escaped parens
+
+[link](https://en.wikipedia.org/wiki/Sandbox_((computer_security)) - unbalanced unescaped parens, not a link
+
+Not Yet Supported
+=================
+
+[link](</uri>) link surrounded by angle brackets should be supported

--- a/tests/markdown012.html
+++ b/tests/markdown012.html
@@ -423,19 +423,29 @@ dfn > a.self-link::before      { content: "#"; }
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
     <li><a href="#fragment"><span class="secno">1</span> <span class="content">Fragment</span></a>
+    <li><a href="#not-yet-supported"><span class="secno">2</span> <span class="content">Not Yet Supported</span></a>
    </ol>
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="fragment"><span class="secno">1. </span><span class="content">Fragment</span><a class="self-link" href="#fragment"></a></h2>
-   <p>[link]() this is fine</p>
+   <p><a href>link</a> missing link and title is fine</p>
    <p><a href="/uri">link</a> this is normal</p>
+   <p><a href="/url" title="title">link</a> link and title</p>
+   <p><a href title="title">link</a> missing link, only title is OK</p>
+   <p>[link] (/uri) is not a proper link, you monster</p>
    <p><a href="#fragment">link</a> cool too</p>
    <p><a href="http://example.com#fragment">link</a> nice</p>
    <p><a href="http://example.com?foo=3#frag">link</a> nice nice</p>
+   <p><a href="http://example.com?foo=3#frag">link</a>; nice and tidy</p>
+   <p><a href="http://example.com?foo=3#frag">link</a></p>
    <p><a href="foo\bar">link</a> leave as-is</p>
    <p><a href="foo%20bä">link</a> also leave as-is</p>
-   <p><a href="/url" title="title">link</a> fancy</p>
    <p><a href="/uri">link</a> is OK, albeit spacy</p>
    <p><a href="/uri" title="title">link</a> is OK</p>
-   <p>[link] (/uri) is not OK, you monster</p>
+   <p><a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)">link</a> - html entities for '(' and ')'</p>
+   <p><a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)and(Other)(Tricks)">link</a> - balanced parens</p>
+   <p><a href="https://en.wikipedia.org/wiki/Sandbox_(computer_security)and(Other)(Tricks">link</a> - escaped parens</p>
+   <p>[link](https://en.wikipedia.org/wiki/Sandbox_((computer_security)) - unbalanced unescaped parens, not a link</p>
+   <h2 class="heading settled" data-level="2" id="not-yet-supported"><span class="secno">2. </span><span class="content">Not Yet Supported</span><a class="self-link" href="#not-yet-supported"></a></h2>
+   <p><a href>link</a> link surrounded by angle brackets should be supported</p>
   </main>


### PR DESCRIPTION
This PR fixes several things, on the way to adding support for balanced parens, to partially fix #1419.

- Escaped parens were not handled quite right, since the escape chars (\\) need to be removed.
- The extra trailing right paren remained a problem until the right paren was removed from the negation set for url chars.
- The url was required, but should be optional.
- Multiple nested balanced paren groups should be supported, but only top-level paren groups can be supported without recursive patterns.
- Angle-brackets around the url should be supported, but that requires recursive patterns.

The link shortcut tests were improved to test all these cases.
