### PR TITLE
Make webidl win over ecmascript, and infra win over i18n-glossary again

### DIFF
--- a/bikeshed/spec-data/readonly/link-defaults.infotree
+++ b/bikeshed/spec-data/readonly/link-defaults.infotree
@@ -99,5 +99,9 @@ info: ignored-specs
 		replacedBy: css-pseudo-4
 	spec: css-tables-3
 		replacedBy: css2
+	spec: i18n-glossary
+		replacedBy: infra
+	spec: ecmascript
+		replacedBy: webidl
 info: anchors
 	type: dfn; text: art direction; url: https://usecases.responsiveimages.org/; spec: respimg-usecases-1


### PR DESCRIPTION
A previous commit made the Infra standard win over the Internationalization glossary but that change was accidently (or at least, I suppose that was not intended ;)) rolled back by the data refresh that followed: https://github.com/tabatkins/bikeshed/commit/163bc60426b65f715b742c7901afb1a9815381b5

The other case that seems to warrant a new rule is WebIDL and ECMAScript: WebIDL creates proxy definitions of `EvalError`, `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, and `URIError` that are otherwise defined in ECMAScript. The WebIDL definitions are typically preferred in web spec to reference the concepts. Other ECMAScript definitions that are redefined in other specs (e.g. "realm" in HTML) are typically namespaced and shouldn't create particular problems.

(Side note that a new version of Bikeshed probably needs to be issued for changes to propagate to bikeshed-data. Nothing urgent on my side, just in case that fell through the cracks! :))



