### PR TITLE
Complete anchors/headings with data from Webref

### DIFF
--- a/bikeshed/update/updateCrossRefs.py
+++ b/bikeshed/update/updateCrossRefs.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import certifi
 import tenacity
+import requests
 from json_home_client import Client as APIClient
 
 from .. import config, messages as m, t
@@ -45,6 +46,31 @@ if t.TYPE_CHECKING:
         total=False,
     )
 
+    RawWebrefAnchorT = t.TypedDict(
+        "RawWebrefAnchorT",
+        {
+            "id": t.Required[str],
+            "type": t.Required[str],
+            "for": list[str],
+            "informative": bool,
+            "access": t.Required[str],
+            "linkingText": list[str],
+            "href": t.Required[str],
+        },
+        total=False,
+    )
+
+    RawWebrefHeadingT = t.TypedDict(
+        "RawWebrefHeadingT",
+        {
+            "id": t.Required[str],
+            "href": t.Required[str],
+            "title": t.Required[str],
+            "level": t.Required[int],
+            "number": t.Required[str]
+        },
+        total=False)
+
     # Need to use function form due to "for" key
     # being invalid as a property name
     AnchorT = t.TypedDict(
@@ -72,6 +98,16 @@ if t.TYPE_CHECKING:
         draft_uri: str | None
         abstract: str | None
 
+    class RawWebrefSpecT(t.TypedDict, total=False):
+        url: t.Required[str]
+        shortname: t.Required[str]
+        title: t.Required[str]
+        shortTitle: t.Required[str]
+        series: t.Required(dict[str, str])
+        nightly: t.Required(dict[str, str | list(str)])
+        release: dict[str, str | list(str)] | None
+        seriesVersion: str | None
+
     class SpecT(t.TypedDict):
         vshortname: str
         shortname: str
@@ -86,9 +122,37 @@ if t.TYPE_CHECKING:
 def progressMessager(index: int, total: int) -> t.Callable[[], None]:
     return lambda: m.say(f"Downloading data for spec {index}/{total}...")
 
-
 def update(path: str, dryRun: bool = False) -> set[str] | None:
-    m.say("Downloading anchor data...")
+    def setStatus(obj: RawAnchorT, status: str) -> RawAnchorT:
+        obj["status"] = status
+        return obj
+
+    def isSpecInList(spec: SpecT, specs: SpecsT) -> bool:
+        if spec["vshortname"].lower() in specs:
+            return True
+        for s in specs.values():
+            # Shortnames don't always match. Let's compare URLs
+            if (s["snapshot_url"] is not None and s["snapshot_url"] == spec["snapshot_url"]) or (s["current_url"] is not None and s["current_url"] == spec["current_url"]):
+                return True
+        return False
+
+    def processRawAnchors(rawAnchorData: list(RawAnchorT), anchors: AnchorsT, specHeadings: AllHeadingsT) -> None:
+        for rawAnchor in rawAnchorData:
+            rawAnchor = fixupAnchor(rawAnchor)
+            linkingTexts = rawAnchor["linking_text"]
+            assert linkingTexts is not None
+            if len(linkingTexts) == 0:
+                # Happens if it had no linking text at all originally
+                continue
+            if len(linkingTexts) == 1 and linkingTexts[0].strip() == "":
+                # Happens if it was marked with an empty lt and Shepherd still picked it up
+                continue
+            if "section" in rawAnchor and rawAnchor["section"] is True:
+                addToHeadings(rawAnchor, specHeadings, spec=spec)
+            if rawAnchor["type"] in config.dfnTypes.union(["dfn"]):
+                addToAnchors(rawAnchor, anchors, spec=spec)
+
+    m.say("Downloading anchor data from Shepherd...")
     shepherd = APIClient(
         "https://api.csswg.org/shepherd/",
         version="vnd.csswg.shepherd.v1",
@@ -115,27 +179,63 @@ def update(path: str, dryRun: bool = False) -> set[str] | None:
         specHeadings: HeadingsT = {}
         headings[spec["vshortname"]] = specHeadings
 
-        def setStatus(obj: RawAnchorT, status: str) -> RawAnchorT:
-            obj["status"] = status
-            return obj
-
         rawAnchorData = [setStatus(x, "snapshot") for x in linearizeAnchorTree(rawSpec.get("anchors", []))] + [
             setStatus(x, "current") for x in linearizeAnchorTree(rawSpec.get("draft_anchors", []))
         ]
-        for rawAnchor in rawAnchorData:
-            rawAnchor = fixupAnchor(rawAnchor)
-            linkingTexts = rawAnchor["linking_text"]
-            assert linkingTexts is not None
-            if len(linkingTexts) == 0:
-                # Happens if it had no linking text at all originally
-                continue
-            if len(linkingTexts) == 1 and linkingTexts[0].strip() == "":
-                # Happens if it was marked with an empty lt and Shepherd still picked it up
-                continue
-            if "section" in rawAnchor and rawAnchor["section"] is True:
-                addToHeadings(rawAnchor, specHeadings, spec=spec)
-            if rawAnchor["type"] in config.dfnTypes.union(["dfn"]):
-                addToAnchors(rawAnchor, anchors, spec=spec)
+        processRawAnchors(rawAnchorData, anchors, specHeadings)
+
+    m.say("Downloading anchor data from Webref...")
+    webrefAPIUrl = "https://raw.githubusercontent.com/w3c/webref/main/"
+    currentWebrefData = dataFromWebref(webrefAPIUrl + "ed/index.json")
+    if not currentWebrefData or not "results" in currentWebrefData or currentWebrefData["results"] is None:
+        return None
+    currentWebrefData = currentWebrefData["results"]
+    snapshotWebrefData = dataFromWebref(webrefAPIUrl + "tr/index.json")
+    snapshotWebrefData = snapshotWebrefData["results"] if snapshotWebrefData and "results" in snapshotWebrefData and snapshotWebrefData["results"] is not None else None
+
+    for i, currentSpec in enumerate(currentWebrefData, 1):
+        lastMsgTime = config.doEvery(
+            s=5,
+            lastTime=lastMsgTime,
+            action=progressMessager(i, len(currentWebrefData)),
+        )
+        if "dfns" not in currentSpec and "headings" not in currentSpec:
+            continue
+        spec = genWebrefSpec(currentSpec)
+        if isSpecInList(spec, specs):
+            # Skip specs that are already in Shepherd's database
+            continue
+
+        assert spec["vshortname"] is not None
+        specs[spec["vshortname"]] = spec
+        specHeadings: HeadingsT = {}
+        headings[spec["vshortname"]] = specHeadings
+        rawAnchorData: list[RawAnchorT] = []
+        if "dfns" in currentSpec:
+            currentAnchors = dataFromWebref(webrefAPIUrl + "ed/" + currentSpec["dfns"])
+            if currentAnchors:
+                rawAnchorData = [setStatus(convertWebrefAnchor(x, spec["current_url"]), "current") for x in currentAnchors["dfns"]]
+        if "headings" in currentSpec:
+            currentHeadings = dataFromWebref(webrefAPIUrl + "ed/" + currentSpec["headings"])
+            if currentHeadings:
+                rawAnchorData += [setStatus(convertWebrefHeading(x, spec["current_url"]), "current") for x in currentHeadings["headings"]]
+
+        # Complete list of anchors/headings with those from the snapshot version of the spec
+        if spec["snapshot_url"] is not None and snapshotWebrefData is not None:
+            snapshotSpec = [s for s in snapshotWebrefData if s["shortname"] == currentSpec["shortname"]]
+            if len(snapshotSpec) > 0:
+                snapshotSpec = snapshotSpec.pop()
+                if "dfns" in snapshotSpec:
+                    snapshotAnchors = dataFromWebref(webrefAPIUrl + "tr/" + snapshotSpec["dfns"])
+                    if snapshotAnchors:
+                        rawAnchorData += [setStatus(convertWebrefAnchor(x, spec["snapshot_url"]), "snapshot") for x in snapshotAnchors["dfns"]]
+                if "headings" in snapshotSpec:
+                    snapshotHeadings = dataFromWebref(webrefAPIUrl + "tr/" + snapshotSpec["headings"])
+                    if snapshotHeadings:
+                        rawAnchorData += [setStatus(convertWebrefHeading(x, spec["snapshot_url"]), "snapshot") for x in snapshotHeadings["headings"]]
+
+        if len(rawAnchorData) > 0:
+            processRawAnchors(rawAnchorData, anchors, specHeadings)
 
     cleanSpecHeadings(headings)
 
@@ -213,6 +313,20 @@ def dataFromApi(api: APIClient, *args: t.Any, **kwargs: t.Any) -> t.JSONT:
         raise Exception(f"Didn't get expected JSON data. Got:\n{data.decode('utf-8')}")
     return t.cast("t.JSONT", data)
 
+@tenacity.retry(reraise=True, stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_random(1, 2))
+def dataFromWebref(url: str) -> t.JSONT:
+    try:
+        response = requests.get(url)
+    except Exception as e:
+        raise Exception(
+            f"Couldn't download data from Webref.\n{e}"
+        )
+    try:
+        data = response.json()
+    except Exception as e:
+        raise Exception(
+            f"Data retrieved from Webref wasn't valid JSON for some reason. Try downloading again?\n{e}")
+    return data
 
 def linearizeAnchorTree(multiTree: list, rawAnchors: list[dict[str, t.Any]] | None = None) -> list[RawAnchorT]:
     if rawAnchors is None:
@@ -263,6 +377,64 @@ def genSpec(rawSpec: RawSpecT) -> SpecT:
         spec["level"] = 1
     return spec
 
+def genWebrefSpec(rawSpec: RawWebrefSpecT) -> SpecT:
+    """Generate a spec object from data gleaned from Webref"""
+    assert rawSpec["shortname"] is not None
+    assert rawSpec["series"] is not None
+    assert rawSpec["nightly"] is not None
+    assert rawSpec["title"] is not None
+    assert rawSpec["shortTitle"] is not None
+    spec: SpecT = {
+        "vshortname": rawSpec["shortname"],
+        "shortname": rawSpec["series"]["shortname"],
+        "snapshot_url": rawSpec["release"]["url"] if "release" in rawSpec else None,
+        "current_url": rawSpec["nightly"]["url"],
+        "title": rawSpec["shortTitle"],
+        "description": rawSpec["title"],
+        "abstract": None,
+        "level": int(rawSpec["seriesVersion"]) if "seriesVersion" in rawSpec and re.match(r"^\d+$", rawSpec["seriesVersion"]) else None,
+    }
+    return spec
+
+def convertWebrefHeading(heading: RawWebrefHeadingT, specUrl: str) -> RawAnchorT:
+    """Convert a heading returned by Webref to the anchor format used in Shepherd"""
+    assert heading["id"] is not None
+    assert heading["title"] is not None
+    assert heading["href"] is not None
+    anchor: RawAnchorT = {
+        "name": heading["number"] if "number" in heading else heading["id"],
+        "type": "heading",
+        "for": [],
+        "section": True,
+        "title": heading["title"],
+        "status": "unknown",
+        "normative": True,
+        "export": "public",
+        "linking_text": [heading["title"]],
+        "uri": heading["href"].replace(specUrl, ""),
+    }
+    return anchor
+
+def convertWebrefAnchor(rawAnchor: RawWebrefAnchorT, specUrl: str) -> RawAnchorT:
+    """Convert an anchor returned by Webref to the anchor format used in Shepherd"""
+    assert rawAnchor["id"] is not None
+    assert rawAnchor["type"] is not None
+    assert rawAnchor["linkingText"] is not None
+    assert rawAnchor["access"] is not None
+    assert rawAnchor["href"] is not None
+    anchor: RawAnchorT = {
+        "name": rawAnchor["id"],
+        "type": rawAnchor["type"],
+        "for": rawAnchor["for"],
+        "section": False,
+        "title": rawAnchor["linkingText"][0],
+        "status": "unknown",
+        "normative": not rawAnchor["informative"],
+        "export": rawAnchor["access"] == "public",
+        "linking_text": rawAnchor["linkingText"],
+        "uri": rawAnchor["href"].replace(specUrl, ""),
+    }
+    return anchor
 
 def fixupAnchor(anchor: RawAnchorT) -> RawAnchorT:
     """Miscellaneous fixes to the anchors before I start processing"""


### PR DESCRIPTION
This proposes to complete the update mechanism that produces the cross-references anchors and headings to also use data from Webref, as proposed in #1761. To keep changes minimal and avoid introducing possibly conflicting anchors and headings here and there (and thus avoid breaking existing specs), data from Webref is only used for specs that are not in Shepherd's database.

In practice, this adds definitions and headings from 267 specifications (~60 of which only have headings), generating ~3.5MB of anchors data and ~5.2MB of headings data. Full list below. Only 3 specs related to CSS that are not (yet) in Shepherd: [CSS Anchor Positioning](https://drafts.csswg.org/css-anchor-1/), [CSS Images Module Level 5](https://drafts.csswg.org/css-images-5/), and [CSS Parser API](https://wicg.github.io/css-parser-api/).

Produced anchors and headings look good to me but I don't really know how to validate them in practice.

There won't be duplicates in the sense that anchors/headings data will either come from Shepherd or from Webref but not from both. Adding new anchors data means that there may be more situations where a term is defined in more than one specification though. Existing specifications should be able to continue linking to terms they already use but some may need to add a few additional linking defaults. If that seems useful, it should be relatively easy to build a list of terms defined in more than one spec to better understand what specifications are going to be potentially affected.

(Side note that I'm not fluent in Python so code may need some re-writing. I tried to be explicit about types for instance but not sure I got that part right, and not sure when these types are actually checked).

<details>
  <summary>List of Webref specs added to cross-ref database</summary>

  - [`tc39-intl-negotiation`](https://tc39.es/proposal-intl-numberformat-v3/out/negotiation/proposed.html)
  - [`tc39-intl-numberformat`](https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html)
  - [`tc39-intl-pluralrules`](https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html)
  - [A Method for Writing Testable Conformance Requirements](https://www.w3.org/TR/test-methodology/) (`test-methodology`)
  - [A Well-Known URL for Changing Passwords](https://w3c.github.io/webappsec-change-password-url/) (`change-password-url`)
  - [A-law PCM WebCodecs Registration](https://w3c.github.io/webcodecs/alaw_codec_registration.html) (`webcodecs-alaw-codec-registration`)
  - [AAC WebCodecs Registration](https://w3c.github.io/webcodecs/aac_codec_registration.html) (`webcodecs-aac-codec-registration`)
  - [Accelerated Shape Detection in Images](https://wicg.github.io/shape-detection-api/) (`shape-detection-api`)
  - [Accelerated Text Detection in Images](https://wicg.github.io/shape-detection-api/text.html) (`text-detection-api`)
  - [Accelerometer](https://w3c.github.io/accelerometer/) (`accelerometer`)
  - [Accessible Name and Description Computation 1.2](https://w3c.github.io/accname/) (`accname-1.2`)
  - [Accessible Rich Internet Applications (WAI-ARIA) 1.3](https://w3c.github.io/aria/) (`wai-aria-1.2`)
  - [Ambient Light Sensor](https://w3c.github.io/ambient-light/) (`ambient-light`)
  - [ARIA in HTML](https://w3c.github.io/html-aria/) (`html-aria`)
  - [Array Grouping](https://tc39.es/proposal-array-grouping/) (`tc39-array-grouping`)
  - [Atomics.waitAsync](https://tc39.es/proposal-atomics-wait-async/) (`tc39-atomics-wait-async`)
  - [Attribution Reporting](https://wicg.github.io/attribution-reporting-api/) (`attribution-reporting-api`)
  - [Audio Output Devices API](https://w3c.github.io/mediacapture-output/) (`audio-output`)
  - [Autoplay Policy Detection](https://w3c.github.io/autoplay/) (`autoplay-detection`)
  - [AV1 WebCodecs Registration](https://w3c.github.io/webcodecs/av1_codec_registration.html) (`webcodecs-av1-codec-registration`)
  - [AVC (H.264) WebCodecs Registration](https://w3c.github.io/webcodecs/avc_codec_registration.html) (`webcodecs-avc-codec-registration`)
  - [Background Fetch](https://wicg.github.io/background-fetch/) (`background-fetch`)
  - [Badging API](https://w3c.github.io/badging/) (`badging`)
  - [Battery Status API](https://w3c.github.io/battery/) (`battery-status`)
  - [Beacon](https://w3c.github.io/beacon/) (`beacon`)
  - [Capability Delegation](https://wicg.github.io/capability-delegation/spec.html) (`capability-delegation`)
  - [Capture Handle - Bootstrapping Collaboration when Screensharing](https://w3c.github.io/mediacapture-handle/identity/) (`capture-handle-identity`)
  - [Change Array by copy](https://tc39.es/proposal-change-array-by-copy/) (`tc39-change-array-by-copy`)
  - [Clear Site Data](https://w3c.github.io/webappsec-clear-site-data/) (`clear-site-data`)
  - [Client Hints Infrastructure](https://wicg.github.io/client-hints-infrastructure/) (`client-hints-infrastructure`)
  - [Client to Authenticator Protocol (CTAP)](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html) (`fido-v2.1`)
  - [Clipboard API and events](https://w3c.github.io/clipboard-apis/) (`clipboard-apis`)
  - [Close Watcher API](https://wicg.github.io/close-watcher/) (`close-watcher`)
  - [Compression Streams](https://wicg.github.io/compression/) (`compression`)
  - [Compute Pressure Level 1](https://wicg.github.io/compute-pressure/) (`compute-pressure`)
  - [Contact Picker API](https://w3c.github.io/contact-api/spec/) (`contact-api`)
  - [Content Index](https://wicg.github.io/content-index/spec/) (`content-index`)
  - [Content Security Policy: Embedded Enforcement](https://w3c.github.io/webappsec-cspee/) (`csp-embedded-enforcement`)
  - [ContentEditable](https://w3c.github.io/contentEditable/) (`contentEditable`)
  - [Cookie Store API](https://wicg.github.io/cookie-store/) (`cookie-store`)
  - [Cookies: HTTP State Management Mechanism](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html) (`rfc6265bis`)
  - [Core Accessibility API Mappings 1.2](https://w3c.github.io/core-aam/) (`core-aam-1.2`)
  - [Crash Reporting](https://wicg.github.io/crash-reporting/) (`crash-reporting`)
  - [CSS Anchor Positioning](https://drafts.csswg.org/css-anchor-1/) (`css-anchor-1`)
  - [CSS Images Module Level 5](https://drafts.csswg.org/css-images-5/) (`css-images-5`)
  - [CSS Parser API](https://wicg.github.io/css-parser-api/) (`css-parser-api`)
  - [Custom State Pseudo Class](https://wicg.github.io/custom-state-pseudo-class/) (`custom-state-pseudo-class`)
  - [DataCue API](https://wicg.github.io/datacue/) (`datacue`)
  - [Decorators proposal](https://tc39.es/proposal-decorators/) (`tc39-decorators`)
  - [Deprecation Reporting](https://wicg.github.io/deprecation-reporting/) (`deprecation-reporting`)
  - [Device Memory](https://www.w3.org/TR/device-memory/) (`device-memory-1`)
  - [Device Posture API](https://w3c.github.io/device-posture/) (`device-posture`)
  - [DeviceOrientation Event Specification](https://w3c.github.io/deviceorientation/) (`orientation-event`)
  - [Digest Fields](https://httpwg.org/http-extensions/draft-ietf-httpbis-digest-headers.html) (`digest-headers`)
  - [Digital Goods API](https://wicg.github.io/digital-goods/) (`digital-goods`)
  - [Document Policy](https://wicg.github.io/document-policy/) (`document-policy`)
  - [DOM Parsing and Serialization](https://w3c.github.io/DOM-Parsing/) (`DOM-Parsing`)
  - [Early detection of input events](https://wicg.github.io/is-input-pending/) (`is-input-pending`)
  - [ECMAScript Explicit Resource Management](https://tc39.es/proposal-explicit-resource-management/) (`tc39-explicit-resource-management`)
  - [ECMAScript® 2023 Internationalization API Specification](https://tc39.es/ecma402/) (`ecma-402`)
  - [ECMAScript® 2023 Language Specification](https://tc39.es/ecma262/multipage/) (`ecmascript`)
  - [EditContext API](https://w3c.github.io/edit-context/) (`edit-context`)
  - [Element Timing API](https://wicg.github.io/element-timing/) (`element-timing`)
  - [Encrypted Media Extensions](https://w3c.github.io/encrypted-media/) (`encrypted-media`)
  - [EPUB 3.3](https://w3c.github.io/epub-specs/epub33/core/) (`epub-33`)
  - [EPUB Reading Systems 3.3](https://w3c.github.io/epub-specs/epub33/rs/) (`epub-rs-33`)
  - [ES Array.fromAsync (2022)](https://tc39.es/proposal-array-from-async/) (`tc39-array-from-async`)
  - [Event Timing API](https://w3c.github.io/event-timing) (`event-timing`)
  - [Extend TimeZoneName Option Proposal](https://tc39.es/proposal-intl-extend-timezonename/) (`tc39-intl-extend-timezonename`)
  - [EyeDropper API](https://wicg.github.io/eyedropper-api/) (`eyedropper-api`)
  - [File and Directory Entries API](https://wicg.github.io/entries-api/) (`entries-api`)
  - [File System Access](https://wicg.github.io/file-system-access/) (`file-system-access`)
  - [FLAC WebCodecs Registration](https://w3c.github.io/webcodecs/flac_codec_registration.html) (`webcodecs-flac-codec-registration`)
  - [Gamepad Extensions](https://w3c.github.io/gamepad/extensions.html) (`gamepad-extensions`)
  - [Gamepad](https://w3c.github.io/gamepad/) (`gamepad`)
  - [Geolocation API](https://w3c.github.io/geolocation-api/) (`geolocation`)
  - [Geolocation Sensor](https://w3c.github.io/geolocation-sensor/) (`geolocation-sensor`)
  - [Get Installed Related Apps API](https://wicg.github.io/get-installed-related-apps/spec/) (`get-installed-related-apps`)
  - [Graphics Accessibility API Mappings](https://w3c.github.io/graphics-aam/) (`graphics-aam-1.0`)
  - [Gyroscope](https://w3c.github.io/gyroscope/) (`gyroscope`)
  - [HEVC (H.265) WebCodecs Registration](https://w3c.github.io/webcodecs/hevc_codec_registration.html) (`webcodecs-hevc-codec-registration`)
  - [HTML Accessibility API Mappings 1.0](https://w3c.github.io/html-aam/) (`html-aam-1.0`)
  - [HTML Media Capture](https://w3c.github.io/html-media-capture/) (`html-media-capture`)
  - [HTML Sanitizer API](https://wicg.github.io/sanitizer-api/) (`sanitizer-api`)
  - [HTMLVideoElement.requestVideoFrameCallback()](https://wicg.github.io/video-rvfc/) (`video-rvfc`)
  - [IceTransport Extensions for WebRTC](https://w3c.github.io/webrtc-ice/) (`webrtc-ice`)
  - [Identity for WebRTC 1.0](https://w3c.github.io/webrtc-identity/) (`webrtc-identity`)
  - [Idle Detection API](https://wicg.github.io/idle-detection/) (`idle-detection`)
  - [import assertions](https://tc39.es/proposal-import-assertions/) (`tc39-import-assertions`)
  - [Incremental Font Transfer](https://w3c.github.io/IFT/Overview.html) (`IFT`)
  - [Ink API](https://wicg.github.io/ink-enhancement/) (`ink-enhancement`)
  - [Input Device Capabilities](https://wicg.github.io/input-device-capabilities/) (`input-device-capabilities`)
  - [Input Events Level 2](https://w3c.github.io/input-events/) (`input-events-2`)
  - [Internationalization Glossary](https://w3c.github.io/i18n-glossary/) (`i18n-glossary`)
  - [Intervention Reporting](https://wicg.github.io/intervention-reporting/) (`intervention-reporting`)
  - [Intl Enumeration API Specification](https://tc39.es/proposal-intl-enumeration/) (`tc39-intl-enumeration`)
  - [Intl Locale Info Proposal](https://tc39.es/proposal-intl-locale-info/) (`tc39-intl-locale-info`)
  - [Intl.DurationFormat](https://tc39.es/proposal-intl-duration-format/) (`tc39-intl-duration-format`)
  - [Iterator Helpers](https://tc39.es/proposal-iterator-helpers/) (`tc39-iterator-helpers`)
  - [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/) (`js-self-profiling`)
  - [JSON modules](https://tc39.es/proposal-json-modules/) (`tc39-json-modules`)
  - [JSON-LD 1.1 Framing](https://w3c.github.io/json-ld-framing/) (`json-ld11-framing`)
  - [JSON-LD 1.1](https://w3c.github.io/json-ld-syntax/) (`json-ld11`)
  - [JSON.parse source text access](https://tc39.es/proposal-json-parse-with-source/) (`tc39-json-parse-with-source`)
  - [Largest Contentful Paint](https://w3c.github.io/largest-contentful-paint/) (`largest-contentful-paint`)
  - [Layout Instability API](https://wicg.github.io/layout-instability/) (`layout-instability`)
  - [Linear PCM WebCodecs Registration](https://w3c.github.io/webcodecs/pcm_codec_registration.html) (`webcodecs-pcm-codec-registration`)
  - [Loading Signed Exchanges](https://wicg.github.io/webpackage/loading.html) (`webpackage`)
  - [Local Font Access API](https://wicg.github.io/local-font-access/) (`local-font-access`)
  - [Long Tasks API](https://w3c.github.io/longtasks/) (`longtasks-1`)
  - [Magnetometer](https://w3c.github.io/magnetometer/) (`magnetometer`)
  - [Manifest Incubations](https://wicg.github.io/manifest-incubations/) (`manifest-incubations`)
  - [MathML Accessiblity API Mappings 1.0](https://w3c.github.io/mathml-aam/) (`mathml-aam`)
  - [MathML Core](https://w3c.github.io/mathml-core/) (`mathml-core`)
  - [Measure Memory API](https://wicg.github.io/performance-measure-memory/) (`performance-measure-memory`)
  - [Media Capabilities](https://w3c.github.io/media-capabilities/) (`media-capabilities`)
  - [Media Capture Automation](https://w3c.github.io/mediacapture-automation/) (`mediacapture-automation`)
  - [Media Capture from DOM Elements](https://w3c.github.io/mediacapture-fromelement/) (`mediacapture-fromelement`)
  - [Media Feeds](https://wicg.github.io/media-feeds/) (`media-feeds`)
  - [Media Playback Quality](https://w3c.github.io/media-playback-quality/) (`media-playback-quality`)
  - [Media Session Standard](https://w3c.github.io/mediasession/) (`mediasession`)
  - [Media Source Extensions™](https://w3c.github.io/media-source/) (`media-source-2`)
  - [MediaStream Image Capture](https://w3c.github.io/mediacapture-image/) (`image-capture`)
  - [MediaStream Recording](https://w3c.github.io/mediacapture-record/) (`mediastream-recording`)
  - [MediaStreamTrack Content Hints](https://w3c.github.io/mst-content-hint/) (`mst-content-hint`)
  - [MediaStreamTrack Insertable Media Processing using Streams](https://w3c.github.io/mediacapture-transform/) (`mediacapture-transform`)
  - [MiniApp Lifecycle](https://w3c.github.io/miniapp-lifecycle/) (`miniapp-lifecycle`)
  - [MiniApp Manifest](https://w3c.github.io/miniapp-manifest/) (`miniapp-manifest`)
  - [MiniApp Packaging](https://w3c.github.io/miniapp-packaging/) (`miniapp-packaging`)
  - [MP3 WebCodecs Registration](https://w3c.github.io/webcodecs/mp3_codec_registration.html) (`webcodecs-mp3-codec-registration`)
  - [Multi-Screen Window Placement](https://w3c.github.io/window-placement/) (`window-placement`)
  - [Navigation API](https://wicg.github.io/navigation-api/) (`navigation-api`)
  - [Network Information API](https://wicg.github.io/netinfo/) (`netinfo`)
  - [Open Screen Protocol](https://w3c.github.io/openscreenprotocol/) (`openscreenprotocol`)
  - [Opus WebCodecs Registration](https://w3c.github.io/webcodecs/opus_codec_registration.html) (`webcodecs-opus-codec-registration`)
  - [Orientation Sensor](https://w3c.github.io/orientation-sensor/) (`orientation-sensor`)
  - [overscroll and scrollend events](https://wicg.github.io/overscroll-scrollend-events/) (`overscroll-scrollend-events`)
  - [Page Lifecycle](https://wicg.github.io/page-lifecycle/) (`page-lifecycle`)
  - [Paint Timing 1](https://w3c.github.io/paint-timing/) (`paint-timing`)
  - [Payment Handler API](https://w3c.github.io/payment-handler/) (`payment-handler`)
  - [Payment Method Manifest](https://w3c.github.io/payment-method-manifest/) (`payment-method-manifest`)
  - [Payment Request API 1.1](https://w3c.github.io/payment-request/) (`payment-request-1.1`)
  - [Performance Timeline](https://w3c.github.io/performance-timeline/) (`performance-timeline`)
  - [Picture-in-Picture](https://w3c.github.io/picture-in-picture/) (`picture-in-picture`)
  - [Pointer Lock 2.0](https://w3c.github.io/pointerlock/) (`pointerlock-2`)
  - [Portable Network Graphics (PNG) Specification (Third Edition)](https://w3c.github.io/PNG-spec/) (`PNG-spec`)
  - [Portals](https://wicg.github.io/portals/) (`portals`)
  - [preferCurrentTab](https://wicg.github.io/prefer-current-tab/) (`prefer-current-tab`)
  - [Prefetch](https://wicg.github.io/nav-speculation/prefetch.html) (`prefetch`)
  - [Prerendering Revamped](https://wicg.github.io/nav-speculation/prerendering.html) (`prerendering-revamped`)
  - [Prioritized Task Scheduling](https://wicg.github.io/scheduling-apis/) (`scheduling-apis`)
  - [Priority Hints](https://wicg.github.io/priority-hints/) (`priority-hints`)
  - [Private Click Measurement](https://privacycg.github.io/private-click-measurement/) (`private-click-measurement`)
  - [Private Network Access](https://wicg.github.io/private-network-access/) (`private-network-access`)
  - [Proposal-array-find-from-last](https://tc39.es/proposal-array-find-from-last/) (`tc39-array-find-from-last`)
  - [Proximity Sensor](https://w3c.github.io/proximity/) (`proximity`)
  - [Push API](https://w3c.github.io/push-api/) (`push-api`)
  - [RDF 1.1 Concepts and Abstract Syntax](https://www.w3.org/TR/rdf11-concepts/) (`rdf11-concepts`)
  - [RDF 1.1 N-Quads](https://www.w3.org/TR/n-quads/) (`n-quads`)
  - [RDF 1.1 Semantics](https://www.w3.org/TR/rdf11-mt/) (`rdf11-mt`)
  - [RDF Dataset Canonicalization](https://w3c.github.io/rdf-canon/spec/) (`rdf-canon`)
  - [Region Capture](https://w3c.github.io/mediacapture-region/) (`mediacapture-region`)
  - [Regular Expression Pattern Modifiers for ECMAScript](https://tc39.es/proposal-regexp-modifiers/) (`tc39-regexp-modifiers`)
  - [requestIdleCallback()](https://w3c.github.io/requestidlecallback/) (`requestidlecallback`)
  - [Resizable ArrayBuffer and growable SharedArrayBuffer](https://tc39.es/proposal-resizablearraybuffer/) (`tc39-resizablearraybuffer`)
  - [Resource Hints](https://w3c.github.io/resource-hints/) (`resource-hints`)
  - [Resource Timing](https://w3c.github.io/resource-timing/) (`resource-timing`)
  - [Responsive Image Client Hints](https://wicg.github.io/responsive-image-client-hints/) (`responsive-image-client-hints`)
  - [RFC 6265 - HTTP State Management Mechanism](https://httpwg.org/specs/rfc6265.html) (`rfc6265`)
  - [RFC 6266 - Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)](https://httpwg.org/specs/rfc6266.html) (`rfc6266`)
  - [RFC 7230 - Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing](https://httpwg.org/specs/rfc7230.html) (`rfc7230`)
  - [RFC 7231 - Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content](https://httpwg.org/specs/rfc7231.html) (`rfc7231`)
  - [RFC 7232 - Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests](https://httpwg.org/specs/rfc7232.html) (`rfc7232`)
  - [RFC 7233 - Hypertext Transfer Protocol (HTTP/1.1): Range Requests](https://httpwg.org/specs/rfc7233.html) (`rfc7233`)
  - [RFC 7234 - Hypertext Transfer Protocol (HTTP/1.1): Caching](https://httpwg.org/specs/rfc7234.html) (`rfc7234`)
  - [RFC 7235 - Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://httpwg.org/specs/rfc7235.html) (`rfc7235`)
  - [RFC 7538 - The Hypertext Transfer Protocol Status Code 308 (Permanent Redirect)](https://httpwg.org/specs/rfc7538.html) (`rfc7538`)
  - [RFC 7540 - Hypertext Transfer Protocol Version 2 (HTTP/2)](https://httpwg.org/specs/rfc7540.html) (`rfc7540`)
  - [RFC 7616 - HTTP Digest Access Authentication](https://httpwg.org/specs/rfc7616.html) (`rfc7616`)
  - [RFC 7617 - The 'Basic' HTTP Authentication Scheme](https://httpwg.org/specs/rfc7617.html) (`rfc7617`)
  - [RFC 7725 - An HTTP Status Code to Report Legal Obstacles](https://httpwg.org/specs/rfc7725.html) (`rfc7725`)
  - [RFC 7838 - HTTP Alternative Services](https://httpwg.org/specs/rfc7838.html) (`rfc7838`)
  - [RFC 8246 - HTTP Immutable Responses](https://httpwg.org/specs/rfc8246.html) (`rfc8246`)
  - [RFC 8288 - Web Linking](https://httpwg.org/specs/rfc8288.html) (`rfc8288`)
  - [RFC 8470 - Using Early Data in HTTP](https://httpwg.org/specs/rfc8470.html) (`rfc8470`)
  - [RFC 8942: HTTP Client Hints](https://www.rfc-editor.org/rfc/rfc8942) (`rfc8942`)
  - [RFC 9110 - HTTP Semantics](https://httpwg.org/specs/rfc9110.html) (`rfc9110`)
  - [RFC 9111 - HTTP Caching](https://httpwg.org/specs/rfc9111.html) (`rfc9111`)
  - [RFC 9112 - HTTP/1.1](https://httpwg.org/specs/rfc9112.html) (`rfc9112`)
  - [RFC 9113 - HTTP/2](https://httpwg.org/specs/rfc9113.html) (`rfc9113`)
  - [RFC 9114 - HTTP/3](https://httpwg.org/specs/rfc9114.html) (`rfc9114`)
  - [RFC 9163: Expect-CT Extension for HTTP](https://www.rfc-editor.org/rfc/rfc9163) (`rfc9163`)
  - [Save Data API](https://wicg.github.io/savedata/) (`savedata`)
  - [Scalable Video Coding (SVC) Extension for WebRTC](https://w3c.github.io/webrtc-svc/) (`webrtc-svc`)
  - [Screen Capture](https://w3c.github.io/mediacapture-screen-share/) (`screen-capture`)
  - [Screen Wake Lock API](https://w3c.github.io/screen-wake-lock/) (`screen-wake-lock`)
  - [Scripting Policy](https://wicg.github.io/csp-next/scripting-policy.html) (`csp-next`)
  - [Secure Curves in the Web Cryptography API](https://wicg.github.io/webcrypto-secure-curves/) (`webcrypto-secure-curves`)
  - [Secure Payment Confirmation](https://w3c.github.io/secure-payment-confirmation/) (`secure-payment-confirmation`)
  - [Selection API](https://w3c.github.io/selection-api/) (`selection-api`)
  - [Server Timing](https://w3c.github.io/server-timing/) (`server-timing`)
  - [Set methods](https://tc39.es/proposal-set-methods/) (`tc39-set-methods`)
  - [ShadowRealm API](https://tc39.es/proposal-shadowrealm/) (`tc39-shadowrealm`)
  - [Speculation Rules](https://wicg.github.io/nav-speculation/speculation-rules.html) (`speculation-rules`)
  - [SVG Accessibility API Mappings](https://w3c.github.io/svg-aam/) (`svg-aam-1.0`)
  - [SVG Animations](https://svgwg.org/specs/animations/) (`svg-animations`)
  - [SVG Integration](https://svgwg.org/specs/integration/) (`svg-integration`)
  - [SVG Strokes](https://svgwg.org/specs/strokes/) (`svg-strokes`)
  - [Symbol as WeakMap Keys Proposal](https://tc39.es/proposal-symbols-as-weakmap-keys/) (`tc39-symbols-as-weakmap-keys`)
  - [Temporal proposal](https://tc39.es/proposal-temporal/) (`tc39-temporal`)
  - [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) (`scroll-to-text-fragment`)
  - [The <model> element](https://immersive-web.github.io/model-element/) (`model-element`)
  - [The Capture-Handle Actions Mechanism](https://w3c.github.io/mediacapture-handle/actions/) (`mediacapture-handle-actions`)
  - [The Storage Access API](https://privacycg.github.io/storage-access/) (`storage-access`)
  - [Timing Entry Names Registry](https://w3c.github.io/timing-entrytypes-registry/) (`timing-entrytypes-registry`)
  - [Touch Events - Level 2](https://w3c.github.io/touch-events/) (`touch-events`)
  - [Tracking Preference Expression (DNT)](https://w3c.github.io/dnt/drafts/tracking-dnt.html) (`tracking-dnt`)
  - [Trusted Types](https://w3c.github.io/trusted-types/dist/spec/) (`trusted-types`)
  - [u-law PCM WebCodecs Registration](https://w3c.github.io/webcodecs/ulaw_codec_registration.html) (`webcodecs-ulaw-codec-registration`)
  - [UI Events KeyboardEvent code Values](https://w3c.github.io/uievents-code/) (`uievents-code`)
  - [UI Events KeyboardEvent key Values](https://w3c.github.io/uievents-key/) (`uievents-key`)
  - [URLPattern API](https://wicg.github.io/urlpattern/) (`urlpattern`)
  - [User Preference Media Features Client Hints Headers](https://wicg.github.io/user-preference-media-features-headers/) (`user-preference-media-features-headers`)
  - [User Timing Level 3](https://w3c.github.io/user-timing/) (`user-timing`)
  - [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/) (`ua-client-hints`)
  - [Vibration API (Second Edition)](https://w3c.github.io/vibration/) (`vibration`)
  - [Viewport Capture](https://w3c.github.io/mediacapture-viewport/) (`mediacapture-viewport`)
  - [VirtualKeyboard API](https://w3c.github.io/virtual-keyboard/) (`virtual-keyboard`)
  - [Vorbis WebCodecs Registration](https://w3c.github.io/webcodecs/vorbis_codec_registration.html) (`webcodecs-vorbis-codec-registration`)
  - [VP8 WebCodecs Registration](https://w3c.github.io/webcodecs/vp8_codec_registration.html) (`webcodecs-vp8-codec-registration`)
  - [VP9 WebCodecs Registration](https://w3c.github.io/webcodecs/vp9_codec_registration.html) (`webcodecs-vp9-codec-registration`)
  - [W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy/) (`w3c-patent-policy`)
  - [W3C Process Document](https://www.w3.org/Consortium/Process/) (`w3c-process`)
  - [WAI-ARIA Graphics Module](https://w3c.github.io/graphics-aria/) (`graphics-aria-1.0`)
  - [Web App Launch Handler API](https://wicg.github.io/web-app-launch/) (`web-app-launch`)
  - [Web App Manifest - Application Information](https://w3c.github.io/manifest-app-info/) (`manifest-app-info`)
  - [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/) (`web-bluetooth`)
  - [Web Locks API](https://w3c.github.io/web-locks/) (`web-locks`)
  - [Web MIDI API](https://webaudio.github.io/web-midi-api/) (`webmidi`)
  - [Web Neural Network API](https://webmachinelearning.github.io/webnn/) (`webnn`)
  - [Web NFC](https://w3c.github.io/web-nfc/) (`web-nfc`)
  - [Web Periodic Background Synchronization](https://wicg.github.io/periodic-background-sync/) (`periodic-background-sync`)
  - [Web Share Target API](https://w3c.github.io/web-share-target/) (`web-share-target`)
  - [Web Speech API](https://wicg.github.io/speech-api/) (`speech-api`)
  - [WebAssembly Core Specification](https://webassembly.github.io/spec/core/bikeshed/) (`wasm-core-1`)
  - [WebAssembly JavaScript Interface: Exception Handling](https://webassembly.github.io/exception-handling/js-api/) (`wasm-js-api-2-fork-exception-handling`)
  - [WebAssembly Web API](https://webassembly.github.io/spec/web-api/) (`wasm-web-api-2`)
  - [WebCodecs Codec Registry](https://w3c.github.io/webcodecs/codec_registry.html) (`webcodecs-codec-registry`)
  - [WebCodecs](https://w3c.github.io/webcodecs/) (`webcodecs`)
  - [WebDriver BiDi](https://w3c.github.io/webdriver-bidi/) (`webdriver-bidi`)
  - [WebGL 2.0 Specification](https://registry.khronos.org/webgl/specs/latest/2.0/) (`webgl2`)
  - [WebGL Specification](https://registry.khronos.org/webgl/specs/latest/1.0/) (`webgl1`)
  - [WebGPU Shading Language](https://gpuweb.github.io/gpuweb/wgsl/) (`WGSL`)
  - [WebGPU](https://gpuweb.github.io/gpuweb/) (`webgpu`)
  - [WebHID API](https://wicg.github.io/webhid/) (`webhid`)
  - [WebOTP API](https://wicg.github.io/web-otp/) (`web-otp`)
  - [WebRTC Encoded Transform](https://w3c.github.io/webrtc-encoded-transform/) (`webrtc-encoded-transform`)
  - [WebRTC Priority Control API](https://w3c.github.io/webrtc-priority/) (`webrtc-priority`)
  - [WebTransport](https://w3c.github.io/webtransport/) (`webtransport`)
  - [WebVTT: The Web Video Text Tracks Format](https://w3c.github.io/webvtt/) (`webvtt1`)
  - [WebXR Anchors Module](https://immersive-web.github.io/anchors/) (`anchors`)
  - [WebXR Depth Sensing Module](https://immersive-web.github.io/depth-sensing/) (`webxr-depth-sensing-1`)
  - [WebXR Lighting Estimation API Level 1](https://immersive-web.github.io/lighting-estimation/) (`webxr-lighting-estimation-1`)
  - [WebXR Raw Camera Access Module](https://immersive-web.github.io/raw-camera-access/) (`raw-camera-access`)
  - [Well-Formed Unicode Strings](https://tc39.es/proposal-is-usv-string/) (`tc39-is-usv-string`)
  - [Window Controls Overlay](https://wicg.github.io/window-controls-overlay/) (`window-controls-overlay`)
  - [WOFF File Format 1.0](https://w3c.github.io/woff/woff1/spec/Overview.html) (`WOFF`)
</details>