### PR TITLE
Update em dash line-ending handling

### DIFF
--- a/bikeshed/h/parser/parser.py
+++ b/bikeshed/h/parser/parser.py
@@ -474,7 +474,7 @@ def parseNode(
         match, i, _ = s.matchRe(start, emdashRe)
         if match is not None:
             # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
-            node = RawText.fromStream(s, start, i, "—\u200b")
+            node = RawText.fromStream(s, start, i, "— ")
             return Ok(node, i)
 
     if first1 in ("<", "&"):

--- a/bikeshed/h/parser/parser.py
+++ b/bikeshed/h/parser/parser.py
@@ -473,7 +473,7 @@ def parseNode(
     if first2 == "—\n" or first3 == "--\n":
         match, i, _ = s.matchRe(start, emdashRe)
         if match is not None:
-            # Fix line-ending em dashes, or --, by moving the previous line up, so no space.
+            # Fix line-ending em dashes, or --, by moving the previous line up with an extra space.
             node = RawText.fromStream(s, start, i, "— ")
             return Ok(node, i)
 

--- a/bikeshed/h/parser/parser.py
+++ b/bikeshed/h/parser/parser.py
@@ -474,7 +474,7 @@ def parseNode(
         match, i, _ = s.matchRe(start, emdashRe)
         if match is not None:
             # Fix line-ending em dashes, or --, by moving the previous line up with an extra space.
-            node = RawText.fromStream(s, start, i, "— ")
+            node = RawText.fromStream(s, start, i, " — ")
             return Ok(node, i)
 
     if first1 in ("<", "&"):

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2047,7 +2047,7 @@ Typography Fixes {#typography}
 Bikeshed will automatically handle a few typographic niceties for you, ones that it can reliably detect:
 
 * Possessive apostrophes, and most contraction apostrophes, are automatically turned into curly right single quotes (`’`).
-* Ending a line with `--` will turn it into an em dash (`—`) and pull the following line upwards so there's no space between the surrounding words and the dash.
+* Ending a line with `--` will turn it into an em dash (`—`) and pull the following line upwards so there's a space between the surrounding words and the dash.
 
 
 


### PR DESCRIPTION
Based on https://github.com/w3c/guide/issues/415, the [W3C guidebook was updated to add an exception to include whitespace before and after em dashes](https://www.w3.org/guide/manual-of-style/#Punctuation).
That PR updates the way bikeshed treats trailing `--` or em dashes accordingly.

@tabatkins, before fixing the tests, I understand this does affect even the non-W3C specs and we probably don't want that. Is there a better place to handle the substitution so it applies only to W3C specs?

/cc @koalie