### PR TITLE
Fix algorithm documentation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1651,7 +1651,7 @@ Bikeshed explicitly recognizes this,
 and has several features related to this.
 
 <dfn>Algorithms</dfn> can be explicitly indicated in your markup
-by putting the `algorithm="to foo a bar"` attribute on a container element
+by putting the `algorithm` attribute on a container element
 or a heading.
 All vars within an [=algorithm=] are "scoped" to that algorithm.
 


### PR DESCRIPTION
The [algorithm tests](https://github.com/tabatkins/bikeshed/blob/main/tests/algorithm001.bs#L23-L27) do not add a algorithm name and neither do some uses in csswg-drafts. Remove the algorithm tag arguments in the documentation. The current documentation caused some confusion in https://github.com/whatwg/fetch/pull/1549.

Wasn't sure if I should also update the generated documentation html file. Feedback is very much welcomed!