### PR TITLE
Fix boilerplate file resolution fallback to readonly data

### DIFF
--- a/bikeshed/retrieve.py
+++ b/bikeshed/retrieve.py
@@ -135,8 +135,11 @@ def retrieveBoilerplateFile(
 
     searchLocally = allowLocal and doc.md.localBoilerplate[name]
 
-    def boilerplatePath(*segs: str) -> str:
-        return dataFile.path("boilerplate", *segs)
+    def boilerplatePaths(*segs: str) -> list[str]:
+        paths = [dataFile.path("boilerplate", *segs)]
+        if dataFile.fallback:
+            paths.append(dataFile.fallback.path("boilerplate", *segs))
+        return paths
 
     filenames = []
     if statusName:
@@ -165,16 +168,23 @@ def retrieveBoilerplateFile(
     # 2: Look in the group's folder
     if groupName and orgName:
         sources.extend(
-            InputSource.FileInputSource(boilerplatePath("org-" + orgName, groupName, fn), chroot=False)
+            InputSource.FileInputSource(p, chroot=False)
             for fn in filenames
+            for p in boilerplatePaths("org-" + orgName, groupName, fn)
         )
     # 3: Look in the org's folder
     if orgName:
         sources.extend(
-            InputSource.FileInputSource(boilerplatePath("org-" + orgName, fn), chroot=False) for fn in filenames
+            InputSource.FileInputSource(p, chroot=False)
+            for fn in filenames
+            for p in boilerplatePaths("org-" + orgName, fn)
         )
     # 4: Look in the generic defaults
-    sources.extend(InputSource.FileInputSource(boilerplatePath("default", fn), chroot=False) for fn in filenames)
+    sources.extend(
+        InputSource.FileInputSource(p, chroot=False)
+        for fn in filenames
+        for p in boilerplatePaths("default", fn)
+    )
 
     # Watch all the possible sources, not just the one that got used, because if
     # an earlier one appears, we want to rebuild.


### PR DESCRIPTION
 ## Problem

Bikeshed 7.1.0 fails to build specs that rely on bundled boilerplate data, producing:

```
FATAL ERROR: Couldn't find an appropriate include file for the {name} inclusion, given Org 'w3c', Group 'webml', and Status 'CG-DRAFT'
```

This affects any spec without local boilerplate overrides. The same specs build successfully with 7.0.14.

## Root Cause

Commit d924eca757 updated `retrieveBoilerplateFile()` in `retrieve.py` to search new-style paths (`org-{org}/{group}/`, `org-{org}/`, `default/`). The bundled readonly data in `spec-data/readonly/boilerplate/` was correctly restructured to match.

However, `retrieveBoilerplateFile()` constructs `FileInputSource` objects using `dataFile.path()`, which only resolves paths in the **latest** (mutable) data directory (`spec-data/boilerplate/`). This directory either:

1. **Doesn't exist** on a fresh install (no `bikeshed update` has been run), or
2. **Contains old-style paths** (`webml/`, `w3c/`) after `bikeshed update`, because `speced/bikeshed-data` still serves the old flat structure.

In both cases, the new-style paths aren't found in the latest directory. The `DataFileRequester` fallback to readonly data is designed to work through `fetch()` (which catches `OSError` and retries with the fallback requester), but `retrieveBoilerplateFile()` bypasses `fetch()` entirely and it calls `dataFile.path()` to build a path string, wraps it in a `FileInputSource`, and calls `.read()` directly. The readonly fallback is never invoked.

## How Found

CI for [webmachinelearning/webmcp PR #204](https://github.com/webmachinelearning/webmcp/pull/204) started failing after the bikeshed 7.1.0 release. Traced the issue to the mismatch between the paths `retrieveBoilerplateFile()` searches and the paths that actually exist on disk.

## Fix

Changed `boilerplatePath()` (singular) to `boilerplatePaths()` (plural), which returns candidate paths from **both** the latest and readonly data directories by consulting `dataFile.fallback`. For each boilerplate include, the search now tries the latest path first, then falls back to the readonly path restoring the intended fallback behavior that `DataFileRequester` provides through `fetch()`.

This is a minimal, low-risk fix that doesn't change the search order or priority semantics. The underlying issue is that `bikeshed update` downloads boilerplate into old-style paths while the code expects new-style paths remains, but this fix ensures the bundled readonly data is always reachable as a fallback.

## Testing

Verified against the [webmachinelearning/webmcp](https://github.com/webmachinelearning/webmcp) spec (`Status: CG-DRAFT`, `Group: webml`).