### PR TITLE
ci: Group Dependabot updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,32 @@ version: 2
 updates:
 - package-ecosystem: pip
   directory: "/"
+  open-pull-requests-limit: 99
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: "monthly"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
 - package-ecosystem: pip
   directory: ".github/workflows/update-tests/"
+  open-pull-requests-limit: 99
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: "monthly"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Move the dependabot updates to a monthly cadency, and allow creating bundles updates for any minor/patch updates. Major updates will still get their own PRs