### PR TITLE
Add test with link-defaults type: permission

### DIFF
--- a/tests/elementdef001.bs
+++ b/tests/elementdef001.bs
@@ -47,3 +47,12 @@ Here are the <dfn>quux attributes</dfn>:
 </ul>
 
 The <dfn interface>SVGTestElement</dfn> interface is defined here.
+
+<pre class=link-defaults>
+    spec: web-bluetooth
+    type: permission
+    text: "bluetooth"
+</pre>
+
+Link to "bluetooth" does not resolve:
+<a permission>"bluetooth"</a>

--- a/tests/elementdef001.html
+++ b/tests/elementdef001.html
@@ -547,6 +547,7 @@ dfn > a.self-link::before      { content: "#"; }
      <p><dfn class="dfn-paneled" data-dfn-for="quux attributes" data-dfn-type="element-attr" data-export id="element-attrdef-quux-attributes-quux2"><code>quux2</code></dfn></p>
    </ul>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="svgtestelement"><code>SVGTestElement</code></dfn> interface is defined here.</p>
+   <p>Link to "bluetooth" does not resolve: <a class="idl-code" data-link-type="permission">"bluetooth"</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>


### PR DESCRIPTION
This PR adds a test with a link-defaults declaration of type: permission.
As #2250 indicates, a link that uses the "permission" attribute does not resolve.
