### PR TITLE
Reference to WebIDL namespace declaration

### DIFF
--- a/tests/idl003.bs
+++ b/tests/idl003.bs
@@ -24,3 +24,14 @@ interface Foo {
 </pre>
 
 {{Foo}}, {{foo}}, {{or}}, {{_or}}
+
+
+Namespace reference
+
+<xmp class=idl>
+namespace FooNamespace {
+  /* namespace_members... */
+};
+</xmp>
+
+{{FooNamespace}}, {{foonamespace}}

--- a/tests/idl003.html
+++ b/tests/idl003.html
@@ -639,6 +639,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <td>An argument.
    </table>
    <p><code class="idl"><a data-link-type="idl" href="#foo" id="ref-for-foo">Foo</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-foo-foo" id="ref-for-dom-foo-foo">foo</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-foo-or" id="ref-for-dom-foo-or">or</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-foo-or" id="ref-for-dom-foo-or①">_or</a></code></p>
+   <p>Namespace reference</p>
+<pre class="idl highlight def"><c- b>namespace</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="namespace" data-export id="namespacedef-foonamespace"><code><c- g>FooNamespace</c-></code></dfn> {
+  /* namespace_members... */
+};
+</pre>
+   <p><code class="idl"><a data-link-type="idl" href="#namespacedef-foonamespace" id="ref-for-namespacedef-foonamespace">FooNamespace</a></code>, <code class="idl"><a data-link-type="idl">foonamespace</a></code></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span></h3>
@@ -649,6 +655,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#enumdef-barenum">BarEnum</a><span>, in § Unnumbered section</span>
    <li><a href="#foo">Foo</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-foo">foo</a><span>, in § Unnumbered section</span>
+   <li><a href="#namespacedef-foonamespace">FooNamespace</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-get">get(a)</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-or">or</a><span>, in § Unnumbered section</span>
   </ul>
@@ -695,6 +702,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-any"><c- b>any</c-></a>> <a href="#dom-foo-get"><code><c- g>get</c-></code></a>(<a data-link-type="idl-name"><c- n>int</c-></a> <a class="idl-code" data-link-type="argument" href="#dom-foo-get-a-a"><c- g>a</c-></a>);
 };
 
+<c- b>namespace</c-> <a href="#namespacedef-foonamespace"><code><c- g>FooNamespace</c-></code></a> {
+  /* namespace_members... */
+};
+
 </pre>
   <aside class="dfn-panel" data-for="enumdef-barenum">
    <b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
@@ -730,6 +741,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <b><a href="#dom-foo-get-a-a">#dom-foo-get-a-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-get-a-a">Unnamed section</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="namespacedef-foonamespace">
+   <b><a href="#namespacedef-foonamespace">#namespacedef-foonamespace</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-namespacedef-foonamespace">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This PR adds a test of a webidl namespace decl and reference via {{Namespace}}.

#2198 says this should fail, but it seems to work, at least if the reference is spelled with the same capitalization.
