### PR TITLE
Stop referring to "Examples" in the docs; "Example:" is not supported

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1683,13 +1683,13 @@ More of Markdown will be supported in the future,
 as I get closer to adhering to the CommonMark specification.
 
 
-Notes, Issues, Examples, Advisements {#notes-etc}
+Notes, Issues, Assertions, Advisements {#notes-etc}
 -------------------------------------------------
 
 The Markdown processor specially recognizes paragraphs starting with
 "Issue: ",
 "Advisement: ",
-"Assertion: ",
+"Assert: ",
 "Note: ",
 or "Note, ",
 and will add a matching class to the paragraph automatically.
@@ -1701,7 +1701,9 @@ so make sure you provide your own styling if you change them.)
 
 The default styling of these blocks includes a generated-content "header"
 containing the word "NOTE:", etc.
-Elements with the `.example` class will also be given a generated-content "header"
+
+Elements with the `.example` class (which must be manually added via [TODO FIXME WHAT GOES HERE])
+will also be given a generated-content "header"
 in the format `EXAMPLE n`
 with an auto-incrementing number,
 and have self-links created to allow linking directly to the example.
@@ -2036,7 +2038,7 @@ For the `<assert>` tag, it will be replaced by a `<span>` tag in the generated
 source. The `<div>` tag will pass through but the `assert` attribute is removed.
 
 In both cases a unique ID is generated from the tags contents of the form "assert-###",
-where "###" is a substring of a hash of the assertions contents.
+where "###" is a substring of a hash of the assertion's contents.
 This ensures that you have a unique ID that won't change arbitrarily,
 but *will* change **when the contents of the assertion change**,
 making it easier to tell when a test might no longer be testing the assertion it points to


### PR DESCRIPTION
This patch is not ready for prime time, as indicated by the `[TODO FIXME WHAT GOES HERE]`. But I hope it's somewhat useful.

I wanted to add an "Example:" block to a C++ paper — basically a "Note:" but with the implication that readers might as well just skip over it if they don't care. The documentation for Bikeshed has a section on "... Examples, ..." — but the section title seems to be a lie: Bikeshed doesn't support `Example:` markup in anything like the way it does for `Note:` or `Issue:`.

I do wonder if `Assert:` is intended to be kind of like an "Example." But of course I don't want my paper to actually _say the word_ "Assert:" inside the gray box. So I'll use some custom div styling, probably.

I have not checked whether the `.example` class actually exists (the doc says it does), but I have definitely checked that the .bs syntax `Example:` doesn't trigger it.