### PR TITLE
chore: Update Python base image to version 3.12 In Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye as base
+FROM python:3.12-bullseye as base
 
 # Get the latest spec-data, then cache it so we don't have to redo this on every rebuild
 from base as specdata


### PR DESCRIPTION
Building the Dockerfile image failed due to stronger requirements in the dependency packages.
Using Python 3.12, building the image works again.