### PR TITLE
Bump widlparser to 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ requests==2.33.1
 result==0.17.0
 setuptools==82.0.1
 tenacity==9.1.4
-widlparser==1.4.0
+widlparser==1.5.0


### PR DESCRIPTION
This adds support for `async_sequence<T>`, see https://github.com/plinss/widlparser/pull/95