### PR TITLE
Add file associations for .include files.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "*.include": "html",
+        "stylesheet.include": "css",
+        "defaults*.include": "json",
+        "bs-extensions.include": "bikeshed"
+    }
+}


### PR DESCRIPTION
This is especially useful for the default case of html files.  But some might be bikeshed files, e.g. bs-extensions.include, though I'm not quite sure what "language" it is.